### PR TITLE
Record which vocabulary limits are contract and which are open (#10)

### DIFF
--- a/docs/instruments/backend-contract.md
+++ b/docs/instruments/backend-contract.md
@@ -50,9 +50,10 @@ A panel is authored in the logical frame its descriptor declares
 
 ## Where the vocabulary deliberately stops
 
-Two limits in the opcode set are contract, not oversight. A backend
-author reading the vocabulary and finding them missing should stop
-looking for the version that adds them.
+Two properties of the opcode set decide what an instrument can be. One
+is settled contract, and a backend author who finds it missing should
+stop looking for the version that adds it. The other is genuinely open,
+and is recorded here with its price rather than left to be discovered.
 
 **There is no `SCALE`, and there will not be one.** The transform ops
 are translate and rotate. A panel is authored in the frame its
@@ -69,21 +70,36 @@ vocabulary change. A compositor therefore never resizes a scene by
 rewriting its commands, and `panel-contract.md` tells authors the same
 thing from the other side.
 
-**`ARC` is stroke-only, and that one is genuinely open.** `LINE`,
-`POLYLINE`, `RECT`, `CIRCLE`, and `POLYGON` carry a paint mode; `ARC`
-does not. A thick stroked arc reproduces a coloured band, so an engine
-dial's green/yellow/red sweeps are expressible today, but the band's
-inner and outer radii end up coupled to the stroke width — the geometry
-expressed sideways. Whether that is sufficient cannot be decided without
-the instrument set that needs it, so it stays open.
+**A filled annular band has no opcode, and that one is genuinely open.**
+Paint mode splits the vocabulary by shape, not by oversight: the
+closed-area ops — `RECT`, `CIRCLE`, `POLYGON` — carry a `PaintMode`,
+while the open-path ops — `LINE`, `POLYLINE`, `ARC` — are stroke-only,
+having no interior to fill. `ARC` is not the odd one out.
+
+That consistency is what makes the question a real one. An engine dial's
+green/yellow/red sweeps are expressible today, because a thick stroked
+arc reproduces a band — but the band's inner and outer radii then come
+out of the stroke width and the radius together, which is the geometry
+expressed sideways. A band is an area between two radii, so what it
+wants is not a mode byte on `ARC` — a stroke-only op has nothing to fill
+— but its own geometry. Whether the sideways expression is sufficient
+cannot be decided without the instrument set that needs it, so it stays
+open.
 
 What it would cost, recorded now so the price is known when that day
 comes: a *new* filled annular-band opcode is **not** a scene-format
 version bump, because an unknown ordinary opcode inside a layer is
 counted and skipped, so older backends degrade gracefully. It is a
 corpus bump, an implementation in every backend, and new admission
-geometry. Changing the existing `ARC` payload, by contrast, is a hard
-break for every pinned interpreter and is off the table. The cheap path
+geometry — the background-coverage check counts only the painting
+commands it knows, so a new one is invisible to it until it is added.
+
+Changing the existing `ARC` payload, by contrast, is off the table, and
+for a worse reason than "a hard break": the decoder reads its five
+floats from fixed offsets and ignores trailing bytes, so prepending a
+mode byte would not raise an error on a pinned interpreter. It would
+silently mis-read the centre and radius from shifted bytes and paint the
+wrong arc. Opcodes are append-only. The cheap path
 exists; take it only with the set in hand.
 
 ## Two disciplines every backend must follow

--- a/docs/instruments/backend-contract.md
+++ b/docs/instruments/backend-contract.md
@@ -48,6 +48,44 @@ A panel is authored in the logical frame its descriptor declares
   drift. Fixing overflowing paint moves frame hashes and is its own
   change, at which point the ratchet steps down.
 
+## Where the vocabulary deliberately stops
+
+Two limits in the opcode set are contract, not oversight. A backend
+author reading the vocabulary and finding them missing should stop
+looking for the version that adds them.
+
+**There is no `SCALE`, and there will not be one.** The transform ops
+are translate and rotate. A panel is authored in the frame its
+descriptor declares and a backend maps that whole frame to the viewport,
+so an instrument cannot be drawn at a different size *within* a scene.
+That is the contract: panels compose, instruments inside them do not.
+
+The limitation this looks like is answered a layer up rather than by a
+transform. An instrument wanted at two-thirds size beside another is a
+finer-grained *panel*, placed at its own frame by the composition layer
+— reuse by decomposition, not by rescaling a replay. Which finer-grained
+panels exist is a decision about what a set exports, and costs no
+vocabulary change. A compositor therefore never resizes a scene by
+rewriting its commands, and `panel-contract.md` tells authors the same
+thing from the other side.
+
+**`ARC` is stroke-only, and that one is genuinely open.** `LINE`,
+`POLYLINE`, `RECT`, `CIRCLE`, and `POLYGON` carry a paint mode; `ARC`
+does not. A thick stroked arc reproduces a coloured band, so an engine
+dial's green/yellow/red sweeps are expressible today, but the band's
+inner and outer radii end up coupled to the stroke width — the geometry
+expressed sideways. Whether that is sufficient cannot be decided without
+the instrument set that needs it, so it stays open.
+
+What it would cost, recorded now so the price is known when that day
+comes: a *new* filled annular-band opcode is **not** a scene-format
+version bump, because an unknown ordinary opcode inside a layer is
+counted and skipped, so older backends degrade gracefully. It is a
+corpus bump, an implementation in every backend, and new admission
+geometry. Changing the existing `ARC` payload, by contrast, is a hard
+break for every pinned interpreter and is off the table. The cheap path
+exists; take it only with the set in hand.
+
 ## Two disciplines every backend must follow
 
 1. **Never rebuild path objects per frame.** Glyph outlines and reusable


### PR DESCRIPTION
Fixes #10. Doc-only; no display behavior changes.

The issue asks for a decision on two properties of the opcode vocabulary, recorded before a second set is authored around the wrong assumption. Both follow the resolution the issue itself argues for.

## No `SCALE` — deliberate, and now stated

"Panels compose; instruments inside them do not" is the contract. The issue's own worry — that a set meant to *rearrange* existing instruments is blocked — is answered a layer up rather than by a transform: an instrument wanted at two-thirds size beside another is a finer-grained **panel** placed at its own frame. Reuse by decomposition, not by rescaling a replay. Which finer-grained panels exist is a decision about what a set exports, and costs no vocabulary change.

So an author reaching for an inset finds the composition contract, not a missing opcode. The panel-side half of this landed with #7; this is the backend half.

## `ARC` paint mode — deliberately left open

The issue argues this cannot be decided without naming the set that needs it, and nothing here overrides that. A thick stroked arc does reproduce a coloured band, so engine dials are expressible today; the band's inner and outer radii just end up coupled to the stroke width.

What is recorded is the **price**, so it is known when the day comes:

- A *new* filled annular-band opcode is **not** a scene-format version bump. Verified: an unknown ordinary opcode decodes to `Cmd::Unknown` with its payload skipped (`decode.rs:208`), so older backends degrade gracefully. It *is* a corpus bump, an implementation in every backend, and new admission geometry.
- Changing the existing `ARC` payload is a hard break for every pinned interpreter and is off the table.

## Claims fact-checked before writing

- `Arc` carries no `mode` field while `Circle` does — confirmed in `cmd.rs:216` vs `:227`.
- Unknown ordinary opcodes are counted and skipped — confirmed in `decode.rs:208` and the module doc at `:31`.

Gates green including both HARD evidence gates.