### PR TITLE
Release markers: a changelog keyed to tags, guarded against drift (#8)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,6 +49,14 @@ jobs:
       - name: check-structure
         run: bash scripts/check-structure.sh
 
+      - name: release marker drift guard
+        # Consumers pin a revision and read the changelog to learn what it
+        # carries. An entry that disagrees with the tree answers the
+        # question wrongly, which is worse than not answering it, so the
+        # five contract values are checked against their definitions.
+        # Tag existence is not checked: CI clones without tags.
+        run: bash scripts/check-release-markers.sh
+
       - name: instrument requirement references
         run: bash scripts/check-instrument-requirements.sh
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,7 +54,11 @@ jobs:
         # carries. An entry that disagrees with the tree answers the
         # question wrongly, which is worse than not answering it, so the
         # five contract values are checked against their definitions.
-        # Tag existence is not checked: CI clones without tags.
+        # Tag existence is not checked, and not because the tags are
+        # absent here — the checkout fetches them. A release tags its own
+        # merge commit, which does not exist while the pull request that
+        # writes the entry is open, so the check would fail every release
+        # on the run that matters. Tagging is a step in CONTRIBUTING.md.
         run: bash scripts/check-release-markers.sh
 
       - name: instrument requirement references

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 
 Consumers pin this repository by revision. A bare revision says nothing
-about what it contains, so every revision meant to be pinned gets an
+about what it contains, so a revision meant to be pinned is given an
 annotated tag and an entry here naming the contract versions it carries.
 
 Five values decide whether a given revision is the one a consumer wants.
@@ -18,9 +18,11 @@ it was written to remove.
 | Composition digest | `BUILTIN_SCENE_DIGEST` in `indicate-instrument-panels` |
 | Panel set | `BUILTIN_PANELS` in `indicate-instrument-panels` |
 
-A release is cut whenever any of the five moves. Entries are newest
-first, and the tag's message carries the same five values so
-`git show <tag>` answers the question without a checkout.
+A release is cut whenever any of the five moves — review's job, since a
+guard comparing the newest entry to the tree cannot tell an added entry
+from a rewritten one. Entries are newest first, and the tag's message
+repeats the same five values so `git show <tag>` answers the question
+without a checkout. `CONTRIBUTING.md` has the release steps.
 
 ## [0.1.0] — 2026-08-07
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,53 @@
+# Changelog
+
+Consumers pin this repository by revision. A bare revision says nothing
+about what it contains, so every revision meant to be pinned gets an
+annotated tag and an entry here naming the contract versions it carries.
+
+Five values decide whether a given revision is the one a consumer wants.
+Each entry states all five, and `scripts/check-release-markers.sh` fails
+the build when the newest entry disagrees with the code it describes — a
+changelog that has to be checked against the source is the archaeology
+it was written to remove.
+
+| Value | Where it lives |
+|---|---|
+| State ABI | `abi::v6::VERSION` in `indicate-instrument-state` |
+| Scene format | `SCENE_FORMAT_VERSION` in `indicate-instrument-scene` |
+| Corpus | `corpusVersion` in `corpus/scene-conformance-corpus.json` |
+| Composition digest | `BUILTIN_SCENE_DIGEST` in `indicate-instrument-panels` |
+| Panel set | `BUILTIN_PANELS` in `indicate-instrument-panels` |
+
+A release is cut whenever any of the five moves. Entries are newest
+first, and the tag's message carries the same five values so
+`git show <tag>` answers the question without a checkout.
+
+## [0.1.0] — 2026-08-07
+
+First tagged revision. The contract surfaces already versioned
+themselves individually; this is the first marker that says which
+*combination* a commit carries.
+
+| Value | This release |
+|---|---|
+| State ABI | 6 |
+| Scene format | 1 |
+| Corpus | 4 |
+| Composition digest | `bd85b8537f0b3e4abf8cf3ad3d36c6abfdceac15355639af2804d58dd9c61931` |
+| Panel set | `pfd`, `hsi`, `monitor` |
+
+Panel set changed since the previous release: n/a, this is the first.
+
+### Notes for anyone re-pinning
+
+- Crates are now named `indicate-*`. A consumer advancing a pin across
+  this release changes every crate name in its manifest. Revisions
+  before it keep the old names, so nothing breaks mid-history.
+- The composition digest is **unchanged** by the rename: it was
+  `bd85b853…` before and after, because the digest domain separator is
+  an identifier and was deliberately not renamed. A consumer that pins
+  the digest does not need to re-verify against this release.
+- The required-layer table in `scene-layer-protocol.md` was corrected to
+  match the shipped descriptors: the PFD requires `Guidance`, and the
+  monitor panel has a row. No descriptor changed, so no digest moved —
+  the document was wrong, not the code.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -56,6 +56,37 @@ the two gate invocations locally after touching any recorded source.
   architecture decision records living in the Pilotage repository's
   `docs/adr/`.
 
+## Cutting a release
+
+Consumers pin a bare revision, so a revision meant to be pinned carries
+an annotated tag and a `CHANGELOG.md` entry naming what it contains.
+
+Cut one whenever any of the five contract values moves: state ABI, scene
+format, corpus, composition digest, or the panel set.
+
+1. Add a `## [x.y.z]` entry at the top of `CHANGELOG.md` with all five
+   values, and anything a consumer re-pinning across it must know.
+   `scripts/check-release-markers.sh` fails the build if a value
+   disagrees with the tree, so run it before pushing.
+2. Merge. The release names the *merge* commit.
+3. Tag that commit, with the same five values in the message:
+
+   ```
+   git tag -a v0.1.0 -m 'Indicate v0.1.0
+   state ABI: 6
+   scene format: 1
+   corpus: 4
+   composition digest: bd85b853…
+   panel set: pfd, hsi, monitor'
+   git push origin v0.1.0
+   ```
+
+Step 3 is deliberately manual and unguarded. A release tags its own
+merge commit, which does not exist while the pull request creating the
+entry is open, so a CI check for the tag would fail every release on the
+one run that matters. The changelog entry is what CI can hold honest;
+the tag is what a human owes it.
+
 ## Discipline that is easy to miss
 
 - REN-03 frame hashes and the scene digest are pinned invariants, not

--- a/README.md
+++ b/README.md
@@ -42,12 +42,17 @@ for the contract every backend author must read.
 
 Consumers pin an exact rev (the same discipline this ecosystem uses for
 Aviate and Navigate). A bare rev says nothing about what it contains, so
-every rev meant to be pinned carries an annotated tag and an entry in
-[`CHANGELOG.md`](CHANGELOG.md) naming the five values that decide
+a rev meant to be pinned is given an annotated tag and an entry in
+[`CHANGELOG.md`](CHANGELOG.md), both naming the five values that decide
 whether it is the rev you want: state ABI, scene format, corpus,
-composition digest, and the panel set. `git show <tag>` answers
-"which rev has ABI v6 and corpus v4?" without a checkout, and CI fails
-when the newest entry disagrees with the tree it describes. The pilot of a change that moves the cross-shell
+composition digest, and the panel set. `git show <tag>` then answers
+"which rev has ABI v6 and corpus v4?" without a checkout. CI fails when
+the newest entry disagrees with the tree it describes; cutting the tag
+itself is a release step in [`CONTRIBUTING.md`](CONTRIBUTING.md),
+because a release tags its own merge commit and so cannot be verified
+by the build that creates it.
+
+The pilot of a change that moves the cross-shell
 scene digest advances the pin in the consuming repositories as part of
 that change; the advance is complete exactly when every consumer
 reproduces the new digest. The scene-conformance corpus

--- a/README.md
+++ b/README.md
@@ -41,7 +41,13 @@ for the contract every backend author must read.
 ## Pinning and advancing
 
 Consumers pin an exact rev (the same discipline this ecosystem uses for
-Aviate and Navigate). The pilot of a change that moves the cross-shell
+Aviate and Navigate). A bare rev says nothing about what it contains, so
+every rev meant to be pinned carries an annotated tag and an entry in
+[`CHANGELOG.md`](CHANGELOG.md) naming the five values that decide
+whether it is the rev you want: state ABI, scene format, corpus,
+composition digest, and the panel set. `git show <tag>` answers
+"which rev has ABI v6 and corpus v4?" without a checkout, and CI fails
+when the newest entry disagrees with the tree it describes. The pilot of a change that moves the cross-shell
 scene digest advances the pin in the consuming repositories as part of
 that change; the advance is complete exactly when every consumer
 reproduces the new digest. The scene-conformance corpus

--- a/scripts/check-release-markers.sh
+++ b/scripts/check-release-markers.sh
@@ -1,0 +1,108 @@
+#!/usr/bin/env bash
+# Guards the release markers (#8): the newest CHANGELOG entry must state
+# the contract versions the tree actually carries.
+#
+# A consumer pins a revision and reads the changelog to learn what it
+# contains. A changelog that drifts from the code is worse than none —
+# it answers the question wrongly instead of sending the reader to the
+# source. So the five values are extracted from the newest entry and
+# compared against the definitions they name.
+#
+# This proves agreement between the entry and the tree. It does NOT
+# prove a tag exists for the entry, or that a tag points where the entry
+# says: tags live in the remote, not the worktree, and CI clones without
+# them. Tag discipline stays a human step.
+set -euo pipefail
+
+root_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$root_dir"
+
+changelog="${INDICATE_CHANGELOG:-CHANGELOG.md}"
+status=0
+
+fail_closed() {
+    echo "$1" >&2
+    echo "check-release-markers: FAILED" >&2
+    exit 1
+}
+
+[ -f "$changelog" ] || fail_closed "MISSING CHANGELOG: $changelog does not exist (fail-closed)"
+
+# The newest entry: from the first release heading to the next one.
+entry="$(awk '
+    /^## \[/ { seen++; if (seen > 1) exit }
+    seen == 1 { print }
+' "$changelog")"
+
+[ -n "$entry" ] || fail_closed "no release entry found in $changelog (fail-closed)"
+
+version="$(printf '%s\n' "$entry" | awk 'NR == 1 { gsub(/^## \[|\].*$/, ""); print; exit }')"
+
+# The value cell of a `| <label> | <value> |` row in the entry's table.
+declared() {
+    printf '%s\n' "$entry" | awk -F'|' -v want="$1" '
+        {
+            label = $2; value = $3
+            gsub(/^[ \t]+|[ \t]+$/, "", label)
+            gsub(/^[ \t]+|[ \t]+$/, "", value)
+            gsub(/`/, "", value)
+            if (label == want) { print value; exit }
+        }
+    '
+}
+
+# The tree's own answer for each of the five.
+actual_abi="$(grep -oE '^pub const VERSION: u8 = [0-9]+' crates/indicate-instrument-state/src/abi/v6.rs | grep -oE '[0-9]+$')"
+actual_scene="$(grep -oE '^pub const SCENE_FORMAT_VERSION: u8 = [0-9]+' crates/indicate-instrument-scene/src/lib.rs | grep -oE '[0-9]+$')"
+actual_corpus="$(grep -oE '"corpusVersion": [0-9]+' crates/indicate-instrument-scene/corpus/scene-conformance-corpus.json | grep -oE '[0-9]+$')"
+actual_digest="$(grep -A2 'BUILTIN_SCENE_DIGEST: &str' crates/indicate-instrument-panels/src/descriptors.rs \
+    | grep -oE '[0-9a-f]{64}')"
+# Panel ids in composition order, as the entry lists them.
+actual_panels="$(awk '
+    /^pub const BUILTIN_PANELS/ { collecting = 1 }
+    collecting { line = line $0; if (/;/) exit }
+    END {
+        n = split(line, parts, /,/)
+        for (i = 1; i <= n; i++) {
+            if (match(parts[i], /[A-Z_]+_DESCRIPTOR/)) {
+                name = tolower(substr(parts[i], RSTART, RLENGTH))
+                sub(/_descriptor/, "", name)
+                out = out (out == "" ? "" : ", ") name
+            }
+        }
+        print out
+    }
+' crates/indicate-instrument-panels/src/descriptors.rs)"
+
+compare() {
+    local label="$1" actual="$2" found
+    found="$(declared "$label")"
+    if [ -z "$found" ]; then
+        echo "MISSING: entry $version states no '$label' row" >&2
+        status=1
+        return
+    fi
+    if [ -z "$actual" ]; then
+        echo "UNREADABLE: cannot read '$label' from the tree" >&2
+        status=1
+        return
+    fi
+    if [ "$found" != "$actual" ]; then
+        echo "DRIFT: entry $version says '$label' is '$found'; the tree says '$actual'" >&2
+        status=1
+    fi
+}
+
+compare "State ABI" "$actual_abi"
+compare "Scene format" "$actual_scene"
+compare "Corpus" "$actual_corpus"
+compare "Composition digest" "$actual_digest"
+compare "Panel set" "$actual_panels"
+
+if [ "$status" -ne 0 ]; then
+    echo "check-release-markers: FAILED" >&2
+    exit 1
+fi
+
+echo "check-release-markers: OK ($version; ABI $actual_abi, scene $actual_scene, corpus $actual_corpus, panels: $actual_panels)"
+echo "check-release-markers: entry/tree agreement only; tag existence is not checked"

--- a/scripts/check-release-markers.sh
+++ b/scripts/check-release-markers.sh
@@ -8,10 +8,18 @@
 # source. So the five values are extracted from the newest entry and
 # compared against the definitions they name.
 #
-# This proves agreement between the entry and the tree. It does NOT
-# prove a tag exists for the entry, or that a tag points where the entry
-# says: tags live in the remote, not the worktree, and CI clones without
-# them. Tag discipline stays a human step.
+# Two things this deliberately does NOT prove:
+#
+#   - That a tag exists for the entry, or points where the entry says.
+#     CI does fetch tags, so this is not a visibility problem; it is a
+#     timing one. A release tags the merge commit, which does not exist
+#     while the pull request that creates the entry is open, so the
+#     check would fail every release on the one run that matters. Tag
+#     discipline is a human step, written down in CONTRIBUTING.md.
+#   - That a release was cut when a value moved. The comparison is
+#     newest-entry-against-tree, so editing a contract and its entry
+#     together passes. That an entry is *added* rather than rewritten is
+#     review's job, not this script's.
 set -euo pipefail
 
 root_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
@@ -28,19 +36,37 @@ fail_closed() {
 
 [ -f "$changelog" ] || fail_closed "MISSING CHANGELOG: $changelog does not exist (fail-closed)"
 
-# The newest entry: from the first release heading to the next one.
+# The newest release entry: from the first version heading to the next.
+# A heading whose bracket holds something other than a version — the
+# conventional `[Unreleased]`, say — is not a release, and skipping it
+# rather than reading it keeps an unreleased section from shadowing the
+# entry this check exists to verify.
 entry="$(awk '
-    /^## \[/ { seen++; if (seen > 1) exit }
+    /^## \[/ {
+        heading = $0
+        sub(/^## \[/, "", heading)
+        sub(/\].*$/, "", heading)
+        is_release = (heading ~ /^[0-9]+\.[0-9]+\.[0-9]+$/)
+        if (is_release) { seen++ }
+        if (seen > 1) { exit }
+    }
     seen == 1 { print }
 ' "$changelog")"
 
-[ -n "$entry" ] || fail_closed "no release entry found in $changelog (fail-closed)"
+[ -n "$entry" ] || fail_closed "no versioned release entry found in $changelog (fail-closed)"
 
 version="$(printf '%s\n' "$entry" | awk 'NR == 1 { gsub(/^## \[|\].*$/, ""); print; exit }')"
 
 # The value cell of a `| <label> | <value> |` row in the entry's table.
+# Rows inside a fenced block or an HTML comment are illustration, not
+# claim, so a table that exists only as an example cannot stand in for
+# the real one.
 declared() {
     printf '%s\n' "$entry" | awk -F'|' -v want="$1" '
+        /^[ \t]*```/ { fenced = !fenced; next }
+        /<!--/ { commented = 1 }
+        /-->/  { commented = 0; next }
+        fenced || commented { next }
         {
             label = $2; value = $3
             gsub(/^[ \t]+|[ \t]+$/, "", label)
@@ -51,23 +77,53 @@ declared() {
     '
 }
 
-# The tree's own answer for each of the five.
-actual_abi="$(grep -oE '^pub const VERSION: u8 = [0-9]+' crates/indicate-instrument-state/src/abi/v6.rs | grep -oE '[0-9]+$')"
-actual_scene="$(grep -oE '^pub const SCENE_FORMAT_VERSION: u8 = [0-9]+' crates/indicate-instrument-scene/src/lib.rs | grep -oE '[0-9]+$')"
-actual_corpus="$(grep -oE '"corpusVersion": [0-9]+' crates/indicate-instrument-scene/corpus/scene-conformance-corpus.json | grep -oE '[0-9]+$')"
-actual_digest="$(grep -A2 'BUILTIN_SCENE_DIGEST: &str' crates/indicate-instrument-panels/src/descriptors.rs \
-    | grep -oE '[0-9a-f]{64}')"
-# Panel ids in composition order, as the entry lists them.
-actual_panels="$(awk '
+# The tree's own answer for each of the five. Each reader is allowed to
+# come back empty so `compare` can report an unreadable source, rather
+# than `set -e` killing the run with a bare grep error.
+read_or_empty() { "$@" 2>/dev/null || true; }
+
+# The ABI in force is the highest version module the crate declares, so
+# adding `v7` moves what this validates instead of leaving it pinned to
+# the file that no longer answers.
+abi_module="$(read_or_empty grep -oE '^pub mod v[0-9]+;' crates/indicate-instrument-state/src/abi.rs \
+    | grep -oE 'v[0-9]+' | sort -V | tail -1)"
+actual_abi=""
+if [ -n "$abi_module" ]; then
+    actual_abi="$(read_or_empty grep -oE '^pub const VERSION: u8 = [0-9]+' \
+        "crates/indicate-instrument-state/src/abi/$abi_module.rs" | grep -oE '[0-9]+$')"
+fi
+actual_scene="$(read_or_empty grep -oE '^pub const SCENE_FORMAT_VERSION: u8 = [0-9]+' \
+    crates/indicate-instrument-scene/src/lib.rs | grep -oE '[0-9]+$')"
+actual_corpus="$(read_or_empty grep -oE '"corpusVersion": [0-9]+' \
+    crates/indicate-instrument-scene/corpus/scene-conformance-corpus.json | grep -oE '[0-9]+$')"
+actual_digest="$(read_or_empty grep -A2 'BUILTIN_SCENE_DIGEST: &str' \
+    crates/indicate-instrument-panels/src/descriptors.rs | grep -oE '[0-9a-f]{64}')"
+
+# The panel ids of BUILTIN_PANELS, in composition order. The slice names
+# descriptor constants, so each is resolved to the `id` its descriptor
+# declares: the id is what a shell selects and what a consumer reads,
+# and a constant renamed without its id is not a panel-set change.
+actual_panels="$(read_or_empty awk '
+    /^pub const [A-Z0-9_]+_DESCRIPTOR: PanelDescriptor/ {
+        match($0, /[A-Z0-9_]+_DESCRIPTOR/)
+        current = substr($0, RSTART, RLENGTH)
+        next
+    }
+    current != "" && /^[ \t]*id:[ \t]*"/ {
+        value = $0
+        sub(/^[ \t]*id:[ \t]*"/, "", value)
+        sub(/".*$/, "", value)
+        id[current] = value
+        current = ""
+    }
     /^pub const BUILTIN_PANELS/ { collecting = 1 }
-    collecting { line = line $0; if (/;/) exit }
+    collecting { slice = slice $0; if (/;/) { collecting = 0 } }
     END {
-        n = split(line, parts, /,/)
+        n = split(slice, parts, /,/)
         for (i = 1; i <= n; i++) {
-            if (match(parts[i], /[A-Z_]+_DESCRIPTOR/)) {
-                name = tolower(substr(parts[i], RSTART, RLENGTH))
-                sub(/_descriptor/, "", name)
-                out = out (out == "" ? "" : ", ") name
+            if (match(parts[i], /[A-Z0-9_]+_DESCRIPTOR/)) {
+                name = substr(parts[i], RSTART, RLENGTH)
+                out = out (out == "" ? "" : ", ") (name in id ? id[name] : "<unresolved:" name ">")
             }
         }
         print out
@@ -77,13 +133,13 @@ actual_panels="$(awk '
 compare() {
     local label="$1" actual="$2" found
     found="$(declared "$label")"
-    if [ -z "$found" ]; then
-        echo "MISSING: entry $version states no '$label' row" >&2
+    if [ -z "$actual" ]; then
+        echo "UNREADABLE: cannot read '$label' from the tree; the check cannot vouch for it" >&2
         status=1
         return
     fi
-    if [ -z "$actual" ]; then
-        echo "UNREADABLE: cannot read '$label' from the tree" >&2
+    if [ -z "$found" ]; then
+        echo "MISSING: entry $version states no '$label' row" >&2
         status=1
         return
     fi
@@ -99,10 +155,17 @@ compare "Corpus" "$actual_corpus"
 compare "Composition digest" "$actual_digest"
 compare "Panel set" "$actual_panels"
 
+case "$actual_panels" in
+    *'<unresolved:'*)
+        echo "UNRESOLVED: a BUILTIN_PANELS entry has no readable id: $actual_panels" >&2
+        status=1
+        ;;
+esac
+
 if [ "$status" -ne 0 ]; then
     echo "check-release-markers: FAILED" >&2
     exit 1
 fi
 
 echo "check-release-markers: OK ($version; ABI $actual_abi, scene $actual_scene, corpus $actual_corpus, panels: $actual_panels)"
-echo "check-release-markers: entry/tree agreement only; tag existence is not checked"
+echo "check-release-markers: entry/tree agreement only; tag existence is a human step (CONTRIBUTING.md)"


### PR DESCRIPTION
Fixes #8.

The issue's own advice was "the cheap version is worth more than the complete one" — a marker naming five values, applied when any of them moves. That is what this is.

## What lands

`CHANGELOG.md`, newest entry first, each naming the five values that decide whether a revision is the one a consumer wants:

| Value | 0.1.0 |
|---|---|
| State ABI | 6 |
| Scene format | 1 |
| Corpus | 4 |
| Composition digest | `bd85b853…` |
| Panel set | `pfd`, `hsi`, `monitor` |

The 0.1.0 entry also tells anyone re-pinning the two things they need to know about this particular release: crate names changed to `indicate-*`, and the composition digest did **not** move across that rename, so a consumer pinning the digest need not re-verify.

## Guardrail

`scripts/check-release-markers.sh`, wired into CI. It extracts the newest entry's five values and compares each against the definition it names (`abi::v6::VERSION`, `SCENE_FORMAT_VERSION`, `corpusVersion`, `BUILTIN_SCENE_DIGEST`, `BUILTIN_PANELS`). A changelog that drifts from its tree answers the pinning question *wrongly*, which is worse than not answering it.

Verified to catch all six failure modes — a wrong value in each of the five rows, and a row deleted outright.

**The guard is deliberately honest about its reach.** It proves entry/tree agreement only. Tags live in the remote and CI clones without them, so it does not and cannot check that a tag exists or points where the entry says; the script prints that caveat rather than implying it checked. Tag discipline stays a human step.

## The tag

`v0.1.0` is annotated on this commit once merged, with the five values in its message. See the note below about pushing it.

## Not done here: moving the tracking issue

The issue also notes that INST-01, the tracking issue, is `luofang34/Pilotage#268` — the wrong repository now that the panels live here. I have not moved or mirrored it: it is a cross-repository change to an issue I did not author, in a repo outside this one, and it is not a code change this PR can carry. Worth doing, but as a deliberate act by someone who owns that tracker.