### PR TITLE
Fix the required-layer table's drift from the shipped descriptors (#14)

### DIFF
--- a/crates/pilotage-instrument-panels/src/descriptors.rs
+++ b/crates/pilotage-instrument-panels/src/descriptors.rs
@@ -462,4 +462,6 @@ pub const BUILTIN_SCENE_DIGEST: &str =
 #[cfg(test)]
 mod digest_tests;
 #[cfg(test)]
+mod layer_profile_doc_tests;
+#[cfg(test)]
 mod tests;

--- a/crates/pilotage-instrument-panels/src/descriptors/layer_profile_doc_tests.rs
+++ b/crates/pilotage-instrument-panels/src/descriptors/layer_profile_doc_tests.rs
@@ -15,7 +15,9 @@ use super::{BUILTIN_PANELS, layer_bit};
 
 const PROTOCOL_DOC: &str = include_str!("../../../../docs/instruments/scene-layer-protocol.md");
 
-const SECTION: &str = "## Required panel profiles";
+const HEADING: &str = "## Required panel profiles";
+
+const HEADER: [&str; 3] = ["Panel", "Required layers", "Optional layers"];
 
 /// Every defined layer, ascending — the order both table columns list.
 fn defined_layers() -> Vec<LayerId> {
@@ -41,42 +43,84 @@ fn backticked(layers: &[LayerId]) -> String {
         .join(", ")
 }
 
-/// The table's data rows as (panel, required, optional).
-fn documented_rows() -> Vec<(String, String, String)> {
-    let section = PROTOCOL_DOC
-        .split_once(SECTION)
+/// The profiles section alone, bounded by the next section's heading:
+/// a table elsewhere in the document can never be read as a profile row,
+/// and deleting the real table fails loudly instead of silently
+/// latching onto the next one.
+fn section() -> &'static str {
+    let after = PROTOCOL_DOC
+        .split_once(HEADING)
         .expect("the layer-protocol document still has a required-profiles section")
         .1;
-    let mut rows: Vec<(String, String, String)> = Vec::new();
-    for line in section.lines() {
-        let line = line.trim();
-        if !line.starts_with('|') {
-            // The profiles table is one contiguous block. Stopping at its
-            // end keeps a later table in the document from being read as
-            // a profile row.
-            if rows.is_empty() {
-                continue;
-            }
-            break;
-        }
-        let cells: Vec<&str> = line.trim_matches('|').split('|').map(str::trim).collect();
-        assert_eq!(
-            cells.len(),
-            3,
-            "a profiles row must carry panel, required, and optional: {line}"
-        );
-        let is_header = cells[0] == "Panel";
-        let is_rule = cells.iter().all(|cell| cell.chars().all(|c| c == '-'));
-        if is_header || is_rule {
-            continue;
-        }
-        rows.push((
-            String::from(cells[0]),
-            String::from(cells[1]),
-            String::from(cells[2]),
-        ));
-    }
-    rows
+    after
+        .split_once("\n## ")
+        .map_or(after, |(section, _)| section)
+}
+
+fn cells(row: &str) -> Vec<&str> {
+    let cells: Vec<&str> = row.trim_matches('|').split('|').map(str::trim).collect();
+    assert_eq!(
+        cells.len(),
+        HEADER.len(),
+        "a profiles row must carry panel, required, and optional: {row}"
+    );
+    cells
+}
+
+/// Lines of the section that belong to a markdown table.
+fn table_lines() -> Vec<&'static str> {
+    section()
+        .lines()
+        .map(str::trim)
+        .filter(|line| line.starts_with('|'))
+        .collect()
+}
+
+/// The table's data rows as (panel, required, optional).
+///
+/// Parsing is positional — header, delimiter, then data — so a row
+/// cannot exempt itself from the comparison by imitating the header or
+/// leaving its cells blank.
+fn documented_rows() -> Vec<(String, String, String)> {
+    let lines = table_lines();
+    let mut lines = lines.into_iter();
+    let header = lines
+        .next()
+        .expect("the profiles section still contains a table");
+    assert_eq!(
+        cells(header),
+        HEADER.to_vec(),
+        "the profiles table's columns must stay panel, required, optional"
+    );
+    let delimiter = lines.next().expect("the table still has a delimiter row");
+    assert!(
+        cells(delimiter)
+            .iter()
+            .all(|cell| !cell.is_empty() && cell.chars().all(|c| c == '-')),
+        "the row under the header must be the table delimiter: {delimiter}"
+    );
+    lines
+        .map(|line| {
+            let cells = cells(line);
+            (
+                String::from(cells[0]),
+                String::from(cells[1]),
+                String::from(cells[2]),
+            )
+        })
+        .collect()
+}
+
+/// A second table in the section could assert profiles nothing checks.
+#[test]
+fn the_profiles_section_holds_exactly_one_table() {
+    let expected = BUILTIN_PANELS.len() + 2;
+    assert_eq!(
+        table_lines().len(),
+        expected,
+        "the profiles section must hold one table: a header, a delimiter, \
+         and one row per shipped panel"
+    );
 }
 
 #[test]
@@ -117,17 +161,25 @@ fn the_documented_profiles_are_the_descriptor_masks() {
     }
 }
 
-/// The guard is only worth its line count if a drifting mask breaks it.
+/// The comparison guards drift only if a changed mask changes the cell
+/// it compares, so drift cannot hide behind an unchanged string.
 #[test]
-fn a_drifting_mask_is_caught() {
-    let mut drifted = *BUILTIN_PANELS
+fn a_changed_mask_changes_the_cell_the_guard_compares() {
+    let panel = BUILTIN_PANELS
         .first()
         .expect("the family ships at least one panel");
+    let rows = documented_rows();
+    let row = rows.first().expect("that panel has a row");
+    let mut drifted = *panel;
     drifted.required_layers &= !layer_bit(LayerId::Annunciation);
-    let (required, _) = cells_from_mask(&drifted);
-    let documented = documented_rows();
+    assert_eq!(
+        cells_from_mask(panel).0,
+        row.1,
+        "the shipped mask must match the row the guard reads"
+    );
     assert_ne!(
-        required, documented[0].1,
-        "dropping a required layer must change the cell this test compares"
+        cells_from_mask(&drifted).0,
+        row.1,
+        "dropping a required layer must break that match"
     );
 }

--- a/crates/pilotage-instrument-panels/src/descriptors/layer_profile_doc_tests.rs
+++ b/crates/pilotage-instrument-panels/src/descriptors/layer_profile_doc_tests.rs
@@ -1,0 +1,133 @@
+//! The required-panel-profiles table in the layer-protocol document is
+//! prose a backend author trusts, so it is checked against the shipped
+//! descriptors rather than maintained beside them.
+
+#![allow(clippy::expect_used, clippy::panic)]
+
+use std::format;
+use std::string::String;
+use std::vec::Vec;
+
+use pilotage_instrument_registry::PanelDescriptor;
+use pilotage_instrument_scene::{LAYER_COUNT, LayerId};
+
+use super::{BUILTIN_PANELS, layer_bit};
+
+const PROTOCOL_DOC: &str = include_str!("../../../../docs/instruments/scene-layer-protocol.md");
+
+const SECTION: &str = "## Required panel profiles";
+
+/// Every defined layer, ascending — the order both table columns list.
+fn defined_layers() -> Vec<LayerId> {
+    (0..LAYER_COUNT as u8)
+        .map(|id| LayerId::from_u8(id).expect("ids below LAYER_COUNT are defined"))
+        .collect()
+}
+
+/// The two cells a descriptor's mask implies: the required layers, and
+/// its complement over the defined layers.
+fn cells_from_mask(panel: &PanelDescriptor) -> (String, String) {
+    let (required, optional): (Vec<LayerId>, Vec<LayerId>) = defined_layers()
+        .into_iter()
+        .partition(|layer| panel.required_layers & layer_bit(*layer) != 0);
+    (backticked(&required), backticked(&optional))
+}
+
+fn backticked(layers: &[LayerId]) -> String {
+    layers
+        .iter()
+        .map(|layer| format!("`{layer:?}`"))
+        .collect::<Vec<_>>()
+        .join(", ")
+}
+
+/// The table's data rows as (panel, required, optional).
+fn documented_rows() -> Vec<(String, String, String)> {
+    let section = PROTOCOL_DOC
+        .split_once(SECTION)
+        .expect("the layer-protocol document still has a required-profiles section")
+        .1;
+    let mut rows: Vec<(String, String, String)> = Vec::new();
+    for line in section.lines() {
+        let line = line.trim();
+        if !line.starts_with('|') {
+            // The profiles table is one contiguous block. Stopping at its
+            // end keeps a later table in the document from being read as
+            // a profile row.
+            if rows.is_empty() {
+                continue;
+            }
+            break;
+        }
+        let cells: Vec<&str> = line.trim_matches('|').split('|').map(str::trim).collect();
+        assert_eq!(
+            cells.len(),
+            3,
+            "a profiles row must carry panel, required, and optional: {line}"
+        );
+        let is_header = cells[0] == "Panel";
+        let is_rule = cells.iter().all(|cell| cell.chars().all(|c| c == '-'));
+        if is_header || is_rule {
+            continue;
+        }
+        rows.push((
+            String::from(cells[0]),
+            String::from(cells[1]),
+            String::from(cells[2]),
+        ));
+    }
+    rows
+}
+
+#[test]
+fn every_shipped_panel_has_a_row_in_shell_order() {
+    let documented: Vec<String> = documented_rows().into_iter().map(|row| row.0).collect();
+    let shipped: Vec<String> = BUILTIN_PANELS
+        .iter()
+        .map(|panel| String::from(panel.title))
+        .collect();
+    assert_eq!(
+        documented, shipped,
+        "the profiles table must list every shipped panel, in shell display order"
+    );
+}
+
+#[test]
+fn the_documented_profiles_are_the_descriptor_masks() {
+    let rows = documented_rows();
+    // Without this, `zip` would truncate to the shorter side and a table
+    // missing its last panel would pass by describing nothing.
+    assert_eq!(
+        rows.len(),
+        BUILTIN_PANELS.len(),
+        "every shipped panel needs a row before its mask can be checked"
+    );
+    for (panel, row) in BUILTIN_PANELS.iter().zip(rows) {
+        let (required, optional) = cells_from_mask(panel);
+        assert_eq!(
+            row.1, required,
+            "{}: documented required layers disagree with required_layers",
+            panel.title
+        );
+        assert_eq!(
+            row.2, optional,
+            "{}: documented optional layers are not the complement of required_layers",
+            panel.title
+        );
+    }
+}
+
+/// The guard is only worth its line count if a drifting mask breaks it.
+#[test]
+fn a_drifting_mask_is_caught() {
+    let mut drifted = *BUILTIN_PANELS
+        .first()
+        .expect("the family ships at least one panel");
+    drifted.required_layers &= !layer_bit(LayerId::Annunciation);
+    let (required, _) = cells_from_mask(&drifted);
+    let documented = documented_rows();
+    assert_ne!(
+        required, documented[0].1,
+        "dropping a required layer must change the cell this test compares"
+    );
+}

--- a/docs/instruments/scene-layer-protocol.md
+++ b/docs/instruments/scene-layer-protocol.md
@@ -112,8 +112,24 @@ enforce its required layer mask before visible commit:
 
 | Panel | Required layers | Optional layers |
 |---|---|---|
-| PFD | `Attitude`, `Tapes`, `Annunciation` | `Background`, `Guidance`, `Failure` |
+| PFD | `Attitude`, `Tapes`, `Guidance`, `Annunciation` | `Background`, `Failure` |
 | HSI | `Attitude`, `Tapes`, `Guidance`, `Annunciation` | `Background`, `Failure` |
+| Monitor | `Tapes`, `Annunciation` | `Background`, `Attitude`, `Guidance`, `Failure` |
+
+This table is the `required_layers` mask of each shipped descriptor, not an
+independent statement of intent: the required column is the mask, the optional
+column is its complement over the six defined layers, and both are listed in
+ascending layer order. `layer_profile_doc_tests` in
+`pilotage-instrument-panels` parses this table and fails the build if either
+column disagrees with the descriptor it describes, so a mask change must
+arrive with its row.
+
+A panel requires a band when it opens that band on *every* frame, not when the
+band always carries content. The PFD requires `Guidance` on those terms: it
+opens the band unconditionally so the layer contract holds under every
+degradation, and the flight-director command bars inside it disappear when the
+director is disengaged, invalid, or decluttered by the unusual-attitude tier.
+A backend must therefore not read an empty `Guidance` band as a missing one.
 
 A well-framed prefix that ends at a layer boundary is a smaller structural
 scene, not proof of a complete panel frame. Missing a required layer is a

--- a/docs/instruments/scene-layer-protocol.md
+++ b/docs/instruments/scene-layer-protocol.md
@@ -118,11 +118,11 @@ enforce its required layer mask before visible commit:
 
 This table is the `required_layers` mask of each shipped descriptor, not an
 independent statement of intent: the required column is the mask, the optional
-column is its complement over the six defined layers, and both are listed in
+column is its complement over the defined layers, and both are listed in
 ascending layer order. `layer_profile_doc_tests` in
 `pilotage-instrument-panels` parses this table and fails the build if either
 column disagrees with the descriptor it describes, so a mask change must
-arrive with its row.
+arrive with its row. The section holds this one table and no other.
 
 A panel requires a band when it opens that band on *every* frame, not when the
 band always carries content. The PFD requires `Guidance` on those terms: it


### PR DESCRIPTION
Fixes #14.

## Which side was authoritative

The descriptor. `draw_pfd` opens the `Guidance` band unconditionally —
its own comment says so ("The band is always emitted so the layer
contract holds under every degradation; its content disappears with the
director"). So this is the issue's **doc-only branch**: the table was
wrong, not the mask.

## What changed

- The PFD row gains `Guidance` in required and loses it from optional.
- The monitor panel gains the row it never had
  (`Tapes`, `Annunciation` required).
- Prose records *why* the PFD requires a band whose content is often
  empty, so a backend author does not read an empty `Guidance` band as
  a missing one.

## The guardrail

`layer_profile_doc_tests` derives the required column from each
descriptor's `required_layers` mask and the optional column from its
complement over the six defined layers, parses this table out of the
document, and fails on any disagreement — the drift-guard family the
issue asked for.

Both halves of the reported drift were verified to fail the new tests
when reintroduced:

- old PFD row → `documented required layers disagree with required_layers`
- monitor row deleted → `the profiles table must list every shipped panel`

## No display behavior change

Scene digest still `bd85b8537f0b3e4abf8cf3ad3d36c6abfdceac15355639af2804d58dd9c61931`
(bench reports "matches pin"), corpus and raster baselines untouched.

## Gates run locally

fmt, clippy `-D warnings`, test `--all-targets`, doc `-D missing_docs`,
release build, `thumbv7em-none-eabihf` no_std closure, check-structure,
instrument-requirements, certification-claims, standards-registry,
instrument-bench, and both HARD evidence-gate steps — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)