### PR TITLE
Evidence: re-anchor the ATT-01 baseline to the merged tier squash

### DIFF
--- a/crates/indicate-evidence/tests/fixtures/att01-run-output-baselined.txt
+++ b/crates/indicate-evidence/tests/fixtures/att01-run-output-baselined.txt
@@ -2,9 +2,9 @@ Pilotage evidence — captured verification run (SIM / NOT FOR FLIGHT)
 scope: ATT-01
 suite: fixture band behavior
 command: cargo test -p indicate-instrument-raster
-config-digest: 08a31a9c1287c549cefb961604ea80ed4428ed33
+config-digest: f660304b057bec44ce31a7602673bc1e9cd9e6b9
 tool-version: rustc 1.95.0
-run-id: local:08a31a9c1287c549cefb961604ea80ed4428ed33
+run-id: local:f660304b057bec44ce31a7602673bc1e9cd9e6b9
 outcome: pass
 summary:
 test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out

--- a/crates/indicate-evidence/tests/fixtures/attitude-slice.evg
+++ b/crates/indicate-evidence/tests/fixtures/attitude-slice.evg
@@ -17,12 +17,12 @@ attr test band_matches_reference
 
 node RESULT-BAND verification-result
 attr command cargo test -p indicate-instrument-raster
-attr config-digest 08a31a9c1287c549cefb961604ea80ed4428ed33
+attr config-digest f660304b057bec44ce31a7602673bc1e9cd9e6b9
 attr tool-version rustc 1.95.0
 attr source-digest git-blob:f399b5de714ad59fc3c75ba830354c8e95e958fd
 attr artifact tests/fixtures/att01-run-output-baselined.txt
-attr output-digest sha256:3c4fe884695b7d6ca0eb3e26cc86eff7e89966461b133b0bd24ca0a57e8d239a
-attr run-id local:08a31a9c1287c549cefb961604ea80ed4428ed33
+attr output-digest sha256:aaf3c06593b58ffecc8a222015c313ffcabc5de9970ca7e2c1debf6eeaa8a322
+attr run-id local:f660304b057bec44ce31a7602673bc1e9cd9e6b9
 attr outcome pass
 node CFG-BASE configuration-item
 node TOOL-CARGO tool

--- a/crates/indicate-evidence/tests/fixtures/unresolved-review-entry.evg
+++ b/crates/indicate-evidence/tests/fixtures/unresolved-review-entry.evg
@@ -27,12 +27,12 @@ attr test band_matches_reference
 
 node RESULT-BAND verification-result
 attr command cargo test -p indicate-instrument-raster
-attr config-digest 08a31a9c1287c549cefb961604ea80ed4428ed33
+attr config-digest f660304b057bec44ce31a7602673bc1e9cd9e6b9
 attr tool-version rustc 1.95.0
 attr source-digest git-blob:f399b5de714ad59fc3c75ba830354c8e95e958fd
 attr artifact tests/fixtures/att01-run-output-baselined.txt
-attr output-digest sha256:3c4fe884695b7d6ca0eb3e26cc86eff7e89966461b133b0bd24ca0a57e8d239a
-attr run-id local:08a31a9c1287c549cefb961604ea80ed4428ed33
+attr output-digest sha256:aaf3c06593b58ffecc8a222015c313ffcabc5de9970ca7e2c1debf6eeaa8a322
+attr run-id local:f660304b057bec44ce31a7602673bc1e9cd9e6b9
 attr outcome pass
 
 node CFG-BASE configuration-item

--- a/docs/instruments/evidence-artifacts/att01/panel.run.txt
+++ b/docs/instruments/evidence-artifacts/att01/panel.run.txt
@@ -2,9 +2,9 @@ Indicate evidence — captured verification run (SIM / NOT FOR FLIGHT)
 scope: ATT-01
 suite: PFD attitude panel
 command: cargo test -p indicate-instrument-panels
-config-digest: 08a31a9c1287c549cefb961604ea80ed4428ed33
+config-digest: f660304b057bec44ce31a7602673bc1e9cd9e6b9
 tool-version: rustc 1.95.0 (59807616e 2026-04-14)
-run-id: local:08a31a9c1287c549cefb961604ea80ed4428ed33
+run-id: local:f660304b057bec44ce31a7602673bc1e9cd9e6b9
 outcome: pass
 summary:
 test result: ok. 79 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out

--- a/docs/instruments/evidence-artifacts/att01/presentation.run.txt
+++ b/docs/instruments/evidence-artifacts/att01/presentation.run.txt
@@ -2,9 +2,9 @@ Indicate evidence — captured verification run (SIM / NOT FOR FLIGHT)
 scope: ATT-01
 suite: SO(3) presentation unit
 command: cargo test -p indicate-instrument-state
-config-digest: 08a31a9c1287c549cefb961604ea80ed4428ed33
+config-digest: f660304b057bec44ce31a7602673bc1e9cd9e6b9
 tool-version: rustc 1.95.0 (59807616e 2026-04-14)
-run-id: local:08a31a9c1287c549cefb961604ea80ed4428ed33
+run-id: local:f660304b057bec44ce31a7602673bc1e9cd9e6b9
 outcome: pass
 summary:
 test result: ok. 167 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out

--- a/docs/instruments/evidence-artifacts/att01/raster.run.txt
+++ b/docs/instruments/evidence-artifacts/att01/raster.run.txt
@@ -2,9 +2,9 @@ Indicate evidence — captured verification run (SIM / NOT FOR FLIGHT)
 scope: ATT-01
 suite: raster attitude behavior
 command: cargo test -p indicate-instrument-raster
-config-digest: 08a31a9c1287c549cefb961604ea80ed4428ed33
+config-digest: f660304b057bec44ce31a7602673bc1e9cd9e6b9
 tool-version: rustc 1.95.0 (59807616e 2026-04-14)
-run-id: local:08a31a9c1287c549cefb961604ea80ed4428ed33
+run-id: local:f660304b057bec44ce31a7602673bc1e9cd9e6b9
 outcome: pass
 summary:
 test result: ok. 86 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out

--- a/docs/instruments/evidence-graph.evg
+++ b/docs/instruments/evidence-graph.evg
@@ -157,34 +157,34 @@ locator docs/instruments/fha.md
 node RESULT-RASTER verification-result
 title raster extreme-attitude behavior — recorded pass
 attr command cargo test -p indicate-instrument-raster
-attr config-digest 08a31a9c1287c549cefb961604ea80ed4428ed33
+attr config-digest f660304b057bec44ce31a7602673bc1e9cd9e6b9
 attr tool-version rustc 1.95.0 (59807616e 2026-04-14)
 attr source-digest git-blob:39567de102031c44439f4fce57661b565cf63ce8
 attr artifact docs/instruments/evidence-artifacts/att01/raster.run.txt
-attr output-digest sha256:f17ec7dff5445123cbb597c7e0c1c63d7fda19e25e552ee886365a5fda741964
-attr run-id local:08a31a9c1287c549cefb961604ea80ed4428ed33
+attr output-digest sha256:3f2dc238625127e4337cfa9904e5dfa6beaa0cd4be3d0e8d7e407a6964004dda
+attr run-id local:f660304b057bec44ce31a7602673bc1e9cd9e6b9
 attr outcome pass
 
 node RESULT-PRESENTATION verification-result
 title SO(3) presentation unit suite — recorded pass
 attr command cargo test -p indicate-instrument-state
-attr config-digest 08a31a9c1287c549cefb961604ea80ed4428ed33
+attr config-digest f660304b057bec44ce31a7602673bc1e9cd9e6b9
 attr tool-version rustc 1.95.0 (59807616e 2026-04-14)
 attr source-digest git-blob:d11595580cab8264e75e9e82ab9994de6d8bdeac
 attr artifact docs/instruments/evidence-artifacts/att01/presentation.run.txt
-attr output-digest sha256:85140c02a28501e19b87beb8bc962ce477103cd421cc95a660f3fe614563e0ea
-attr run-id local:08a31a9c1287c549cefb961604ea80ed4428ed33
+attr output-digest sha256:937eb84a8b5b8ad4c30554e05a809c833ffaa31dc7b4ad6ae4bcf4d7b896542b
+attr run-id local:f660304b057bec44ce31a7602673bc1e9cd9e6b9
 attr outcome pass
 
 node RESULT-PFD verification-result
 title PFD attitude panel suite — recorded pass
 attr command cargo test -p indicate-instrument-panels
-attr config-digest 08a31a9c1287c549cefb961604ea80ed4428ed33
+attr config-digest f660304b057bec44ce31a7602673bc1e9cd9e6b9
 attr tool-version rustc 1.95.0 (59807616e 2026-04-14)
 attr source-digest git-blob:015edf11e26fa840cb410c086262cf4ed2621413
 attr artifact docs/instruments/evidence-artifacts/att01/panel.run.txt
-attr output-digest sha256:4842363fc3a7e4d9763f1bc3ef66f6d854d89f0d3b5b482060e8a4d5184704e1
-attr run-id local:08a31a9c1287c549cefb961604ea80ed4428ed33
+attr output-digest sha256:f478281129119a05c81bed83daea28ed711cf0c3d5d98fb9246e6df267393c38
+attr run-id local:f660304b057bec44ce31a7602673bc1e9cd9e6b9
 attr outcome pass
 
 # --- Configuration and tool identity ---
@@ -192,8 +192,8 @@ attr outcome pass
 node CFG-WORKTREE configuration-item
 title engineering worktree baseline — the git working tree the recorded results were produced against (not certified SCM)
 attr scm git-worktree
-attr commit 08a31a9c1287c549cefb961604ea80ed4428ed33
-attr tree 8aa549bea28951079e32bff42f6402186134b20b
+attr commit f660304b057bec44ce31a7602673bc1e9cd9e6b9
+attr tree 8cf0d6158f55c1a39e5ae59350046a0655c3e171
 
 node TOOL-CARGO-TEST tool
 title cargo test on Rust stable — not DO-330 tool-qualified


### PR DESCRIPTION
Follow-up to #20, which its description and merge comment flagged as required. Same lifecycle as #17 after #16, and `baf56e2` before that.

Squash-merging #20 rewrote the lane commit that `CFG-WORKTREE` and all three `RESULT-*` nodes named, orphaning the baseline. **Main is red** on both HARD evidence steps until this lands — the condition the `baseline-unreachable` negative fixture exists to enforce.

**What moves:** `CFG-WORKTREE`'s commit and tree, every result's `config-digest` / `run-id`, and the resulting `output-digest`s. The evidence crate's two positive fixtures carry the same anchor.

**What does not:** the `source-digest` values. The squash preserved the bound test sources byte-for-byte, so nothing was re-run and nothing claims to have been — only the baseline identity moved, which is exactly what the squash changed.

Both HARD gates `verdict: VALID`; evidence crate tests and check-structure green.