### PR TITLE
Review follow-ups: category sentinels, honest ceilings, ported framing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -99,6 +99,15 @@ jobs:
             esac
           done < <(grep -oE '^name = "(pilotage|avionics|navigate|aviate|instrument)[a-z0-9-]*"' Cargo.lock \
                    | sed 's/^name = "//;s/"$//')
+          # Category sentinels the prefix filter cannot see: third-party
+          # wire-protocol and transport crates mean the boundary leaked
+          # regardless of what they are named.
+          for banned in prost tonic wtransport; do
+            if grep -qE "^name = \"$banned(-[a-z0-9]+)*\"" Cargo.lock; then
+              echo "Cargo.lock names $banned; wire-protocol and transport crates belong to consumers"
+              fail=1
+            fi
+          done
           exit $fail
 
       - name: instrument closure is no_std, standalone

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -102,7 +102,7 @@ jobs:
           # Category sentinels the prefix filter cannot see: third-party
           # wire-protocol and transport crates mean the boundary leaked
           # regardless of what they are named.
-          for banned in prost tonic wtransport; do
+          for banned in prost tonic wtransport quinn h3 quiche; do
             if grep -qE "^name = \"$banned(-[a-z0-9]+)*\"" Cargo.lock; then
               echo "Cargo.lock names $banned; wire-protocol and transport crates belong to consumers"
               fail=1

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,6 +23,7 @@ bash scripts/check-instrument-requirements.sh
 bash scripts/check-certification-claims.sh
 bash scripts/check-standards-registry.sh
 bash scripts/trace-report.sh
+bash scripts/detect-target.sh
 cargo check --locked -p pilotage-frames -p pilotage-alerts -p pilotage-sha256 \
   -p pilotage-instrument-state -p pilotage-instrument-scene \
   -p pilotage-instrument-glyphs -p pilotage-instrument-symbology \
@@ -40,6 +41,20 @@ The evidence gate binds recorded test sources by content digest: editing
 a recorded test file (the attitude-behavior and presentation suites
 among them) reddens the gate until that evidence is re-recorded, so run
 the two gate invocations locally after touching any recorded source.
+
+## PR discipline
+
+- One issue per PR. Break large refactors into independently revertible
+  steps.
+- Every PR lands the fix **and** the guardrail that prevents its
+  regression (a test, a lint, or a CI script change) in the same PR. A
+  fix without a guardrail is temporary.
+- Do not skip hooks, force-push shared branches, or bypass the gates to
+  land a PR faster; if a gate is wrong, fix the gate in its own PR
+  first.
+- `ADR-NNNN` identifiers cited in code, scripts, and docs are
+  architecture decision records living in the Pilotage repository's
+  `docs/adr/`.
 
 ## Discipline that is easy to miss
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,15 @@
 # Indicate
 
-SIM / NOT FOR FLIGHT. Nothing here is certified, approved, or airworthy.
+> **⚠️ Work in progress — experimental.** Indicate is early-stage,
+> experimental software under active development, provided **as is**
+> with **no warranty or guarantee of any kind**, express or implied —
+> including, without limitation, fitness for a particular purpose,
+> correctness, reliability, availability, or safety. Interfaces and
+> behavior may change without notice.
+>
+> **SIM / NOT FOR FLIGHT.** Nothing here is certified, approved, or airworthy.
+> Nothing may be used for operational control of a real vehicle or for any
+> safety-critical purpose. Use at your own risk.
 
 The standalone instrument crate family: `no_std` flight instrument
 panels that emit an immediate-mode scene command stream, plus the

--- a/docs/instruments/backend-contract.md
+++ b/docs/instruments/backend-contract.md
@@ -10,15 +10,21 @@ below keep them from eroding.
 A panel emits its **complete** command stream every frame, in immediate
 mode, into a caller-supplied buffer:
 
-- `SceneWriter::new(buf: &mut [u8])` borrows the caller's bytes;
-  `finish()` returns the encoded length. No allocation happens anywhere
-  on the emit path — the closure crates are `no_std` and CI compiles
-  them standalone for `thumbv7em-none-eabihf` to prove it.
+- `SceneWriter::new(buf: &mut [u8])` borrows the caller's bytes and
+  returns a typed error rather than an unusable writer; `finish()`
+  returns the encoded length. A command that does not fit rolls back
+  whole (`SceneError::BufferFull`), so the stream always ends at a
+  command boundary — never a truncated frame. No allocation happens
+  anywhere on the emit path — the closure crates are `no_std` and CI
+  compiles them standalone for `thumbv7em-none-eabihf` to prove it.
 - The stream is bounded by compile-time ceilings in
   `pilotage-instrument-scene::layer`: `MAX_LAYER_COMMANDS` (4096 per
   layer), `MAX_STACK_DEPTH` (32 save/restore levels), and
-  `MAX_SCENE_BYTES` (64 KiB per scene). A scene that would exceed them
-  is a typed encode error, never a truncated frame.
+  `MAX_SCENE_BYTES` (64 KiB per scene). `validate_layers` enforces them
+  as typed `LayerError`s (`OverCapacity`, `StackOverCapacity`,
+  `SceneTooLarge`): run it on every scene before the bytes reach a
+  backend — the encoder deliberately does not re-check the layer
+  ceilings.
 - Adding a panel adds commands — never a new mechanism. A backend that
   interprets the opcode vocabulary renders every current and future
   panel; the Swift SceneKit backend is frozen against the opcodes, not

--- a/docs/instruments/renderer-verification.md
+++ b/docs/instruments/renderer-verification.md
@@ -233,10 +233,11 @@ failure page and an independent DOM fault surface.
 
 The reference-side tests run under the existing `cargo test -p
 pilotage-instrument-raster` step (they include the drift guard, coverage, budget,
-and fail-safe tests). The browser-side conformance test runs in the Pilotage
-repository's CI:
+and fail-safe tests). The browser-side conformance test is a step in the
+Pilotage repository's workflow, not this one:
 
 ```
+# Pilotage repository, .github/workflows/ci.yml
 - name: renderer backend conformance corpus
   run: node clients/web/scene-conformance.test.mjs
 ```

--- a/tools/xtask/src/fixture.rs
+++ b/tools/xtask/src/fixture.rs
@@ -4,9 +4,9 @@
 //! runtime uses and writes one lowercase-hex line per fixture into
 //! `crates/pilotage-instrument-state/fixtures/` — inside the crate that
 //! owns the codec, so the fixtures travel with it. The Rust golden test
-//! and the JS state-writer
-//! test both pin against these committed files, so the two sides of the
-//! wasm boundary can only drift by turning CI red.
+//! and downstream state writers (the Pilotage browser shell's
+//! `state-abi.js` among them) pin against these committed files, so the
+//! sides of that boundary can only drift by turning a consumer's CI red.
 
 use std::path::{Path, PathBuf};
 


### PR DESCRIPTION
Implements the second independent reviewer's findings on the extraction PR (#1), verified against merged main:

- **MAJOR (regression):** the allowlist conversion silently dropped the `prost` ban — the prefix filter only sees ecosystem-named crates. The gate regains a category-sentinel pass over the unfiltered Cargo.lock (`prost`, `tonic`, `wtransport`); verified to trip on a poisoned lock.
- **MAJOR:** `backend-contract.md` attributed the three ceilings to "a typed encode error". They are `validate_layers` `LayerError`s (`OverCapacity`, `StackOverCapacity`, `SceneTooLarge`); the encoder deliberately does not re-check them. The doc now names the real mechanism, plus `SceneWriter::new`'s fallibility and the whole-command `BufferFull` rollback that makes "never truncated" true.
- MINOR: README ports the experimental / no-warranty / no-operational-use framing (wrapped per-line for the claims guard); CONTRIBUTING gains PR discipline, the ADR-identifier pointer, and `detect-target.sh`; `fixture.rs` names downstream state writers the way `abi.rs` does; the renderer-verification CI example is labeled as the consuming repository's step.

Full battery green: fmt, clippy, 18/18 test targets, structure, cert-claims, requirement/standards guards.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013gPz9A5f9NbYFmop3UHMuw