### PR TITLE
Evidence: re-anchor the ATT-01 baseline to the merged rename squash

### DIFF
--- a/crates/indicate-evidence/tests/fixtures/att01-run-output-baselined.txt
+++ b/crates/indicate-evidence/tests/fixtures/att01-run-output-baselined.txt
@@ -2,9 +2,9 @@ Pilotage evidence — captured verification run (SIM / NOT FOR FLIGHT)
 scope: ATT-01
 suite: fixture band behavior
 command: cargo test -p indicate-instrument-raster
-config-digest: 458e3d29dd03ebb37777585459452288e50698e9
+config-digest: 66494ff9a1b9ccd0eaedd2a48211c027c71f841c
 tool-version: rustc 1.95.0
-run-id: local:458e3d29dd03ebb37777585459452288e50698e9
+run-id: local:66494ff9a1b9ccd0eaedd2a48211c027c71f841c
 outcome: pass
 summary:
 test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out

--- a/crates/indicate-evidence/tests/fixtures/attitude-slice.evg
+++ b/crates/indicate-evidence/tests/fixtures/attitude-slice.evg
@@ -17,12 +17,12 @@ attr test band_matches_reference
 
 node RESULT-BAND verification-result
 attr command cargo test -p indicate-instrument-raster
-attr config-digest 458e3d29dd03ebb37777585459452288e50698e9
+attr config-digest 66494ff9a1b9ccd0eaedd2a48211c027c71f841c
 attr tool-version rustc 1.95.0
 attr source-digest git-blob:f399b5de714ad59fc3c75ba830354c8e95e958fd
 attr artifact tests/fixtures/att01-run-output-baselined.txt
-attr output-digest sha256:d311930a432cde5ffc753498435850d559924f6f073ddb1ae6acbdd73ac864ed
-attr run-id local:458e3d29dd03ebb37777585459452288e50698e9
+attr output-digest sha256:01ac153f5658e6ea74568b2ebadc4393b11151728eb57164c0293f0e7c3061e1
+attr run-id local:66494ff9a1b9ccd0eaedd2a48211c027c71f841c
 attr outcome pass
 node CFG-BASE configuration-item
 node TOOL-CARGO tool

--- a/crates/indicate-evidence/tests/fixtures/unresolved-review-entry.evg
+++ b/crates/indicate-evidence/tests/fixtures/unresolved-review-entry.evg
@@ -27,12 +27,12 @@ attr test band_matches_reference
 
 node RESULT-BAND verification-result
 attr command cargo test -p indicate-instrument-raster
-attr config-digest 458e3d29dd03ebb37777585459452288e50698e9
+attr config-digest 66494ff9a1b9ccd0eaedd2a48211c027c71f841c
 attr tool-version rustc 1.95.0
 attr source-digest git-blob:f399b5de714ad59fc3c75ba830354c8e95e958fd
 attr artifact tests/fixtures/att01-run-output-baselined.txt
-attr output-digest sha256:d311930a432cde5ffc753498435850d559924f6f073ddb1ae6acbdd73ac864ed
-attr run-id local:458e3d29dd03ebb37777585459452288e50698e9
+attr output-digest sha256:01ac153f5658e6ea74568b2ebadc4393b11151728eb57164c0293f0e7c3061e1
+attr run-id local:66494ff9a1b9ccd0eaedd2a48211c027c71f841c
 attr outcome pass
 
 node CFG-BASE configuration-item

--- a/docs/instruments/evidence-artifacts/att01/panel.run.txt
+++ b/docs/instruments/evidence-artifacts/att01/panel.run.txt
@@ -2,9 +2,9 @@ Indicate evidence — captured verification run (SIM / NOT FOR FLIGHT)
 scope: ATT-01
 suite: PFD attitude panel
 command: cargo test -p indicate-instrument-panels
-config-digest: 458e3d29dd03ebb37777585459452288e50698e9
+config-digest: 66494ff9a1b9ccd0eaedd2a48211c027c71f841c
 tool-version: rustc 1.95.0 (59807616e 2026-04-14)
-run-id: local:458e3d29dd03ebb37777585459452288e50698e9
+run-id: local:66494ff9a1b9ccd0eaedd2a48211c027c71f841c
 outcome: pass
 summary:
 test result: ok. 77 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out

--- a/docs/instruments/evidence-artifacts/att01/presentation.run.txt
+++ b/docs/instruments/evidence-artifacts/att01/presentation.run.txt
@@ -2,9 +2,9 @@ Indicate evidence — captured verification run (SIM / NOT FOR FLIGHT)
 scope: ATT-01
 suite: SO(3) presentation unit
 command: cargo test -p indicate-instrument-state
-config-digest: 458e3d29dd03ebb37777585459452288e50698e9
+config-digest: 66494ff9a1b9ccd0eaedd2a48211c027c71f841c
 tool-version: rustc 1.95.0 (59807616e 2026-04-14)
-run-id: local:458e3d29dd03ebb37777585459452288e50698e9
+run-id: local:66494ff9a1b9ccd0eaedd2a48211c027c71f841c
 outcome: pass
 summary:
 test result: ok. 167 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out

--- a/docs/instruments/evidence-artifacts/att01/raster.run.txt
+++ b/docs/instruments/evidence-artifacts/att01/raster.run.txt
@@ -2,9 +2,9 @@ Indicate evidence — captured verification run (SIM / NOT FOR FLIGHT)
 scope: ATT-01
 suite: raster attitude behavior
 command: cargo test -p indicate-instrument-raster
-config-digest: 458e3d29dd03ebb37777585459452288e50698e9
+config-digest: 66494ff9a1b9ccd0eaedd2a48211c027c71f841c
 tool-version: rustc 1.95.0 (59807616e 2026-04-14)
-run-id: local:458e3d29dd03ebb37777585459452288e50698e9
+run-id: local:66494ff9a1b9ccd0eaedd2a48211c027c71f841c
 outcome: pass
 summary:
 test result: ok. 86 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out

--- a/docs/instruments/evidence-graph.evg
+++ b/docs/instruments/evidence-graph.evg
@@ -157,34 +157,34 @@ locator docs/instruments/fha.md
 node RESULT-RASTER verification-result
 title raster extreme-attitude behavior — recorded pass
 attr command cargo test -p indicate-instrument-raster
-attr config-digest 458e3d29dd03ebb37777585459452288e50698e9
+attr config-digest 66494ff9a1b9ccd0eaedd2a48211c027c71f841c
 attr tool-version rustc 1.95.0 (59807616e 2026-04-14)
 attr source-digest git-blob:39567de102031c44439f4fce57661b565cf63ce8
 attr artifact docs/instruments/evidence-artifacts/att01/raster.run.txt
-attr output-digest sha256:db661e4ed715c5f7d431541d2fc5581ac756f8427f79d48e8af8bfab777f70b8
-attr run-id local:458e3d29dd03ebb37777585459452288e50698e9
+attr output-digest sha256:40b77cb4b48ded88d3e2f8091466bb859eabd2ec00043e80b65e226cafd3151b
+attr run-id local:66494ff9a1b9ccd0eaedd2a48211c027c71f841c
 attr outcome pass
 
 node RESULT-PRESENTATION verification-result
 title SO(3) presentation unit suite — recorded pass
 attr command cargo test -p indicate-instrument-state
-attr config-digest 458e3d29dd03ebb37777585459452288e50698e9
+attr config-digest 66494ff9a1b9ccd0eaedd2a48211c027c71f841c
 attr tool-version rustc 1.95.0 (59807616e 2026-04-14)
 attr source-digest git-blob:d11595580cab8264e75e9e82ab9994de6d8bdeac
 attr artifact docs/instruments/evidence-artifacts/att01/presentation.run.txt
-attr output-digest sha256:a3417406282da0b168c0be153d5c6bc3b783d3691b65be7e67a2610bc48bbe7e
-attr run-id local:458e3d29dd03ebb37777585459452288e50698e9
+attr output-digest sha256:e81db9b58368fbdd827085afb71a000c0c7ea876d3e702f7f4e0dca3fbfd8b23
+attr run-id local:66494ff9a1b9ccd0eaedd2a48211c027c71f841c
 attr outcome pass
 
 node RESULT-PFD verification-result
 title PFD attitude panel suite — recorded pass
 attr command cargo test -p indicate-instrument-panels
-attr config-digest 458e3d29dd03ebb37777585459452288e50698e9
+attr config-digest 66494ff9a1b9ccd0eaedd2a48211c027c71f841c
 attr tool-version rustc 1.95.0 (59807616e 2026-04-14)
 attr source-digest git-blob:015edf11e26fa840cb410c086262cf4ed2621413
 attr artifact docs/instruments/evidence-artifacts/att01/panel.run.txt
-attr output-digest sha256:ad0c540fcacc5b0e190e2e7705e1f9216cc2c1c5ead80e6487b2030431b5a34c
-attr run-id local:458e3d29dd03ebb37777585459452288e50698e9
+attr output-digest sha256:9ad826cf6791e07cdfe7a78da2310fd539b90a4936b9b4b4e6fb73bb6f945777
+attr run-id local:66494ff9a1b9ccd0eaedd2a48211c027c71f841c
 attr outcome pass
 
 # --- Configuration and tool identity ---
@@ -192,8 +192,8 @@ attr outcome pass
 node CFG-WORKTREE configuration-item
 title engineering worktree baseline — the git working tree the recorded results were produced against (not certified SCM)
 attr scm git-worktree
-attr commit 458e3d29dd03ebb37777585459452288e50698e9
-attr tree 2b18878ed34d6313891ce2aea786ff55f047d9f8
+attr commit 66494ff9a1b9ccd0eaedd2a48211c027c71f841c
+attr tree b61596cf6e62cb4ccec65a7fb41c27c59d2b4721
 
 node TOOL-CARGO-TEST tool
 title cargo test on Rust stable — not DO-330 tool-qualified


### PR DESCRIPTION
Follow-up to #16, which its own description and merge comment flagged as required.

Squash-merging #16 rewrote the lane commit that `CFG-WORKTREE` and all three `RESULT-*` nodes named, orphaning the baseline. **Main is currently red** on both HARD evidence steps:

```
[placeholder-result] RESULT-RASTER: baseline 458e3d29… is not reachable from HEAD:
a non-ancestor commit is a force-push artifact that a fresh clone cannot fetch;
an unreachable baseline fails closed
```

That is the gate working — the `baseline-unreachable` negative fixture exists to prove it does — and this is the same lifecycle as `baf56e2` ("Evidence: re-anchor the ATT-01 baseline to the merged euler-retirement squash").

## What moves

- `CFG-WORKTREE` commit and tree, and every result's `config-digest` / `run-id`, re-anchor to the merged commit `66494ff`.
- The three run records re-stamp their config identity, so their `output-digest` values follow.
- The evidence crate's two positive fixtures carry the same anchor and move with it.

## What does not

The **`source-digest` values are unchanged** — `39567de1…`, `d1159558…`, `015edf11…`. Nothing was re-run, and nothing claims to have been: only the baseline identity moved, which is exactly what the squash changed.

Precisely scoped, since the trees are not globally identical: the squash preserved **the bound test sources** byte-for-byte, and every *build input* of the three recorded suites — all ten closure crate directories, `Cargo.toml`, `Cargo.lock`, `rust-toolchain.toml`, `.cargo`, `clippy.toml`, `rustfmt.toml` — is identical across it. The paths that do differ between the two trees are docs, CI scripts, evidence data, and the `indicate-evidence` crate itself, none of which any recorded suite builds against. So the re-anchored config identity is sound for the runs it names.

Both HARD gates report `verdict: VALID`. Full test suite, check-structure, and fmt green locally.