### PR TITLE
A registry composition can span two panel provider crates (#6)

### DIFF
--- a/crates/indicate-instrument-panels/src/descriptors.rs
+++ b/crates/indicate-instrument-panels/src/descriptors.rs
@@ -9,7 +9,7 @@
 use indicate_alerts::AlertOutput;
 use indicate_instrument_registry::{
     BackgroundCapability, ConfigBlob, DesignFrame, GroupSet, PanelDescriptor, PanelDrawError,
-    Region,
+    PanelSet, Region,
 };
 use indicate_instrument_scene::{LayerId, SceneWriter};
 use indicate_instrument_state::{
@@ -447,6 +447,17 @@ fn monitor_full_channel() -> AircraftState {
 /// The panels this crate ships, in shell display order.
 pub const BUILTIN_PANELS: &[PanelDescriptor] =
     &[PFD_DESCRIPTOR, HSI_DESCRIPTOR, MONITOR_DESCRIPTOR];
+
+/// The panels this crate ships, as the set a shell names.
+///
+/// A shell composing this crate alongside another provider names sets
+/// rather than panels, so gaining a panel here does not edit any
+/// shell. Set identity stays out of the scene digest, so this composes
+/// to the same digest as the bare slice.
+pub const BUILTIN_SET: PanelSet = PanelSet {
+    id: "builtin",
+    panels: BUILTIN_PANELS,
+};
 
 /// The pinned scene digest over [`BUILTIN_PANELS`] and the canonical
 /// corpus (ADR-0033): the composition contract every build target must

--- a/crates/indicate-instrument-panels/src/descriptors/digest_tests.rs
+++ b/crates/indicate-instrument-panels/src/descriptors/digest_tests.rs
@@ -3,10 +3,10 @@
 use std::string::String;
 use std::vec;
 
-use indicate_instrument_registry::{PanelDescriptor, Registry, scene_digest};
+use indicate_instrument_registry::{PanelDescriptor, PanelSet, Registry, scene_digest};
 use indicate_instrument_scene::MAX_SCENE_BYTES;
 
-use super::{BUILTIN_PANELS, HSI_DESCRIPTOR, PFD_DESCRIPTOR};
+use super::{BUILTIN_PANELS, HSI_DESCRIPTOR, MONITOR_DESCRIPTOR, PFD_DESCRIPTOR};
 
 fn hex(digest: [u8; 32]) -> String {
     const HEX: &[u8; 16] = b"0123456789abcdef";
@@ -36,4 +36,41 @@ fn the_digest_moves_when_the_composition_moves() {
     let full = digest_of(BUILTIN_PANELS);
     assert_ne!(digest_of(&PFD_ONLY), full, "dropping a panel must move it");
     assert_ne!(digest_of(&REVERSED), full, "panel order is contractual");
+}
+
+/// The mechanism #6 asks for is a pure refactor of composition, not of
+/// paint: naming the shipped panels as a set must reproduce the pinned
+/// digest byte for byte, or set identity has leaked into cross-shell
+/// identity.
+#[test]
+fn composing_the_builtin_set_reproduces_the_pinned_digest() {
+    static SETS: [&PanelSet; 1] = [&super::BUILTIN_SET];
+    let registry = Registry::from_sets(&SETS).expect("the shipped set composes");
+    let mut scratch = vec![0u8; MAX_SCENE_BYTES];
+    assert_eq!(
+        hex(scene_digest(&registry, &mut scratch).expect("digests")),
+        super::BUILTIN_SCENE_DIGEST,
+    );
+}
+
+/// Sets are packaging, not paint: the same panels in the same order
+/// digest the same however they are grouped.
+#[test]
+fn regrouping_panels_without_reordering_them_is_digest_neutral() {
+    static HEAD: PanelSet = PanelSet {
+        id: "head",
+        panels: &[PFD_DESCRIPTOR],
+    };
+    static TAIL: PanelSet = PanelSet {
+        id: "tail",
+        panels: &[HSI_DESCRIPTOR, MONITOR_DESCRIPTOR],
+    };
+    static SPLIT: [&PanelSet; 2] = [&HEAD, &TAIL];
+    let registry = Registry::from_sets(&SPLIT).expect("composes");
+    let mut scratch = vec![0u8; MAX_SCENE_BYTES];
+    assert_eq!(
+        hex(scene_digest(&registry, &mut scratch).expect("digests")),
+        super::BUILTIN_SCENE_DIGEST,
+        "set boundaries must not reach the digest",
+    );
 }

--- a/crates/indicate-instrument-panels/src/lib.rs
+++ b/crates/indicate-instrument-panels/src/lib.rs
@@ -25,7 +25,8 @@ mod monitor;
 mod pfd;
 
 pub use descriptors::{
-    BUILTIN_PANELS, BUILTIN_SCENE_DIGEST, HSI_DESCRIPTOR, MONITOR_DESCRIPTOR, PFD_DESCRIPTOR,
+    BUILTIN_PANELS, BUILTIN_SCENE_DIGEST, BUILTIN_SET, HSI_DESCRIPTOR, MONITOR_DESCRIPTOR,
+    PFD_DESCRIPTOR,
 };
 pub use hsi::draw_hsi;
 pub use monitor::draw_monitor;

--- a/crates/indicate-instrument-registry/src/lib.rs
+++ b/crates/indicate-instrument-registry/src/lib.rs
@@ -7,9 +7,19 @@
 //! panel enumeration: identity, required layers and state groups, the
 //! design frame, background capability, the bounded key-TLV
 //! configuration schema, and the draw entry point. A registry is plain
-//! data composed by each shell ([`Registry::new`] validates the
-//! composition at init); an out-of-repo panel registers by being listed
-//! in the shell's descriptor slice, never by link-time magic.
+//! data composed by each shell, validated at init; an out-of-repo panel
+//! registers by being named in the shell's composition, never by
+//! link-time magic.
+//!
+//! A shell drawing from one provider crate passes a descriptor slice to
+//! [`Registry::new`]. A shell drawing from several names
+//! [`PanelSet`]s and calls [`Registry::from_sets`], so adding an
+//! instrument family is one declaration naming the set rather than one
+//! line per panel — the by-hand panel list ADR-0029 removed does not
+//! reappear one layer up. Both compositions are `Copy` and
+//! allocation-free, and the same per-panel rules run over the flattened
+//! traversal either way, so a panel id claimed by two sets is refused
+//! at init.
 
 #![no_std]
 
@@ -21,6 +31,7 @@ mod descriptor;
 mod digest;
 mod group_set;
 mod registry;
+mod set;
 pub mod states;
 
 pub use config::{CONFIG_BLOB_MAX, ConfigBlob, ConfigError, ConfigKey, EMPTY_CONFIG, keys};
@@ -30,5 +41,6 @@ pub use descriptor::{
 };
 pub use digest::{DigestError, SCENE_DIGEST_DOMAIN, scene_digest};
 pub use group_set::GroupSet;
-pub use registry::{Registry, RegistryError};
+pub use registry::{Panels, Registry, RegistryError};
+pub use set::PanelSet;
 pub use states::{CANONICAL_STATES, CanonicalState};

--- a/crates/indicate-instrument-registry/src/registry.rs
+++ b/crates/indicate-instrument-registry/src/registry.rs
@@ -31,7 +31,12 @@ pub struct Registry {
 /// The flattened order is contractual — it is the order
 /// [`crate::scene_digest`] streams — so a shell's set list is its
 /// composition order.
-#[derive(Debug, Clone, Copy)]
+///
+/// `Clone` but deliberately not `Copy`, following the slice iterators:
+/// a `Copy` iterator can be consumed through a copy while the original
+/// silently stays where it was, and a half-read composition that looks
+/// whole is the wrong thing to make easy here.
+#[derive(Debug, Clone)]
 pub struct Panels {
     composition: Composition,
     set: usize,
@@ -100,7 +105,7 @@ pub enum RegistryError {
     /// A panel id violates the lowercase/digits/dashes charset.
     #[error("panel {index} has a malformed id")]
     BadId {
-        /// Position in the composed slice.
+        /// Position in the flattened composition.
         index: usize,
     },
     /// Two panels share an id.
@@ -112,20 +117,20 @@ pub enum RegistryError {
     /// An empty title cannot label health or layout surfaces.
     #[error("panel {index} has an empty title")]
     EmptyTitle {
-        /// Position in the composed slice.
+        /// Position in the flattened composition.
         index: usize,
     },
     /// A panel that requires no layers would pass every completeness
     /// check vacuously.
     #[error("panel {index} declares no required layers")]
     NoRequiredLayers {
-        /// Position in the composed slice.
+        /// Position in the flattened composition.
         index: usize,
     },
     /// Required-layer bits beyond the defined scene layers.
     #[error("panel {index} requires undefined layer bits {bits:#04x}")]
     UndefinedLayerBits {
-        /// Position in the composed slice.
+        /// Position in the flattened composition.
         index: usize,
         /// The offending mask.
         bits: u8,
@@ -133,13 +138,13 @@ pub enum RegistryError {
     /// A non-finite or non-positive design frame.
     #[error("panel {index} has a degenerate design frame")]
     BadDesignFrame {
-        /// Position in the composed slice.
+        /// Position in the flattened composition.
         index: usize,
     },
     /// Schema keys must be strictly ascending (unique by construction).
     #[error("panel {index} schema key {key} repeats or descends")]
     SchemaKeysNotAscending {
-        /// Position in the composed slice.
+        /// Position in the flattened composition.
         index: usize,
         /// The out-of-order key.
         key: u16,
@@ -147,7 +152,7 @@ pub enum RegistryError {
     /// A group region for a group the panel does not consume.
     #[error("panel {index} declares a region for group {group} it does not require")]
     RegionGroupNotRequired {
-        /// Position in the composed slice.
+        /// Position in the flattened composition.
         index: usize,
         /// The wire tag of the unrequired group.
         group: u8,
@@ -155,7 +160,7 @@ pub enum RegistryError {
     /// A group region outside the design frame (or degenerate).
     #[error("panel {index} declares a region for group {group} outside its design frame")]
     RegionOutsideFrame {
-        /// Position in the composed slice.
+        /// Position in the flattened composition.
         index: usize,
         /// The wire tag of the group.
         group: u8,
@@ -163,7 +168,7 @@ pub enum RegistryError {
     /// Two extreme states of one panel share an id.
     #[error("panel {index} repeats the extreme-state id at position {position}")]
     DuplicateExtremeId {
-        /// Position in the composed slice.
+        /// Position in the flattened composition.
         index: usize,
         /// Position of the second occurrence within the panel.
         position: usize,
@@ -171,7 +176,7 @@ pub enum RegistryError {
     /// An extreme-state id violates the lowercase/digits/dashes charset.
     #[error("panel {index} extreme state {position} has a malformed id")]
     BadExtremeId {
-        /// Position in the composed slice.
+        /// Position in the flattened composition.
         index: usize,
         /// Position of the offending extreme state within the panel.
         position: usize,
@@ -231,6 +236,11 @@ impl Registry {
     /// The per-panel rules, run over the flattened composition.
     fn validated(composition: Composition) -> Result<Registry, RegistryError> {
         let registry = Registry { composition };
+        // Both constructors already refuse a composition that yields no
+        // panels, so this is unreachable today. It stays because it is
+        // the invariant the per-panel loop below depends on, and a
+        // third `Composition` shape would otherwise inherit a loop that
+        // passes by iterating nothing.
         if registry.panels().next().is_none() {
             return Err(RegistryError::Empty);
         }

--- a/crates/indicate-instrument-registry/src/registry.rs
+++ b/crates/indicate-instrument-registry/src/registry.rs
@@ -3,12 +3,69 @@
 use indicate_instrument_scene::LAYER_COUNT;
 
 use crate::descriptor::PanelDescriptor;
+use crate::set::PanelSet;
+
+/// How a shell named the panels it composed.
+///
+/// A shell with one provider crate passes a slice and never sees sets;
+/// a shell composing several names the sets. Both are `Copy` and hold
+/// only `'static` references, so a registry stays allocation-free —
+/// the family has no allocator with which to concatenate slices.
+#[derive(Debug, Clone, Copy)]
+enum Composition {
+    /// One unnamed set: the single-provider shell.
+    Anonymous(&'static [PanelDescriptor]),
+    /// Named sets, in composition order.
+    Sets(&'static [&'static PanelSet]),
+}
 
 /// A validated panel composition. Construction is the gate: a shell
 /// that composes nonsense fails at init, not at draw time.
 #[derive(Debug, Clone, Copy)]
 pub struct Registry {
-    panels: &'static [PanelDescriptor],
+    composition: Composition,
+}
+
+/// The composed panels: set order, then panel order within each set.
+///
+/// The flattened order is contractual — it is the order
+/// [`crate::scene_digest`] streams — so a shell's set list is its
+/// composition order.
+#[derive(Debug, Clone, Copy)]
+pub struct Panels {
+    composition: Composition,
+    set: usize,
+    panel: usize,
+}
+
+impl Iterator for Panels {
+    type Item = &'static PanelDescriptor;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        match self.composition {
+            Composition::Anonymous(panels) => {
+                let next = panels.get(self.panel)?;
+                self.panel += 1;
+                Some(next)
+            }
+            Composition::Sets(sets) => loop {
+                let set = sets.get(self.set)?;
+                match set.panels.get(self.panel) {
+                    Some(next) => {
+                        self.panel += 1;
+                        return Some(next);
+                    }
+                    // An exhausted set yields to the next. Empty sets
+                    // are refused at construction, so in a validated
+                    // registry this advances at most once per call.
+                    None => {
+                        self.set += 1;
+                        self.panel = 0;
+                    }
+                }
+            },
+        }
+    }
 }
 
 /// Why a composition was refused.
@@ -17,6 +74,29 @@ pub enum RegistryError {
     /// A shell with no panels has nothing to display.
     #[error("a registry must contain at least one panel")]
     Empty,
+    /// A composition naming no sets has nothing to display, and would
+    /// pass the per-panel checks vacuously.
+    #[error("a registry must contain at least one set")]
+    NoSets,
+    /// A set id violates the lowercase/digits/dashes charset.
+    #[error("set {set} has a malformed id")]
+    BadSetId {
+        /// Position in the composed set list.
+        set: usize,
+    },
+    /// Two sets share an id, so neither can be named unambiguously.
+    #[error("set {set} repeats an earlier set's id")]
+    DuplicateSetId {
+        /// Position of the second occurrence.
+        set: usize,
+    },
+    /// A set contributing no panels is a provider wired up wrongly, not
+    /// a shell that wanted nothing.
+    #[error("set {set} contributes no panels")]
+    EmptySet {
+        /// Position in the composed set list.
+        set: usize,
+    },
     /// A panel id violates the lowercase/digits/dashes charset.
     #[error("panel {index} has a malformed id")]
     BadId {
@@ -115,28 +195,79 @@ fn id_ok(id: &str) -> bool {
 }
 
 impl Registry {
-    /// Validates and composes `panels`.
+    /// Validates and composes `panels` as a single unnamed set — the
+    /// shell that draws from one provider crate.
     pub fn new(panels: &'static [PanelDescriptor]) -> Result<Registry, RegistryError> {
         if panels.is_empty() {
             return Err(RegistryError::Empty);
         }
-        for (index, panel) in panels.iter().enumerate() {
+        Registry::validated(Composition::Anonymous(panels))
+    }
+
+    /// Validates and composes `sets`, in the order the shell lists
+    /// them.
+    ///
+    /// Every rule [`Registry::new`] applies runs over the flattened
+    /// composition, so two sets contributing the same panel id fail
+    /// here rather than resolving to whichever set was listed first.
+    pub fn from_sets(sets: &'static [&'static PanelSet]) -> Result<Registry, RegistryError> {
+        if sets.is_empty() {
+            return Err(RegistryError::NoSets);
+        }
+        for (index, set) in sets.iter().enumerate() {
+            if !id_ok(set.id) {
+                return Err(RegistryError::BadSetId { set: index });
+            }
+            if set.panels.is_empty() {
+                return Err(RegistryError::EmptySet { set: index });
+            }
+            if sets[..index].iter().any(|earlier| earlier.id == set.id) {
+                return Err(RegistryError::DuplicateSetId { set: index });
+            }
+        }
+        Registry::validated(Composition::Sets(sets))
+    }
+
+    /// The per-panel rules, run over the flattened composition.
+    fn validated(composition: Composition) -> Result<Registry, RegistryError> {
+        let registry = Registry { composition };
+        if registry.panels().next().is_none() {
+            return Err(RegistryError::Empty);
+        }
+        for (index, panel) in registry.panels().enumerate() {
             validate_panel(index, panel)?;
-            if panels[..index].iter().any(|earlier| earlier.id == panel.id) {
+            if registry
+                .panels()
+                .take(index)
+                .any(|earlier| earlier.id == panel.id)
+            {
                 return Err(RegistryError::DuplicateId { index });
             }
         }
-        Ok(Registry { panels })
+        Ok(registry)
     }
 
     /// The composed descriptors, in shell order.
-    pub const fn panels(&self) -> &'static [PanelDescriptor] {
-        self.panels
+    pub const fn panels(&self) -> Panels {
+        Panels {
+            composition: self.composition,
+            set: 0,
+            panel: 0,
+        }
+    }
+
+    /// The sets this registry composes, in shell order; empty for a
+    /// registry built from a bare slice, which named none.
+    pub const fn sets(&self) -> &'static [&'static PanelSet] {
+        match self.composition {
+            Composition::Anonymous(_) => &[],
+            Composition::Sets(sets) => sets,
+        }
     }
 
     /// The descriptor with `id`, if composed.
     pub fn by_id(&self, id: &str) -> Option<&'static PanelDescriptor> {
-        self.panels.iter().find(|panel| panel.id == id)
+        self.panels().find(|panel| panel.id == id)
     }
 }
 

--- a/crates/indicate-instrument-registry/src/registry/tests.rs
+++ b/crates/indicate-instrument-registry/src/registry/tests.rs
@@ -4,12 +4,15 @@ use indicate_alerts::AlertOutput;
 use indicate_instrument_scene::{LAYER_COUNT, SceneWriter};
 use indicate_instrument_state::{AircraftState, GroupId, PanelData};
 
+use std::vec::Vec;
+
 use super::{Registry, RegistryError};
 use crate::config::ConfigBlob;
 use crate::descriptor::{
     BackgroundCapability, DesignFrame, ExtremeState, PanelDescriptor, PanelDrawError, Region,
 };
 use crate::group_set::GroupSet;
+use crate::set::PanelSet;
 
 fn draw_nothing(
     _data: &PanelData,
@@ -47,7 +50,7 @@ const fn panel(id: &'static str) -> PanelDescriptor {
 fn a_valid_composition_is_accepted_and_queryable() {
     static PANELS: [PanelDescriptor; 2] = [panel("alpha"), panel("beta-2")];
     let registry = Registry::new(&PANELS).expect("two well-formed panels");
-    assert_eq!(registry.panels().len(), 2);
+    assert_eq!(registry.panels().count(), 2);
     assert_eq!(registry.by_id("beta-2").expect("registered").id, "beta-2");
     assert!(registry.by_id("gamma").is_none());
 }
@@ -193,4 +196,112 @@ fn extreme_state_ids_must_be_unique_and_well_formed() {
             position: 1,
         })
     );
+}
+
+// --- Composition across provider crates (#6) ---
+
+static ALPHA: PanelSet = PanelSet {
+    id: "alpha-set",
+    panels: &[panel("alpha")],
+};
+static BETA: PanelSet = PanelSet {
+    id: "beta-set",
+    panels: &[panel("beta")],
+};
+
+#[test]
+fn sets_compose_in_shell_order_and_stay_queryable() {
+    static SETS: [&PanelSet; 2] = [&ALPHA, &BETA];
+    let registry = Registry::from_sets(&SETS).expect("two well-formed sets");
+    let ids: Vec<&str> = registry.panels().map(|panel| panel.id).collect();
+    assert_eq!(ids, ["alpha", "beta"], "set order is composition order");
+    assert_eq!(registry.by_id("beta").expect("registered").id, "beta");
+    assert_eq!(registry.sets().len(), 2);
+}
+
+/// The property this mechanism exists for: a shell that composes two
+/// sets claiming the same panel gets a refusal at init, not whichever
+/// panel happened to be listed first.
+#[test]
+fn a_panel_id_claimed_by_two_sets_is_refused() {
+    static CLASH: PanelSet = PanelSet {
+        id: "clash-set",
+        panels: &[panel("alpha")],
+    };
+    static SETS: [&PanelSet; 2] = [&ALPHA, &CLASH];
+    assert_eq!(
+        Registry::from_sets(&SETS).map(|_| ()),
+        Err(RegistryError::DuplicateId { index: 1 }),
+    );
+}
+
+#[test]
+fn per_panel_rules_still_run_over_a_composition_of_sets() {
+    static UPPER: PanelSet = PanelSet {
+        id: "upper-set",
+        panels: &[panel("Alpha")],
+    };
+    static SETS: [&PanelSet; 2] = [&ALPHA, &UPPER];
+    assert_eq!(
+        Registry::from_sets(&SETS).map(|_| ()),
+        Err(RegistryError::BadId { index: 1 }),
+        "a malformed id must not ride in unchecked because it arrived in a set",
+    );
+}
+
+#[test]
+fn two_sets_sharing_an_id_are_refused() {
+    static TWIN: PanelSet = PanelSet {
+        id: "alpha-set",
+        panels: &[panel("other")],
+    };
+    static SETS: [&PanelSet; 2] = [&ALPHA, &TWIN];
+    assert_eq!(
+        Registry::from_sets(&SETS).map(|_| ()),
+        Err(RegistryError::DuplicateSetId { set: 1 }),
+    );
+}
+
+#[test]
+fn a_set_contributing_no_panels_is_refused() {
+    static HOLLOW: PanelSet = PanelSet {
+        id: "hollow-set",
+        panels: &[],
+    };
+    static SETS: [&PanelSet; 2] = [&ALPHA, &HOLLOW];
+    assert_eq!(
+        Registry::from_sets(&SETS).map(|_| ()),
+        Err(RegistryError::EmptySet { set: 1 }),
+    );
+}
+
+#[test]
+fn a_malformed_set_id_is_refused() {
+    static SHOUTY: PanelSet = PanelSet {
+        id: "Alpha_Set",
+        panels: &[panel("gamma")],
+    };
+    static SETS: [&PanelSet; 1] = [&SHOUTY];
+    assert_eq!(
+        Registry::from_sets(&SETS).map(|_| ()),
+        Err(RegistryError::BadSetId { set: 0 }),
+    );
+}
+
+#[test]
+fn a_composition_naming_no_sets_is_refused() {
+    assert_eq!(
+        Registry::from_sets(&[]).map(|_| ()),
+        Err(RegistryError::NoSets),
+    );
+}
+
+/// A bare slice still composes: a single-provider shell never learns
+/// that sets exist.
+#[test]
+fn an_anonymous_composition_names_no_sets() {
+    static PANELS: [PanelDescriptor; 1] = [panel("alpha")];
+    let registry = Registry::new(&PANELS).expect("composes");
+    assert!(registry.sets().is_empty());
+    assert_eq!(registry.panels().count(), 1);
 }

--- a/crates/indicate-instrument-registry/src/set.rs
+++ b/crates/indicate-instrument-registry/src/set.rs
@@ -1,0 +1,24 @@
+//! Panel sets: the unit a shell names when it composes a registry.
+//!
+//! A provider crate exports one [`PanelSet`] rather than loose
+//! descriptors, so adding an instrument family to a shell is one
+//! declaration naming the set instead of one line per panel. The
+//! registry still validates panels, so a set cannot smuggle a
+//! malformed descriptor past the checks by arriving in a group, and
+//! cross-set duplicate ids are caught at init rather than resolving to
+//! whichever panel the shell happened to list first.
+//!
+//! Sets are packaging, not paint: set identity stays out of the scene
+//! digest, so regrouping the same panels into different sets without
+//! reordering them leaves cross-shell identity untouched.
+
+use crate::descriptor::PanelDescriptor;
+
+/// A named group of panels contributed by one provider crate.
+#[derive(Debug, Clone, Copy)]
+pub struct PanelSet {
+    /// Set identity, under the same charset rule as panel ids.
+    pub id: &'static str,
+    /// The set's panels, in the order they compose.
+    pub panels: &'static [PanelDescriptor],
+}

--- a/tools/instrument-bench/src/main.rs
+++ b/tools/instrument-bench/src/main.rs
@@ -119,7 +119,7 @@ fn main() -> Result<(), BenchError> {
     }
     print_line(&format!(
         "rasterized {} panels x {} states",
-        registry.panels().len(),
+        registry.panels().count(),
         CANONICAL_STATES.len()
     ));
     Ok(())


### PR DESCRIPTION
Fixes #6.

Implements the two-level registry the issue's plan recommends — of its three candidates, the only one that is alloc-free, macro-free, and keeps the shell's declaration to one line naming sets.

## Shape

- `PanelSet { id, panels }` — a named group a provider crate exports. Set ids pass the same charset rule as panel ids.
- `Registry::from_sets(&'static [&'static PanelSet])` composes sets in shell order.
- `Registry::new(panels)` stays as the single-anonymous-set convenience, so a one-provider shell never learns sets exist.
- `Registry` stays `Copy` and allocation-free: the composition is an enum over the two shapes, and `panels()` returns an iterator over the flattened traversal (set order, then panel order). Only 5 call sites existed; 3 were `for` loops that needed no change.

## Validation

Today's per-panel rules run over the flattened traversal, so **a panel id claimed by two sets fails as `DuplicateId` at init** — precisely the omission the registry could not previously detect, because it was never shown the whole composition. Plus four new variants: `DuplicateSetId`, `EmptySet`, `BadSetId`, `NoSets`.

A test also pins that a malformed panel id cannot ride in unchecked merely because it arrived inside a set.

## Acceptance criterion — met

`Registry::from_sets(&[&BUILTIN_SET])` reproduces `BUILTIN_SCENE_DIGEST` (`bd85b853…`) **byte for byte**, which is the proof this is a pure refactor of composition rather than of paint.

A second test pins the corollary the issue argues for: splitting the same panels across two sets *without reordering them* digests identically, because set identity stays out of the digest — sets are packaging, not paint. Regrouping is therefore digest-neutral, while reordering still moves the digest (the pre-existing test covers that).

## Out of scope, deliberately

Where set crates live, what they may depend on, and the authoring path are #13's; the panel-side contract is #7's. Landing them separately keeps each independently revertible.

## Gates

fmt, clippy `-D warnings`, test `--all-targets`, doc `-D missing_docs`, `thumbv7em-none-eabihf` (the mechanism is in the no_std closure), check-structure, check-release-markers, instrument-bench (digest matches pin), and the HARD evidence gate — all green.