### PR TITLE
A panel-authoring contract, and a template set that proves it (#7)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -96,7 +96,8 @@ jobs:
           known="indicate-frames indicate-alerts indicate-sha256 \
                  indicate-instrument-scene indicate-instrument-state \
                  indicate-instrument-glyphs indicate-instrument-symbology \
-                 indicate-instrument-panels indicate-instrument-raster \
+                 indicate-instrument-panels indicate-instrument-template \
+                 indicate-instrument-raster \
                  indicate-instrument-conformance indicate-instrument-feeder \
                  indicate-instrument-descriptor indicate-instrument-registry \
                  indicate-evidence instrument-bench"
@@ -150,6 +151,7 @@ jobs:
           -p indicate-instrument-symbology
           -p indicate-instrument-descriptor
           -p indicate-instrument-panels
+          -p indicate-instrument-template
           -p indicate-instrument-raster
           -p indicate-instrument-feeder
           -p indicate-instrument-registry

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -259,6 +259,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "indicate-instrument-template"
+version = "0.1.0"
+dependencies = [
+ "indicate-alerts",
+ "indicate-instrument-conformance",
+ "indicate-instrument-descriptor",
+ "indicate-instrument-registry",
+ "indicate-instrument-scene",
+ "indicate-instrument-state",
+ "indicate-instrument-symbology",
+]
+
+[[package]]
 name = "indicate-sha256"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ members = [
     "crates/indicate-instrument-symbology",
     "crates/indicate-instrument-descriptor",
     "sets/indicate-instrument-panels",
+    "sets/indicate-instrument-template",
     "crates/indicate-instrument-raster",
     "crates/indicate-instrument-conformance",
     "crates/indicate-instrument-feeder",
@@ -38,6 +39,7 @@ indicate-instrument-glyphs = { path = "crates/indicate-instrument-glyphs" }
 indicate-instrument-symbology = { path = "crates/indicate-instrument-symbology" }
 indicate-instrument-descriptor = { path = "crates/indicate-instrument-descriptor" }
 indicate-instrument-panels = { path = "sets/indicate-instrument-panels" }
+indicate-instrument-template = { path = "sets/indicate-instrument-template" }
 indicate-instrument-raster = { path = "crates/indicate-instrument-raster" }
 indicate-instrument-conformance = { path = "crates/indicate-instrument-conformance" }
 indicate-instrument-feeder = { path = "crates/indicate-instrument-feeder" }

--- a/README.md
+++ b/README.md
@@ -35,8 +35,10 @@ repository by git rev and integrate through three published surfaces:
 
 CI enforces the direction: a step fails if the closure ever reaches a
 consumer crate. See [`crates/README.md`](crates/README.md) for the crate
-map and [`docs/instruments/backend-contract.md`](docs/instruments/backend-contract.md)
-for the contract every backend author must read.
+map, [`docs/instruments/backend-contract.md`](docs/instruments/backend-contract.md)
+for the contract every backend author must read, and
+[`docs/instruments/panel-contract.md`](docs/instruments/panel-contract.md)
+for its mirror: what a panel author must deliver.
 
 ## Pinning and advancing
 

--- a/crates/README.md
+++ b/crates/README.md
@@ -87,9 +87,14 @@ that judges it. The registry is allowed as a **dev**-dependency: that
 lets a set pin its own scene digest without standing up a shell, and a
 test-graph edge is not a shipping one.
 
+Writing one: `../docs/instruments/panel-contract.md` is what a set must
+honour, and `indicate-instrument-template` is the smallest panel that
+passes admission — copy it rather than starting from a shipped panel.
+
 | Crate | Role |
 |---|---|
 | `indicate-instrument-panels` | The shipped panels (PFD, HSI, monitor): immediate-mode scene emission per frame. |
+| `indicate-instrument-template` | The smallest set that passes admission, written to be read and copied; its own test admits it, so the worked example cannot drift from the contract. |
 
 ### Tools — `tools/`
 

--- a/docs/instruments/panel-contract.md
+++ b/docs/instruments/panel-contract.md
@@ -12,8 +12,10 @@ blurs "checked" into "expected" teaches authors to trust the wrong
 things.
 
 The worked example is a real crate: `sets/indicate-instrument-template`
-is the smallest panel that passes admission, it is admitted by its own
-test in CI, and its comments explain each field where it stands. Read it
+is the smallest panel that exercises the honesty rules below — a panel
+claiming nothing passes admission more easily and teaches less — it is
+admitted by its own test in CI, and its comments explain each field
+where it stands. Read it
 alongside this document; if the two ever disagree, the crate is right,
 because the crate is the one that has to compile.
 
@@ -21,11 +23,17 @@ because the crate is the one that has to compile.
 
 Under `sets/`, one crate per set, exporting one `PanelSet`. A set's
 normal dependencies are kernel-only — `crates/README.md` states the tier
-law and `check-structure.sh` enforces it, so a set cannot depend on the
-registry, the rasterizer, or the conformance harness that judges it. The
-registry is permitted as a **dev**-dependency, which is what lets a set
-pin its own scene digest and run its own admission test without standing
-up a shell.
+law and `check-structure.sh` enforces it, so a set cannot *ship* against
+the registry, the rasterizer, or the conformance harness that judges it.
+The whole verification tier is permitted as **dev**-dependencies, and a
+set needs two of them: the registry to compose itself and pin its own
+scene digest, and the conformance harness to run its own admission test.
+Neither reaches the shipped artifact.
+
+A set is `no_std`. CI compiles every set for `thumbv7em-none-eabihf` in
+the closure check, so reaching for `std` outside `#[cfg(test)]` breaks
+the build; the template shows the `#[cfg(test)] extern crate std` idiom
+that keeps tests comfortable without loosening the crate.
 
 A set can therefore live outside this repository entirely. Nothing in
 the mechanism requires a panel to be written here.
@@ -104,11 +112,12 @@ Two corollaries fall out of the same machinery:
 
 `Opaque` and `Cedeable` both promise a full-frame opaque cover, and
 admission proves it against the ink rather than taking the word: it
-looks for one axis-aligned, unclipped, full-alpha rect fill covering the
-whole design frame in the `Background` band. A ground assembled from
-polygons, painted at alpha below full, drawn under a rotated transform,
-or under a clip that does not contain the frame **does not count**, and
-fails as `BackgroundContract`. Coverage is exact, not conservative.
+looks for one axis-aligned, full-alpha rect fill covering the whole
+design frame in the `Background` band. A ground assembled from polygons,
+painted at alpha below full, drawn under a rotated transform, or under a
+clip that does not contain the frame **does not count**, and fails as
+`BackgroundContract`. A clip that does contain the frame is fine.
+Coverage is exact, not conservative.
 
 A panel that paints nothing in the background band declares `NotUsed`
 and composes as an overlay.
@@ -146,16 +155,28 @@ then once per withheld group — the harness checks that the draw returns,
 that the scene decodes and satisfies the layer envelope, that every
 required layer is present, that the background claim holds, that every
 glyph is in the controlled vocabulary, and that the provenance rules
-above hold. Ink outside the design frame is **counted and ratcheted, not
-refused**: warnings are allowed to exist but never to grow.
+above hold. Ink outside the design frame is **counted, not refused** —
+and the ratchet that keeps the count from growing is an assertion *you*
+write in your own admission test, not something the harness does for
+you. A new set has no ratchet until its author pins one.
 
-Two limits worth knowing, because they bound what a green run means:
+Three limits worth knowing, because they bound what a green run means:
 
-- The harness tests *withholding*, not resolved status. Nothing forces
-  the "source unusable, draw dashes" branch, so your dash-out path is
-  contract-required and harness-invisible. Test it yourself.
-- Admission draws the empty config, so no configured behaviour is
-  covered by it at all.
+- **A green run does not mean your failure cues are painted.** The
+  canonical corpus does drive the degraded branches — `nothing-fed` and
+  `source-unusable` are two of the four states every panel meets, so
+  your dash-out path really is drawn and its output really is policed
+  for untagged numerals, glyphs, layers, and background. What no check
+  asserts is that anything appears there at all: delete the contents of
+  your dash branch and admission still passes. Drawing nothing where a
+  dash belongs is admissible, and it is a defect.
+- **The provenance check fires against withholding, not against
+  resolved status.** A stale value painted with its group's claim in
+  `source-unusable`, with nothing withheld, is not what
+  `FabricatedNumeral` looks for. Cover that with your own tests.
+- **Admission draws the empty config and no alerts.** No configured
+  behaviour is covered by it at all, and neither is any alert-driven
+  drawing — the digest passes no alerts either.
 
 ## Symbology you may not invent
 
@@ -167,8 +188,12 @@ the point is that a future theme cannot make them skinnable.
 reaches for the palette aliases; use the `safety::` constants.
 
 Text is equally constrained: the glyph pack is a controlled vocabulary,
-and a character outside it fails admission rather than falling back to a
-substitute.
+and a character outside it fails admission as `GlyphCoverage` rather
+than falling back to a substitute. It is `PANEL_VOCABULARY` in
+`indicate-instrument-glyphs`, and it is smaller than it looks — space,
+`-`, `.`, `°`, the digits, the uppercase letters, and of the lowercase
+only `k` and `t`. A label reading `kts`, `fpm`, `%`, or `/` fails; check
+the vocabulary before inventing one.
 
 ## Digests, baselines, and who re-pins them
 
@@ -204,6 +229,22 @@ composition layer, not for a transform — the answer is a finer-grained
 panel placed at its own frame, not a scaled replay of a coarser one.
 Sub-instrument reuse is therefore a decision about which panels a set
 exports, never a change to the opcode vocabulary.
+
+## Wiring a set into this repository
+
+A set written here needs four registrations, each of which is a CI
+failure if missed — which is the discovery-by-red-build this contract
+exists to replace:
+
+- `members` and `[workspace.dependencies]` in the root `Cargo.toml`;
+- a row in `crates/README.md` under the Sets tier, which
+  `check-structure.sh` requires for every crate;
+- the `-p` list of the `thumbv7em-none-eabihf` closure step in CI;
+- the `known` allowlist of the downstream-agnostic step in CI.
+
+A set published elsewhere needs none of them, and rewrites the
+`workspace = true` inheritance the template uses for its edition,
+dependencies, and lints.
 
 ## The worked example
 

--- a/docs/instruments/panel-contract.md
+++ b/docs/instruments/panel-contract.md
@@ -1,0 +1,213 @@
+# Panel contract
+
+What every panel author must honour. `backend-contract.md` is the other
+side of the same boundary: it tells an author interpreting the scene
+stream what they may assume. This tells an author *producing* one what
+they must deliver.
+
+Everything here is enforced by the admission harness or by
+`Registry::new`/`Registry::from_sets`, except where it says otherwise —
+and where it says otherwise, it says so plainly, because a contract that
+blurs "checked" into "expected" teaches authors to trust the wrong
+things.
+
+The worked example is a real crate: `sets/indicate-instrument-template`
+is the smallest panel that passes admission, it is admitted by its own
+test in CI, and its comments explain each field where it stands. Read it
+alongside this document; if the two ever disagree, the crate is right,
+because the crate is the one that has to compile.
+
+## Where a panel lives
+
+Under `sets/`, one crate per set, exporting one `PanelSet`. A set's
+normal dependencies are kernel-only — `crates/README.md` states the tier
+law and `check-structure.sh` enforces it, so a set cannot depend on the
+registry, the rasterizer, or the conformance harness that judges it. The
+registry is permitted as a **dev**-dependency, which is what lets a set
+pin its own scene digest and run its own admission test without standing
+up a shell.
+
+A set can therefore live outside this repository entirely. Nothing in
+the mechanism requires a panel to be written here.
+
+## The descriptor, field by field
+
+A `PanelDescriptor` is the whole of what a shell knows about a panel.
+Three tiers of obligation, and the difference matters:
+
+| Field | Obligation |
+|---|---|
+| `required_layers` | **Load-bearing.** Admission asserts every declared band is present in every case. |
+| `required_groups` | **Load-bearing.** This *is* the withholding matrix: admission withholds each declared group in turn. |
+| `design_frame` | **Load-bearing.** Every geometry check is expressed in its units. |
+| `background` | **Load-bearing.** An `Opaque` or `Cedeable` claim is proven against the emitted ink. |
+| `draw` | **Load-bearing.** Refusing to draw any case fails admission. |
+| `extreme_states` | **Load-bearing.** Each one multiplies the case matrix. |
+| `id`, `title` | Validated at registry init: charset, non-empty. |
+| `config_schema` | Validated at init (keys strictly ascending). Admission always draws the empty config. |
+| `group_regions` | **Declared, not currently read by admission.** See below. |
+| `raster_baseline` | Inert unless the panel is in a set the raster tests cover. |
+
+### `required_layers` — declare what you always emit
+
+A panel requires a band when it *opens* that band on every frame, not
+when the band always carries content. The PFD requires `Guidance` and
+opens it unconditionally; the flight-director bars inside it disappear
+under degradation and declutter, and the empty band is still a complete
+frame. `scene-layer-protocol.md` carries the shipped table, checked
+against these masks.
+
+Declaring a band you emit only sometimes is the most common way to fail
+admission: the harness draws states you did not have in mind, and
+`MissingRequiredLayers` names the case.
+
+Do not declare `Background`. It is the one band a compositor may drop,
+so requiring it would forbid the composition it exists for — paint it if
+you want it, and let the mask stay quiet about it.
+
+### `required_groups` — declare what you consume, honestly
+
+Admission runs your panel once fully fed and then once per declared
+group with that group withheld. Declaring a group you do not use costs
+cases and proves nothing. Declaring fewer than you use is worse: the
+group you left out is never withheld, so the one case that would have
+caught a fabricated value never runs.
+
+Follow the data, not the drawing. If a readout folds a second group into
+its resolved status — the template's airspeed folds `Trust`, so
+withholding `Trust` genuinely dashes the number — that group belongs in
+the mask.
+
+### The honesty rules, and their asymmetry
+
+This is the part of the contract that is easiest to get exactly
+backwards, so it is stated twice.
+
+- **A numeral must carry a claim.** Any digits you paint must go through
+  `text_attributed` with the group the number came from. An unclaimed
+  numeral fails as `UntaggedNumeral` — even when it is clipped out of
+  sight, because the check is over emitted runs, not visible pixels.
+- **A dash must not.** The `---` you paint *instead of* a value is not a
+  value, and tagging it claims a group that was withheld. It fails as
+  `FabricatedNumeral` in precisely the case the dashes exist to serve.
+  Paint them with plain `text`.
+
+Two corollaries fall out of the same machinery:
+
+- A claim naming a group outside `required_groups` fails as
+  `ForeignClaim`. The mask is the vocabulary of claims you may make.
+- A numeral derived from configuration is unadmittable by construction.
+  Admission draws the empty config deliberately, so a visible
+  config-sourced claim fails as `ConfigClaim`. Values come from state.
+
+### `background` — an `Opaque` claim is checked exactly
+
+`Opaque` and `Cedeable` both promise a full-frame opaque cover, and
+admission proves it against the ink rather than taking the word: it
+looks for one axis-aligned, unclipped, full-alpha rect fill covering the
+whole design frame in the `Background` band. A ground assembled from
+polygons, painted at alpha below full, drawn under a rotated transform,
+or under a clip that does not contain the frame **does not count**, and
+fails as `BackgroundContract`. Coverage is exact, not conservative.
+
+A panel that paints nothing in the background band declares `NotUsed`
+and composes as an overlay.
+
+### `group_regions` — declared, and not yet load-bearing
+
+Regions say which surface of the panel a group's readout owns. They are
+validated for geometry at registry init — inside the frame, non-
+degenerate, only for groups the panel requires — and **admission does
+not currently read them**. The conformance crate says so in its own
+module documentation, and this contract will not paper over it.
+
+What actually keeps a panel honest today is the provenance machinery
+above, which tests every claimed run wherever the ink lands. Declare
+regions accurately anyway: they are a shell's statement of readout
+ownership, and giving them teeth is the first phase of the screen
+composition work. A region drawn wrong will become a failure the day it
+is checked, and the person who has to fix it is the one who drew it.
+
+Draw the boundary around the value's own ink and nothing else. Scale
+ladders, tick labels, and neighbouring boxes belong to other groups or
+to no group; a region generous enough to swallow them is the vacuous
+case the mechanism exists to prevent.
+
+## What the admission harness actually asserts
+
+Run it before opening a pull request, not after CI tells you:
+
+```
+cargo test -p <your set crate>
+```
+
+Per case — canonical states plus your extreme states, each fully fed and
+then once per withheld group — the harness checks that the draw returns,
+that the scene decodes and satisfies the layer envelope, that every
+required layer is present, that the background claim holds, that every
+glyph is in the controlled vocabulary, and that the provenance rules
+above hold. Ink outside the design frame is **counted and ratcheted, not
+refused**: warnings are allowed to exist but never to grow.
+
+Two limits worth knowing, because they bound what a green run means:
+
+- The harness tests *withholding*, not resolved status. Nothing forces
+  the "source unusable, draw dashes" branch, so your dash-out path is
+  contract-required and harness-invisible. Test it yourself.
+- Admission draws the empty config, so no configured behaviour is
+  covered by it at all.
+
+## Symbology you may not invent
+
+`indicate-instrument-symbology` owns the never-skinnable safety
+constants. A panel that paints its own failure red, caution amber, or
+reference yellow is a defect even if it looks identical today, because
+the point is that a future theme cannot make them skinnable.
+`check-structure.sh` fails a file outside the symbology crate that
+reaches for the palette aliases; use the `safety::` constants.
+
+Text is equally constrained: the glyph pack is a controlled vocabulary,
+and a character outside it fails admission rather than falling back to a
+substitute.
+
+## Digests, baselines, and who re-pins them
+
+- **The composition digest** covers the panels a registry composes, in
+  order, with their contract-relevant descriptor fields and their
+  emitted bytes. Adding a panel to a shipped set moves it. Set identity
+  is deliberately *not* in the digest, so publishing a new set does not
+  disturb a shell that does not compose it.
+- **Who re-pins:** the author of the change that moves it, in the same
+  change, with the reason in the commit message. Consumers advance their
+  pins on the discipline in `README.md`. A digest that moves without a
+  stated reason is indistinguishable from a regression.
+- **Raster baselines** are per-panel pinned frame hashes over the shared
+  typical state, asserted by the reference rasterizer (REN-03). A
+  mismatch means the paint changed. It is a regression unless the change
+  deliberately moved paint, in which case it re-pins once, for a stated
+  reason — never refreshed to make a red build green.
+- A new set outside `BUILTIN_PANELS` may leave `raster_baseline` at
+  `None` until it has rasterizer coverage; nothing asserts a baseline
+  that was never declared.
+
+Contract values that a consumer pins — the state ABI, the scene format,
+the corpus, the composition digest, the shipped panel set — are named
+per release in `CHANGELOG.md`, and cutting that release is a step in
+`CONTRIBUTING.md`.
+
+## Where the vocabulary stops
+
+There is no `SCALE` opcode, and that is deliberate rather than missing:
+panels compose, instruments inside them do not. An author who wants an
+instrument at two-thirds size beside another is reaching for the
+composition layer, not for a transform — the answer is a finer-grained
+panel placed at its own frame, not a scaled replay of a coarser one.
+Sub-instrument reuse is therefore a decision about which panels a set
+exports, never a change to the opcode vocabulary.
+
+## The worked example
+
+`sets/indicate-instrument-template`. One panel, one band of content, a
+readout that dashes honestly, and an admission test that fails the build
+if any of the above stops being true. Copy it, rename it, and grow it —
+it is the shortest path from nothing to a set that passes.

--- a/sets/indicate-instrument-template/Cargo.toml
+++ b/sets/indicate-instrument-template/Cargo.toml
@@ -1,0 +1,25 @@
+[package]
+name = "indicate-instrument-template"
+description = "The smallest panel set that passes admission: the worked example a new set crate is copied from (ADR-0029, ADR-0033)"
+version = "0.1.0"
+edition.workspace = true
+publish = false
+
+[lints]
+workspace = true
+
+# Kernel only. A set may not reach the machinery that judges it, and
+# scripts/check-structure.sh fails the build on a manifest that tries.
+[dependencies]
+indicate-alerts = { workspace = true }
+indicate-instrument-descriptor = { workspace = true }
+indicate-instrument-scene = { workspace = true }
+indicate-instrument-state = { workspace = true }
+indicate-instrument-symbology = { workspace = true }
+
+# The verification tier is reachable as a DEV dependency: running the
+# admission harness over this set is a test-graph edge, not a shipping
+# one, and it is what makes "admitted in CI" a build result.
+[dev-dependencies]
+indicate-instrument-conformance = { workspace = true }
+indicate-instrument-registry = { workspace = true }

--- a/sets/indicate-instrument-template/src/lib.rs
+++ b/sets/indicate-instrument-template/src/lib.rs
@@ -1,0 +1,39 @@
+//! The smallest panel set that passes admission, written to be read.
+//!
+//! A panel is a plugin over three stable contracts — the state-group
+//! vocabulary, the scene-command IR, and the glyph vocabulary — and a
+//! set is the unit a shell names when it composes panels. This crate is
+//! one of each: a single [`TEMPLATE_DESCRIPTOR`] inside a single
+//! [`TEMPLATE_SET`], drawing one label and one readout.
+//!
+//! It exists to be copied, so the comments say why each value is what it
+//! is rather than what it contains. Four properties are what a copy has
+//! to keep:
+//!
+//! - **The layer envelope.** Every band is opened, saved, drawn,
+//!   restored and closed, in strictly ascending order and never nested.
+//!   `SceneWriter::begin_layer`/`end_layer` emit the mandatory
+//!   save/restore, so using them is the whole obligation.
+//! - **Honest status.** A run showing a number claims the state group
+//!   the number came from; a run showing dashes claims nothing. Getting
+//!   this backwards is the failure a first set hits.
+//! - **A background declaration the scene keeps.** Declaring
+//!   [`BackgroundCapability::Opaque`](indicate_instrument_descriptor::BackgroundCapability)
+//!   obliges the panel to cover the frame in the `Background` band, in
+//!   every corpus case.
+//! - **Kernel-only dependencies.** A set draws against the kernel and
+//!   never against the tier that judges it.
+//!
+//! The crate's own test composes this set into a registry and runs the
+//! `indicate-instrument-conformance` admission harness over it, so "the
+//! template is admissible" is something the build establishes rather
+//! than something this comment asserts.
+
+#![no_std]
+
+#[cfg(test)]
+extern crate std;
+
+mod template;
+
+pub use template::{TEMPLATE_DESCRIPTOR, TEMPLATE_SET};

--- a/sets/indicate-instrument-template/src/template.rs
+++ b/sets/indicate-instrument-template/src/template.rs
@@ -1,0 +1,208 @@
+//! The template panel: one label, one readout, one honest dash-out.
+//!
+//! The panel shows indicated airspeed. That choice is doing work: a
+//! number a shell could fabricate is exactly what the admission harness
+//! polices, so the smallest interesting panel is one that paints a
+//! numeral it must justify.
+
+use indicate_alerts::AlertOutput;
+use indicate_instrument_descriptor::{
+    BackgroundCapability, ConfigBlob, DesignFrame, GroupSet, PanelDescriptor, PanelDrawError,
+    PanelSet, Region,
+};
+use indicate_instrument_scene::{Anchor, LayerId, PaintMode, SceneWriter};
+use indicate_instrument_state::{GroupId, PanelData};
+use indicate_instrument_symbology::{fmt_label, palette, safety};
+
+/// Design-frame width. A panel's logical space is its own declaration,
+/// not a house size: backends scale it to whatever viewport they own.
+const FRAME_W: f32 = 240.0;
+
+/// Design-frame height.
+const FRAME_H: f32 = 120.0;
+
+const LABEL_X: f32 = 16.0;
+const LABEL_Y: f32 = 34.0;
+const LABEL_SIZE: f32 = 16.0;
+
+/// The readout is right-anchored, so a value that grows wider grows
+/// leftward into empty frame instead of off the right edge.
+const VALUE_RIGHT_X: f32 = 224.0;
+const VALUE_Y: f32 = 78.0;
+
+/// Sized against the value buffer, not against the corpus: the widest
+/// label the buffer can hold — a full eight characters, measured by
+/// `indicate_instrument_scene::nominal_text_ink_width` — still starts
+/// inside the frame from `VALUE_RIGHT_X`. Fitting only the values the
+/// fixtures happen to produce is what leaves a panel with counted
+/// frame-overflow warnings the day a wider one arrives; the crate's
+/// admission test holds that count at zero.
+const VALUE_SIZE: f32 = 24.0;
+
+/// A required-layer mask is a bitset over [`LayerId`] wire values.
+const fn layer_bit(layer: LayerId) -> u8 {
+    1u8 << layer.to_u8()
+}
+
+/// Draws the template panel from resolved state.
+///
+/// Two bands, in ascending order: `Background` carries the opaque ground
+/// the descriptor promises, `Tapes` the label and the readout. Each
+/// `begin_layer`/`end_layer` pair emits the mandatory state-isolation
+/// save and restore, which is the layer envelope admission checks.
+fn draw_template_panel(
+    data: &PanelData,
+    config: &ConfigBlob<'_>,
+    _alerts: Option<&AlertOutput>,
+    scene: &mut SceneWriter<'_>,
+) -> Result<(), PanelDrawError> {
+    // The empty schema already makes any keyed blob a shell-side
+    // rejection; re-checking here keeps the property when a shell skips
+    // its gate.
+    config.require_schema(TEMPLATE_DESCRIPTOR.config_schema)?;
+
+    // `Opaque` is a promise to a compositor, and this is how it is kept:
+    // one axis-aligned, unclipped, full-alpha rect over the whole frame.
+    // A ground assembled from polygons, or drawn under a clip, does not
+    // satisfy the check however opaque it looks.
+    scene.begin_layer(LayerId::Background)?;
+    scene.fill_color(palette::BLACK)?;
+    scene.rect(PaintMode::Fill, 0.0, 0.0, FRAME_W, FRAME_H)?;
+    scene.end_layer(LayerId::Background)?;
+
+    scene.begin_layer(LayerId::Tapes)?;
+    scene.fill_color(palette::GREY)?;
+    // Fixed furniture: a run with no digits needs no provenance claim,
+    // because there is no value in it to fabricate.
+    scene.text(LABEL_X, LABEL_Y, LABEL_SIZE, Anchor::MIDDLE_LEFT, "IAS")?;
+    draw_airspeed(data, scene)?;
+    scene.end_layer(LayerId::Tapes)?;
+    Ok(())
+}
+
+/// The readout, and the whole honest-status rule in one branch.
+fn draw_airspeed(data: &PanelData, scene: &mut SceneWriter<'_>) -> Result<(), PanelDrawError> {
+    let ias = data.ias_kt;
+    if ias.status.shows_value() {
+        scene.fill_color(palette::WHITE)?;
+        // Every run carrying a digit goes through `text_attributed`: the
+        // claim names the state group the number derives from, and the
+        // withholding matrix tests it. An unclaimed numeral is refused
+        // outright — omitting the tag is not an escape, it is the
+        // failure.
+        let value = fmt_label!(8, "{:.0}kt", ias.value);
+        scene.text_attributed(
+            GroupId::Air.to_u8(),
+            VALUE_RIGHT_X,
+            VALUE_Y,
+            VALUE_SIZE,
+            Anchor::MIDDLE_RIGHT,
+            value.as_str(),
+        )?;
+    } else {
+        // Unclaimed on purpose. A claim is tested against withholding
+        // wherever its run is drawn, so dashes tagged `Air` would be
+        // refused in the very case they exist for: the panel would be
+        // claiming to show air data while showing that it has none.
+        // Dashes are a failure cue, not blank space, so they paint in
+        // the never-skinnable failure red.
+        scene.fill_color(safety::FAILURE_RED)?;
+        scene.text(
+            VALUE_RIGHT_X,
+            VALUE_Y,
+            VALUE_SIZE,
+            Anchor::MIDDLE_RIGHT,
+            "---",
+        )?;
+    }
+    Ok(())
+}
+
+/// The template panel, as data.
+///
+/// Every field below is a statement a shell, a compositor, or the
+/// admission harness acts on. Filling one in wrongly is not a style
+/// defect; it is a claim the panel then has to keep.
+pub const TEMPLATE_DESCRIPTOR: PanelDescriptor = PanelDescriptor {
+    // Lowercase, digits and dashes only — the registry refuses anything
+    // else at init. Canvas ids, health keys and evidence records key off
+    // this string, so it outlives whatever the constant is called.
+    id: "template",
+    // Operator-facing, and non-empty: a registry refuses a panel that
+    // cannot label a health or layout surface.
+    title: "Template",
+    // The bands that must be present and complete in every frame,
+    // however degraded the state. The readout lives in `Tapes`, so
+    // `Tapes` is required and nothing else is. `Background` is
+    // deliberately absent even though this panel always paints it: it is
+    // the one band a compositor may replace or drop, and requiring it
+    // would promise something the contract lets a shell take away.
+    required_layers: layer_bit(LayerId::Tapes),
+    // The withholding matrix. Admission redraws the panel once per group
+    // named here with that group withheld, and refuses any visible run
+    // still claiming it. Declare the groups the readout DERIVES from:
+    // `Air` carries the airspeed, and `Trust` decides whether it may be
+    // shown at all — with trust withheld the source has declared
+    // nothing, so the value dashes out even though the air data is still
+    // there. A group a panel merely reads past belongs nowhere here.
+    required_groups: GroupSet::of(&[GroupId::Air, GroupId::Trust]),
+    // The logical space this panel draws against. It need not match any
+    // other panel's; the registry asks only that it be finite and
+    // positive, and every geometry check downstream is expressed in it.
+    design_frame: DesignFrame {
+        width: FRAME_W,
+        height: FRAME_H,
+    },
+    // A compositor plans around this declaration, so admission refuses
+    // both directions: painting a band declared `NotUsed`, and failing
+    // to cover a band declared owned. `Opaque` is the honest answer for
+    // a panel whose text needs a ground of its own.
+    background: BackgroundCapability::Opaque,
+    // No configuration. An empty schema makes any keyed blob a
+    // shell-side rejection; a panel with real keys lists them in
+    // strictly ascending order, and decodes them in `draw`.
+    config_schema: &[],
+    // Where a consumed group paints its readout, in design-frame units.
+    // The admission harness does not read this — honest status is proven
+    // by the provenance claims on the runs, wherever the ink lands — but
+    // the registry validates the geometry at init, and a shell that
+    // presents readout ownership or a dash-out declaration reads it.
+    // `Trust` gets no region: it qualifies a readout rather than owning
+    // one, and the map is allowed to be partial.
+    group_regions: &[(
+        GroupId::Air,
+        Region {
+            x: 60.0,
+            y: 64.0,
+            width: 168.0,
+            height: 28.0,
+        },
+    )],
+    // Stress fixtures beyond the four shared canonical states, which
+    // every panel meets regardless. A panel whose geometry can leave the
+    // frame, or whose readouts have a widest case no shared fixture
+    // reaches, contributes its own here. This one has nothing to add.
+    extreme_states: &[],
+    // The pinned reference-rasterizer hash of this panel's typical
+    // frame, once a baseline travels with the descriptor. `None` is the
+    // honest value until then, not a placeholder to fill with anything.
+    raster_baseline: None,
+    // The entry point: pure resolved state to scene. A panel never
+    // reaches for a clock, a source, or a shell — everything it may draw
+    // from arrives in the arguments.
+    draw: draw_template_panel,
+};
+
+/// The set a shell names to compose this panel.
+///
+/// A provider crate exports one set rather than loose descriptors, so
+/// gaining a panel is a change here instead of one line in every shell.
+/// Set identity stays out of the scene digest: regrouping the same
+/// panels without reordering them leaves cross-shell identity untouched.
+pub const TEMPLATE_SET: PanelSet = PanelSet {
+    id: "template",
+    panels: &[TEMPLATE_DESCRIPTOR],
+};
+
+#[cfg(test)]
+mod tests;

--- a/sets/indicate-instrument-template/src/template.rs
+++ b/sets/indicate-instrument-template/src/template.rs
@@ -62,9 +62,10 @@ fn draw_template_panel(
     config.require_schema(TEMPLATE_DESCRIPTOR.config_schema)?;
 
     // `Opaque` is a promise to a compositor, and this is how it is kept:
-    // one axis-aligned, unclipped, full-alpha rect over the whole frame.
-    // A ground assembled from polygons, or drawn under a clip, does not
-    // satisfy the check however opaque it looks.
+    // one axis-aligned, full-alpha rect over the whole frame. A ground
+    // assembled from polygons, painted below full alpha, or drawn under
+    // a rotated transform does not satisfy the check however opaque it
+    // looks. A clip is fine only if it contains the frame.
     scene.begin_layer(LayerId::Background)?;
     scene.fill_color(palette::BLACK)?;
     scene.rect(PaintMode::Fill, 0.0, 0.0, FRAME_W, FRAME_H)?;

--- a/sets/indicate-instrument-template/src/template/tests.rs
+++ b/sets/indicate-instrument-template/src/template/tests.rs
@@ -1,0 +1,25 @@
+#![allow(clippy::expect_used, clippy::panic)]
+
+use indicate_instrument_conformance::admit;
+use indicate_instrument_registry::{PanelSet, Registry};
+
+use super::TEMPLATE_SET;
+
+/// The claim this crate makes about itself, as a build result rather
+/// than a comment: the template is judged by the same harness every
+/// other set is, over the shared canonical corpus and its own
+/// withholding matrix.
+#[test]
+fn the_template_set_passes_admission() {
+    static SETS: [&PanelSet; 1] = [&TEMPLATE_SET];
+    let registry = Registry::from_sets(&SETS).expect("the template set composes");
+    let report = admit(&registry).expect("the template must be admissible");
+    // Four canonical states x (one fed case + one per required group
+    // withheld); the panel contributes no extreme states of its own.
+    assert_eq!(report.cases, 12);
+    // A set copied from this template starts with nothing tolerated:
+    // every run's nominal ink sits inside the design frame, so no
+    // frame-overflow observation is counted. Keeping the line at zero is
+    // what makes a new warning a decision instead of a drift.
+    assert!(report.warnings.is_empty(), "{:?}", report.warnings);
+}


### PR DESCRIPTION
Fixes #7.

## What lands

`docs/instruments/panel-contract.md` — the mirror of `backend-contract.md` — plus `sets/indicate-instrument-template`, a real crate that is the smallest panel passing admission and **asserts so in its own test**, so the worked example cannot drift from the contract the way a doc snippet would. That is the form #13 argued for: one source of truth instead of a doc listing and a skeleton diverging.

## The part imitation cannot teach

The document's job is the distinction the code cannot show you: **which descriptor fields admission actually enforces**, versus which are validated at registry init, versus which are declared and read by nothing.

`group_regions` is the honest case. It is geometry-validated at init and **admission does not read it** — the conformance crate says so in its own module doc. The contract says so too, rather than implying a check that does not run, and explains what *does* keep a panel honest today (the provenance machinery) and why regions should still be drawn tightly.

The rule easiest to get exactly backwards is stated twice: **a numeral must carry a claim; a dash must not.** Tagging the `---` that stands in for a withheld value claims the group that was withheld, and fails as `FabricatedNumeral` in precisely the case the dashes exist to serve.

Each documented failure mode was verified by mutating the template and reading the error the harness actually produces — `FabricatedNumeral`, `UntaggedNumeral`, `BackgroundContract`, `MissingRequiredLayers`, `ForeignClaim` — not by reading the source and guessing.

## Blind spots, recorded

A contract that lets an author read a green run as more than it is has failed them. Two limits are stated:

- The harness tests **withholding**, not resolved status, so the "source unusable, draw dashes" path is contract-required and harness-invisible. Test it yourself.
- It draws the **empty config**, so no configured behaviour is covered at all — and a numeral derived from configuration is unadmittable by construction.

## The template

One panel, 240×120, its own design frame. Kernel-only normal dependencies (the tier law forbids a set from reaching the machinery that judges it); registry and conformance are dev-dependencies. It declares `required_groups = {Air, Trust}` rather than just `Air`, because its airspeed folds `trust.quality` — so withholding `Trust` genuinely dashes the number, which is the honest mirror of what the shipped panels do.

Admission over it: 4 states × (1 fed + 2 withheld) = 12 cases, zero warnings.

## Not in this PR

The `SCALE` decision is stated on the panel side here because an author reaching for an inset needs it; the backend-contract half and the `ARC` question are #10.

## Acceptance

Scene digest unchanged at `bd85b8537f0b3e4abf8cf3ad3d36c6abfdceac15355639af2804d58dd9c61931` — the template is a set of its own and does not join the shipped composition. Full battery green including the HARD evidence gates.