### PR TITLE
The design frame becomes an emission input (#12)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,47 @@ from a rewritten one. Entries are newest first, and the tag's message
 repeats the same five values so `git show <tag>` answers the question
 without a checkout. `CONTRIBUTING.md` has the release steps.
 
+## [0.2.0] — 2026-08-07
+
+The design frame becomes an emission input. `DrawFn` gains a
+`DesignFrame` parameter, and `PanelDescriptor` declares the range of
+frames a shell may ask for — `frame_min`, `frame_max`, `frame_step`,
+aspect bounds, and the `canonical_frames` the evidence is pinned at —
+in place of the single `design_frame` constant. `raster_baseline`
+becomes `raster_baselines`, one per canonical frame.
+
+| Value | This release |
+|---|---|
+| State ABI | 6 |
+| Scene format | 1 |
+| Corpus | 4 |
+| Composition digest | `3efb08c55eadadc2b006ee6b006b29e4b3a3f8d4ec3ce1324f401dbc16dc85ca` |
+| Panel set | `pfd`, `hsi`, `monitor` |
+
+Panel set changed since the previous release: no.
+
+### Notes for anyone re-pinning
+
+- The composition digest **moved**, and this is the deliberate move: the
+  digest's per-panel contract block now carries the frame constraints,
+  and scenes are drawn per canonical state × canonical frame. It was
+  `bd85b853…` and is now `3efb08c5…`. No paint changed — the reference
+  rasterizer's REN-03 frame hashes are byte-identical, which is what
+  proves the move is format and not regression.
+- Every shipped panel declares a degenerate range: `frame_min` equals
+  `frame_max` equals 480×360, with one canonical frame. The only frame a
+  conforming shell may ask them for is that one, and behaviour there is
+  unchanged. What the registry refuses is a *declaration* whose bounds,
+  step, aspect, or canonical frames break its rules; deriving a frame
+  for a placement and clamping it into the declared range stays the
+  shell's job.
+- A shell calling `(panel.draw)(…)` passes the frame it chose, between
+  the alerts and the scene writer. A shell that wants exactly today's
+  behaviour asks for `frame_min` and scales, as before.
+- Out-of-repo panel sets must add the new descriptor fields; the
+  registry refuses a composition whose canonical frames do not include
+  both ends of its declared range.
+
 ## [0.1.0] — 2026-08-07
 
 First tagged revision. The contract surfaces already versioned

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -101,6 +101,7 @@ the tag is what a human owes it.
   sources by content digest and its baseline by commit: editing a
   recorded source file requires re-recording that evidence, and history
   rewrites that orphan the baseline commit are forbidden.
-- Panels are authored in the design frame their descriptor declares;
-  unclipped ink past the frame edge is counted and ratcheted by the
-  admission harness — growth is a deliberate decision, not drift.
+- Panels are authored against the frame range their descriptor declares
+  and receive the chosen frame as a draw argument; unclipped ink past
+  that frame's edge is counted and ratcheted per frame by the admission
+  harness — growth is a deliberate decision, not drift.

--- a/crates/indicate-evidence/tests/fixtures/att01-run-output-baselined.txt
+++ b/crates/indicate-evidence/tests/fixtures/att01-run-output-baselined.txt
@@ -2,9 +2,9 @@ Pilotage evidence — captured verification run (SIM / NOT FOR FLIGHT)
 scope: ATT-01
 suite: fixture band behavior
 command: cargo test -p indicate-instrument-raster
-config-digest: f660304b057bec44ce31a7602673bc1e9cd9e6b9
+config-digest: 836371a8dd7fab23231f9a17f461f562cd42433a
 tool-version: rustc 1.95.0
-run-id: local:f660304b057bec44ce31a7602673bc1e9cd9e6b9
+run-id: local:836371a8dd7fab23231f9a17f461f562cd42433a
 outcome: pass
 summary:
 test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out

--- a/crates/indicate-evidence/tests/fixtures/attitude-slice.evg
+++ b/crates/indicate-evidence/tests/fixtures/attitude-slice.evg
@@ -17,12 +17,12 @@ attr test band_matches_reference
 
 node RESULT-BAND verification-result
 attr command cargo test -p indicate-instrument-raster
-attr config-digest f660304b057bec44ce31a7602673bc1e9cd9e6b9
+attr config-digest 836371a8dd7fab23231f9a17f461f562cd42433a
 attr tool-version rustc 1.95.0
 attr source-digest git-blob:f399b5de714ad59fc3c75ba830354c8e95e958fd
 attr artifact tests/fixtures/att01-run-output-baselined.txt
-attr output-digest sha256:aaf3c06593b58ffecc8a222015c313ffcabc5de9970ca7e2c1debf6eeaa8a322
-attr run-id local:f660304b057bec44ce31a7602673bc1e9cd9e6b9
+attr output-digest sha256:e6f2deb70e5329029516be3a52a984fb1e33a17ad817fe6f418d20eb03458575
+attr run-id local:836371a8dd7fab23231f9a17f461f562cd42433a
 attr outcome pass
 node CFG-BASE configuration-item
 node TOOL-CARGO tool

--- a/crates/indicate-evidence/tests/fixtures/unresolved-review-entry.evg
+++ b/crates/indicate-evidence/tests/fixtures/unresolved-review-entry.evg
@@ -27,12 +27,12 @@ attr test band_matches_reference
 
 node RESULT-BAND verification-result
 attr command cargo test -p indicate-instrument-raster
-attr config-digest f660304b057bec44ce31a7602673bc1e9cd9e6b9
+attr config-digest 836371a8dd7fab23231f9a17f461f562cd42433a
 attr tool-version rustc 1.95.0
 attr source-digest git-blob:f399b5de714ad59fc3c75ba830354c8e95e958fd
 attr artifact tests/fixtures/att01-run-output-baselined.txt
-attr output-digest sha256:aaf3c06593b58ffecc8a222015c313ffcabc5de9970ca7e2c1debf6eeaa8a322
-attr run-id local:f660304b057bec44ce31a7602673bc1e9cd9e6b9
+attr output-digest sha256:e6f2deb70e5329029516be3a52a984fb1e33a17ad817fe6f418d20eb03458575
+attr run-id local:836371a8dd7fab23231f9a17f461f562cd42433a
 attr outcome pass
 
 node CFG-BASE configuration-item

--- a/crates/indicate-instrument-conformance/src/admission.rs
+++ b/crates/indicate-instrument-conformance/src/admission.rs
@@ -1,5 +1,10 @@
 //! The admission matrix and its five check families.
 //!
+//! The matrix runs at every canonical frame a panel pins, and every
+//! geometry check is expressed against the frame being drawn rather
+//! than a descriptor constant — a panel that lays out differently at a
+//! different size is judged at each size it declares.
+//!
 //! All geometry tests happen in DESIGN-FRAME space: text runs are
 //! reduced to conservative ink rectangles (nominal metrics around the
 //! anchor) and mapped through the scene's transform state, exactly as
@@ -17,7 +22,7 @@
 
 use indicate_instrument_glyphs::PANEL_VOCABULARY;
 use indicate_instrument_registry::{
-    CANONICAL_STATES, EMPTY_CONFIG, PanelDescriptor, PanelDrawError, Registry,
+    CANONICAL_STATES, DesignFrame, EMPTY_CONFIG, PanelDescriptor, PanelDrawError, Registry,
 };
 use indicate_instrument_scene::{
     Cmd, LayerError, MAX_SCENE_BYTES, SceneCmds, SceneWriter, validate_layers,
@@ -47,13 +52,17 @@ pub struct AdmissionReport {
 /// A tolerated observation, counted so growth is visible.
 #[derive(Debug, Clone, PartialEq)]
 pub enum AdmissionWarning {
-    /// A text run whose ink extends outside the panel's design frame
-    /// without a bounding clip.
+    /// A text run whose ink extends outside the frame it was drawn in
+    /// without a bounding clip. The frame is part of the observation:
+    /// a run that fits at one canonical size and overhangs at another
+    /// is two different facts, and the ratchet counts them separately.
     FrameOverflow {
         /// The drawing panel.
         panel: &'static str,
         /// The corpus state.
         state: &'static str,
+        /// The frame the panel was drawn at.
+        frame: DesignFrame,
         /// The text run's content.
         text: String,
     },
@@ -231,16 +240,27 @@ fn admit_panel(
     panel: &'static PanelDescriptor,
     report: &mut AdmissionReport,
 ) -> Result<(), AdmissionError> {
+    for frame in panel.canonical_frames {
+        admit_panel_at_frame(panel, *frame, report)?;
+    }
+    Ok(())
+}
+
+fn admit_panel_at_frame(
+    panel: &'static PanelDescriptor,
+    frame: DesignFrame,
+    report: &mut AdmissionReport,
+) -> Result<(), AdmissionError> {
     let states = CANONICAL_STATES
         .iter()
         .map(|s| (s.id, s.build))
         .chain(panel.extreme_states.iter().map(|e| (e.id, e.build)));
     for (state_id, build) in states {
-        check_case(panel, state_id, None, build(), report)?;
+        check_case(panel, state_id, None, build(), frame, report)?;
         for group in GroupId::ALL {
             if panel.required_groups.contains(group) {
                 let withheld = withhold_group(&build(), group);
-                check_case(panel, state_id, Some(group), withheld, report)?;
+                check_case(panel, state_id, Some(group), withheld, frame, report)?;
             }
         }
     }
@@ -252,16 +272,17 @@ fn check_case(
     state_id: &'static str,
     withheld: Option<GroupId>,
     state: AircraftState,
+    frame: DesignFrame,
     report: &mut AdmissionReport,
 ) -> Result<(), AdmissionError> {
     let data = resolve(&state, &FreshnessPolicy::default());
-    let runs = draw_runs(panel, state_id, withheld, &data)?;
+    let runs = draw_runs(panel, state_id, withheld, &data, frame)?;
     check_provenance(panel, state_id, withheld, &runs)?;
-    let frame = Rect {
+    let bounds = Rect {
         min_x: 0.0,
         min_y: 0.0,
-        max_x: panel.design_frame.width,
-        max_y: panel.design_frame.height,
+        max_x: frame.width,
+        max_y: frame.height,
     };
     for run in &runs {
         for ch in run.text.chars() {
@@ -273,10 +294,11 @@ fn check_case(
                 });
             }
         }
-        if !frame.contains(&run.rect) && !run.clipped {
+        if !bounds.contains(&run.rect) && !run.clipped {
             report.warnings.push(AdmissionWarning::FrameOverflow {
                 panel: panel.id,
                 state: state_id,
+                frame,
                 text: run.text.clone(),
             });
         }
@@ -290,14 +312,16 @@ fn draw_runs(
     state_id: &'static str,
     withheld: Option<GroupId>,
     data: &PanelData,
+    frame: DesignFrame,
 ) -> Result<Vec<TextRun>, AdmissionError> {
     let mut buf = vec![0u8; MAX_SCENE_BYTES];
-    let scene = draw_scene(panel, data, &mut buf).map_err(|source| AdmissionError::Draw {
-        panel: panel.id,
-        state: state_id,
-        withheld,
-        source,
-    })?;
+    let scene =
+        draw_scene(panel, data, frame, &mut buf).map_err(|source| AdmissionError::Draw {
+            panel: panel.id,
+            state: state_id,
+            withheld,
+            source,
+        })?;
     let layers = validate_layers(scene).map_err(|error| match error {
         LayerError::Decode(_) => AdmissionError::Decode {
             panel: panel.id,
@@ -318,7 +342,7 @@ fn draw_runs(
             missing,
         });
     }
-    check_background(panel, state_id, scene)?;
+    check_background(panel, state_id, frame, scene)?;
     match collect_runs(scene) {
         Ok(runs) => Ok(runs),
         Err(RunsDefect::Decode) => Err(AdmissionError::Decode {
@@ -341,10 +365,11 @@ enum RunsDefect {
 fn draw_scene<'b>(
     panel: &PanelDescriptor,
     data: &PanelData,
+    frame: DesignFrame,
     buf: &'b mut [u8],
 ) -> Result<&'b [u8], PanelDrawError> {
     let mut writer = SceneWriter::new(buf)?;
-    (panel.draw)(data, &EMPTY_CONFIG, None, &mut writer)?;
+    (panel.draw)(data, &EMPTY_CONFIG, None, frame, &mut writer)?;
     let used = writer.finish();
     Ok(buf.get(..used).unwrap_or(&[]))
 }

--- a/crates/indicate-instrument-conformance/src/admission/background.rs
+++ b/crates/indicate-instrument-conformance/src/admission/background.rs
@@ -1,7 +1,7 @@
 //! The background-contract family: the declared capability must be the
 //! Background band's actual behavior in every corpus case.
 
-use indicate_instrument_registry::{BackgroundCapability, PanelDescriptor};
+use indicate_instrument_registry::{BackgroundCapability, DesignFrame, PanelDescriptor};
 use indicate_instrument_scene::{Cmd, LayerId, PaintMode, SceneCmds};
 
 use super::AdmissionError;
@@ -21,15 +21,14 @@ use super::geometry::{Ctm, Rect};
 pub(super) fn check_background(
     panel: &'static PanelDescriptor,
     state_id: &'static str,
+    frame: DesignFrame,
     scene: &[u8],
 ) -> Result<(), AdmissionError> {
     let (painted, covered) =
-        scan_background(scene, panel.design_frame.width, panel.design_frame.height).ok_or(
-            AdmissionError::Decode {
-                panel: panel.id,
-                state: state_id,
-            },
-        )?;
+        scan_background(scene, frame.width, frame.height).ok_or(AdmissionError::Decode {
+            panel: panel.id,
+            state: state_id,
+        })?;
     let (declared, defect) = match panel.background {
         BackgroundCapability::NotUsed if painted => ("NotUsed", "paints"),
         BackgroundCapability::Opaque if !covered => (

--- a/crates/indicate-instrument-conformance/src/admission/tests.rs
+++ b/crates/indicate-instrument-conformance/src/admission/tests.rs
@@ -32,6 +32,14 @@ fn builtin_panels_pass_admission() {
 mod background_checks;
 mod provenance_checks;
 
+/// The one frame every fixture panel below declares: a degenerate
+/// range, so each fixture is drawn exactly once per case and the counts
+/// asserted above stay readable.
+const FIXTURE_FRAME: DesignFrame = DesignFrame {
+    width: 480.0,
+    height: 360.0,
+};
+
 /// One-panel descriptor around a draw fixture, shared by the
 /// background and provenance fixture suites.
 fn opaque_panel(draw: indicate_instrument_registry::DrawFn) -> [PanelDescriptor; 1] {
@@ -40,15 +48,17 @@ fn opaque_panel(draw: indicate_instrument_registry::DrawFn) -> [PanelDescriptor;
         title: "Probe",
         required_layers: 1 << 2, // Tapes
         required_groups: GroupSet::EMPTY,
-        design_frame: DesignFrame {
-            width: 480.0,
-            height: 360.0,
-        },
+        frame_min: FIXTURE_FRAME,
+        frame_max: FIXTURE_FRAME,
+        frame_step: (1.0, 1.0),
+        aspect_min: 1.30,
+        aspect_max: 1.37,
+        canonical_frames: &[FIXTURE_FRAME],
         background: BackgroundCapability::Opaque,
         config_schema: &[],
         group_regions: &[],
         extreme_states: &[],
-        raster_baseline: None,
+        raster_baselines: &[],
         draw,
     }]
 }

--- a/crates/indicate-instrument-conformance/src/admission/tests/background_checks.rs
+++ b/crates/indicate-instrument-conformance/src/admission/tests/background_checks.rs
@@ -14,7 +14,7 @@ use indicate_instrument_scene::{LayerId, Rgba8, SceneWriter};
 use indicate_instrument_state::PanelData;
 
 use super::super::{AdmissionError, admit};
-use super::opaque_panel;
+use super::{FIXTURE_FRAME, opaque_panel};
 
 /// The shipped defect class: declaring NotUsed while painting an opaque
 /// ground in the Background band. Human review caught this once; the
@@ -23,6 +23,7 @@ fn draw_notused_painter(
     _data: &PanelData,
     _config: &ConfigBlob<'_>,
     _alerts: Option<&AlertOutput>,
+    _frame: DesignFrame,
     scene: &mut SceneWriter<'_>,
 ) -> Result<(), PanelDrawError> {
     scene.begin_layer(LayerId::Background)?;
@@ -47,15 +48,17 @@ fn a_notused_panel_that_paints_the_band_is_refused() {
         title: "Shy Painter",
         required_layers: 1 << 2, // Tapes
         required_groups: GroupSet::EMPTY,
-        design_frame: DesignFrame {
-            width: 480.0,
-            height: 360.0,
-        },
+        frame_min: FIXTURE_FRAME,
+        frame_max: FIXTURE_FRAME,
+        frame_step: (1.0, 1.0),
+        aspect_min: 1.30,
+        aspect_max: 1.37,
+        canonical_frames: &[FIXTURE_FRAME],
         background: BackgroundCapability::NotUsed,
         config_schema: &[],
         group_regions: &[],
         extreme_states: &[],
-        raster_baseline: None,
+        raster_baselines: &[],
         draw: draw_notused_painter,
     }];
     let registry = Registry::new(&DEFECT).expect("structurally valid");
@@ -75,6 +78,7 @@ fn draw_optimist(
     _data: &PanelData,
     _config: &ConfigBlob<'_>,
     _alerts: Option<&AlertOutput>,
+    _frame: DesignFrame,
     scene: &mut SceneWriter<'_>,
 ) -> Result<(), PanelDrawError> {
     scene.begin_layer(LayerId::Tapes)?;
@@ -89,15 +93,17 @@ fn an_opaque_panel_that_covers_nothing_is_refused() {
         title: "Optimist",
         required_layers: 1 << 2, // Tapes
         required_groups: GroupSet::EMPTY,
-        design_frame: DesignFrame {
-            width: 480.0,
-            height: 360.0,
-        },
+        frame_min: FIXTURE_FRAME,
+        frame_max: FIXTURE_FRAME,
+        frame_step: (1.0, 1.0),
+        aspect_min: 1.30,
+        aspect_max: 1.37,
+        canonical_frames: &[FIXTURE_FRAME],
         background: BackgroundCapability::Opaque,
         config_schema: &[],
         group_regions: &[],
         extreme_states: &[],
-        raster_baseline: None,
+        raster_baselines: &[],
         draw: draw_optimist,
     }];
     let registry = Registry::new(&DEFECT).expect("structurally valid");
@@ -114,6 +120,7 @@ fn draw_clip_evasion(
     _data: &PanelData,
     _config: &ConfigBlob<'_>,
     _alerts: Option<&AlertOutput>,
+    _frame: DesignFrame,
     scene: &mut SceneWriter<'_>,
 ) -> Result<(), PanelDrawError> {
     scene.begin_layer(LayerId::Background)?;
@@ -138,6 +145,7 @@ fn draw_rotate_evasion(
     _data: &PanelData,
     _config: &ConfigBlob<'_>,
     _alerts: Option<&AlertOutput>,
+    _frame: DesignFrame,
     scene: &mut SceneWriter<'_>,
 ) -> Result<(), PanelDrawError> {
     scene.begin_layer(LayerId::Background)?;
@@ -163,6 +171,7 @@ fn draw_alpha_evasion(
     _data: &PanelData,
     _config: &ConfigBlob<'_>,
     _alerts: Option<&AlertOutput>,
+    _frame: DesignFrame,
     scene: &mut SceneWriter<'_>,
 ) -> Result<(), PanelDrawError> {
     scene.begin_layer(LayerId::Background)?;
@@ -188,6 +197,7 @@ fn draw_empty_band_notused(
     _data: &PanelData,
     _config: &ConfigBlob<'_>,
     _alerts: Option<&AlertOutput>,
+    _frame: DesignFrame,
     scene: &mut SceneWriter<'_>,
 ) -> Result<(), PanelDrawError> {
     scene.begin_layer(LayerId::Background)?;
@@ -229,15 +239,17 @@ fn an_empty_band_under_notused_is_tolerated() {
         title: "Shy",
         required_layers: 1 << 2, // Tapes
         required_groups: GroupSet::EMPTY,
-        design_frame: DesignFrame {
-            width: 480.0,
-            height: 360.0,
-        },
+        frame_min: FIXTURE_FRAME,
+        frame_max: FIXTURE_FRAME,
+        frame_step: (1.0, 1.0),
+        aspect_min: 1.30,
+        aspect_max: 1.37,
+        canonical_frames: &[FIXTURE_FRAME],
         background: BackgroundCapability::NotUsed,
         config_schema: &[],
         group_regions: &[],
         extreme_states: &[],
-        raster_baseline: None,
+        raster_baselines: &[],
         draw: draw_empty_band_notused,
     }];
     let registry = Registry::new(&SHY).expect("structurally valid");
@@ -249,6 +261,7 @@ fn draw_empty(
     _data: &PanelData,
     _config: &ConfigBlob<'_>,
     _alerts: Option<&AlertOutput>,
+    _frame: DesignFrame,
     _scene: &mut SceneWriter<'_>,
 ) -> Result<(), PanelDrawError> {
     Ok(())
@@ -261,15 +274,17 @@ fn a_panel_missing_its_required_band_is_refused() {
         title: "Hollow",
         required_layers: 1 << 4, // Annunciation
         required_groups: GroupSet::EMPTY,
-        design_frame: DesignFrame {
-            width: 480.0,
-            height: 360.0,
-        },
+        frame_min: FIXTURE_FRAME,
+        frame_max: FIXTURE_FRAME,
+        frame_step: (1.0, 1.0),
+        aspect_min: 1.30,
+        aspect_max: 1.37,
+        canonical_frames: &[FIXTURE_FRAME],
         background: BackgroundCapability::NotUsed,
         config_schema: &[],
         group_regions: &[],
         extreme_states: &[],
-        raster_baseline: None,
+        raster_baselines: &[],
         draw: draw_empty,
     }];
     let registry = Registry::new(&HOLLOW).expect("structurally valid");

--- a/crates/indicate-instrument-conformance/src/admission/tests/provenance_checks.rs
+++ b/crates/indicate-instrument-conformance/src/admission/tests/provenance_checks.rs
@@ -11,7 +11,7 @@ use indicate_instrument_scene::{Anchor, LayerId, Rgba8, SceneWriter};
 use indicate_instrument_state::{GroupId, PanelData};
 
 use super::super::{AdmissionError, admit};
-use super::opaque_panel;
+use super::{FIXTURE_FRAME, opaque_panel};
 
 /// A panel that draws a numeral carrying no provenance claim — the
 /// totality hole that would otherwise escape every withholding case.
@@ -19,6 +19,7 @@ fn draw_dishonest(
     _data: &PanelData,
     _config: &ConfigBlob<'_>,
     _alerts: Option<&AlertOutput>,
+    _frame: DesignFrame,
     scene: &mut SceneWriter<'_>,
 ) -> Result<(), PanelDrawError> {
     scene.begin_layer(LayerId::Tapes)?;
@@ -35,10 +36,12 @@ fn an_unclaimed_numeral_is_refused() {
         title: "Dishonest",
         required_layers: 1 << 2, // Tapes
         required_groups: GroupSet::of(&[GroupId::Air]),
-        design_frame: DesignFrame {
-            width: 480.0,
-            height: 360.0,
-        },
+        frame_min: FIXTURE_FRAME,
+        frame_max: FIXTURE_FRAME,
+        frame_step: (1.0, 1.0),
+        aspect_min: 1.30,
+        aspect_max: 1.37,
+        canonical_frames: &[FIXTURE_FRAME],
         background: BackgroundCapability::NotUsed,
         config_schema: &[],
         group_regions: &[(
@@ -51,7 +54,7 @@ fn an_unclaimed_numeral_is_refused() {
             },
         )],
         extreme_states: &[],
-        raster_baseline: None,
+        raster_baselines: &[],
         draw: draw_dishonest,
     }];
     let registry = Registry::new(&DISHONEST).expect("structurally valid");
@@ -72,6 +75,7 @@ fn draw_leaking(
     data: &PanelData,
     _config: &ConfigBlob<'_>,
     _alerts: Option<&AlertOutput>,
+    _frame: DesignFrame,
     scene: &mut SceneWriter<'_>,
 ) -> Result<(), PanelDrawError> {
     scene.begin_layer(LayerId::Tapes)?;
@@ -99,10 +103,12 @@ fn a_fabricated_claim_is_refused_when_its_group_is_withheld() {
         title: "Leaking",
         required_layers: 1 << 2, // Tapes
         required_groups: GroupSet::of(&[GroupId::Air, GroupId::Kinematics]),
-        design_frame: DesignFrame {
-            width: 480.0,
-            height: 360.0,
-        },
+        frame_min: FIXTURE_FRAME,
+        frame_max: FIXTURE_FRAME,
+        frame_step: (1.0, 1.0),
+        aspect_min: 1.30,
+        aspect_max: 1.37,
+        canonical_frames: &[FIXTURE_FRAME],
         background: BackgroundCapability::NotUsed,
         config_schema: &[],
         group_regions: &[(
@@ -115,7 +121,7 @@ fn a_fabricated_claim_is_refused_when_its_group_is_withheld() {
             },
         )],
         extreme_states: &[],
-        raster_baseline: None,
+        raster_baselines: &[],
         draw: draw_leaking,
     }];
     let registry = Registry::new(&LEAKING).expect("structurally valid");
@@ -135,6 +141,7 @@ fn draw_translated(
     data: &PanelData,
     _config: &ConfigBlob<'_>,
     _alerts: Option<&AlertOutput>,
+    _frame: DesignFrame,
     scene: &mut SceneWriter<'_>,
 ) -> Result<(), PanelDrawError> {
     scene.begin_layer(LayerId::Tapes)?;
@@ -165,10 +172,12 @@ fn a_transform_cannot_hide_a_dishonest_numeral() {
         title: "Translated",
         required_layers: 1 << 2, // Tapes
         required_groups: GroupSet::of(&[GroupId::Air, GroupId::Kinematics]),
-        design_frame: DesignFrame {
-            width: 480.0,
-            height: 360.0,
-        },
+        frame_min: FIXTURE_FRAME,
+        frame_max: FIXTURE_FRAME,
+        frame_step: (1.0, 1.0),
+        aspect_min: 1.30,
+        aspect_max: 1.37,
+        canonical_frames: &[FIXTURE_FRAME],
         background: BackgroundCapability::NotUsed,
         config_schema: &[],
         group_regions: &[(
@@ -181,7 +190,7 @@ fn a_transform_cannot_hide_a_dishonest_numeral() {
             },
         )],
         extreme_states: &[],
-        raster_baseline: None,
+        raster_baselines: &[],
         draw: draw_translated,
     }];
     let registry = Registry::new(&TRANSLATED).expect("structurally valid");
@@ -200,6 +209,7 @@ fn draw_foreign_claim(
     _data: &PanelData,
     _config: &ConfigBlob<'_>,
     _alerts: Option<&AlertOutput>,
+    _frame: DesignFrame,
     scene: &mut SceneWriter<'_>,
 ) -> Result<(), PanelDrawError> {
     scene.begin_layer(LayerId::Tapes)?;
@@ -233,6 +243,7 @@ fn draw_config_claim(
     _data: &PanelData,
     _config: &ConfigBlob<'_>,
     _alerts: Option<&AlertOutput>,
+    _frame: DesignFrame,
     scene: &mut SceneWriter<'_>,
 ) -> Result<(), PanelDrawError> {
     scene.begin_layer(LayerId::Tapes)?;
@@ -266,6 +277,7 @@ fn draw_clipped_away(
     _data: &PanelData,
     _config: &ConfigBlob<'_>,
     _alerts: Option<&AlertOutput>,
+    _frame: DesignFrame,
     scene: &mut SceneWriter<'_>,
 ) -> Result<(), PanelDrawError> {
     scene.begin_layer(LayerId::Tapes)?;

--- a/crates/indicate-instrument-descriptor/src/descriptor.rs
+++ b/crates/indicate-instrument-descriptor/src/descriptor.rs
@@ -8,11 +8,19 @@ use crate::config::{ConfigBlob, ConfigError, ConfigKey};
 use crate::group_set::GroupSet;
 
 /// A panel's draw entry point: pure resolved-state → scene, with its
-/// configuration delivered as the validated blob the shell accepted.
+/// configuration delivered as the validated blob the shell accepted and
+/// the logical frame it must lay out against.
+///
+/// The frame is an input, not a configuration key. Configuration is an
+/// optional schema-gated wire blob and the admission harness draws the
+/// empty one deliberately, so a size-adaptive panel that read its frame
+/// from configuration would be unadmittable by construction. It sits
+/// before the writer because it is an input and the writer is the sink.
 pub type DrawFn = fn(
     &PanelData,
     &ConfigBlob<'_>,
     Option<&AlertOutput>,
+    DesignFrame,
     &mut SceneWriter<'_>,
 ) -> Result<(), PanelDrawError>;
 
@@ -48,6 +56,11 @@ pub enum BackgroundCapability {
 
 /// The logical space a panel draws against; backends scale, panels
 /// never see viewport pixels.
+///
+/// One frame is one draw. A panel declares the *range* of frames it can
+/// lay out against ([`PanelDescriptor::frame_min`] through
+/// [`PanelDescriptor::frame_max`]) and receives the chosen one as a
+/// [`DrawFn`] argument.
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub struct DesignFrame {
     /// Logical width.
@@ -96,8 +109,29 @@ pub struct PanelDescriptor {
     /// State groups this panel consumes — the withholding matrix the
     /// admission harness drives honest-status checks from.
     pub required_groups: GroupSet,
-    /// The logical space this panel draws against.
-    pub design_frame: DesignFrame,
+    /// The smallest frame this panel lays out against: the readability
+    /// floor, where conspicuity must still hold (AIR-OUT-004). Group
+    /// regions are validated against it, because the floor is where a
+    /// region has to fit.
+    pub frame_min: DesignFrame,
+    /// The largest frame this panel lays out against.
+    pub frame_max: DesignFrame,
+    /// Per-axis quantization step: admissible dimensions are
+    /// `frame_min + k * step`, which keeps the behaviour space and the
+    /// evidence matrix finite. A degenerate range declares any positive
+    /// step, since the only admissible `k` is zero.
+    pub frame_step: (f32, f32),
+    /// Smallest width/height ratio the layout supports. Per-axis bounds
+    /// alone would admit shapes the layout was never designed for, so
+    /// the ratio is bounded separately.
+    pub aspect_min: f32,
+    /// Largest width/height ratio the layout supports.
+    pub aspect_max: f32,
+    /// The pinned evidence sizes: the frames the digest, the admission
+    /// matrix, and the raster baselines are taken at. Must include both
+    /// [`PanelDescriptor::frame_min`] and [`PanelDescriptor::frame_max`],
+    /// and every entry must itself be admissible.
+    pub canonical_frames: &'static [DesignFrame],
     /// What the panel does with the `Background` band.
     pub background: BackgroundCapability,
     /// Configuration keys this panel understands; a shell refuses a
@@ -111,10 +145,12 @@ pub struct PanelDescriptor {
     pub group_regions: &'static [(GroupId, Region)],
     /// Panel-contributed stress fixtures beyond the canonical states.
     pub extreme_states: &'static [ExtremeState],
-    /// Pinned raster baseline: SHA-256 hex of the reference
-    /// rasterizer's render of the shared "typical" corpus state, or
-    /// `None` until the baseline travels into the descriptor.
-    pub raster_baseline: Option<&'static str>,
+    /// Pinned raster baselines: per canonical frame, the SHA-256 hex of
+    /// the reference rasterizer's render of the shared "typical" corpus
+    /// state at that frame. Every entry must name a frame in
+    /// [`PanelDescriptor::canonical_frames`]; an empty slice is the
+    /// honest declaration for a panel with no baseline pinned yet.
+    pub raster_baselines: &'static [(DesignFrame, &'static str)],
     /// The draw entry point.
     pub draw: DrawFn,
 }

--- a/crates/indicate-instrument-descriptor/src/lib.rs
+++ b/crates/indicate-instrument-descriptor/src/lib.rs
@@ -4,10 +4,11 @@
 //! A panel is a plugin over three stable contracts — the state-group
 //! vocabulary, the scene-command IR, and the glyph vocabulary. This
 //! crate holds the words a panel uses to describe itself against them:
-//! identity, required layers and state groups, the design frame,
-//! background capability, the bounded key-TLV configuration schema, the
-//! draw entry point, the panel-set grouping, and the canonical state
-//! corpus every panel is expected to survive.
+//! identity, required layers and state groups, the range of design
+//! frames it lays out against, background capability, the bounded
+//! key-TLV configuration schema, the draw entry point, the panel-set
+//! grouping, and the canonical state corpus every panel is expected to
+//! survive.
 //!
 //! Declaring is separate from composing. A panel needs the vocabulary to
 //! be describable at all, so the vocabulary is `no_std` and sits low

--- a/crates/indicate-instrument-raster/src/raster/tests/attitude_behavior.rs
+++ b/crates/indicate-instrument-raster/src/raster/tests/attitude_behavior.rs
@@ -10,7 +10,7 @@
 //! the f32 `libm` presentation under test — so a sign or rotation error in
 //! the draw layer surfaces as a misclassified pixel, not a plausible frame.
 
-use indicate_instrument_panels::{PANEL_H, PANEL_W, PfdConfig, draw_pfd};
+use indicate_instrument_panels::{BUILTIN_FRAME, PANEL_H, PANEL_W, PfdConfig, draw_pfd};
 use indicate_instrument_scene::{MAX_SCENE_BYTES, SceneWriter};
 use indicate_instrument_state::{
     AirData, AircraftState, Attitude, EstimateQuality, FreshnessPolicy, Kinematics, Quat, Stamped,
@@ -166,7 +166,14 @@ fn render_quat(quat: Quat) -> Vec<u8> {
     let data = resolve(&state_from_quat(quat), &FreshnessPolicy::default());
     let mut buf = std::vec![0u8; MAX_SCENE_BYTES];
     let mut writer = SceneWriter::new(&mut buf).expect("writer");
-    draw_pfd(&data, &PfdConfig::default(), None, &mut writer).expect("pfd");
+    draw_pfd(
+        &data,
+        &PfdConfig::default(),
+        None,
+        BUILTIN_FRAME,
+        &mut writer,
+    )
+    .expect("pfd");
     let n = writer.finish();
     buf.truncate(n);
 

--- a/crates/indicate-instrument-raster/src/raster/tests/frame_hashes.rs
+++ b/crates/indicate-instrument-raster/src/raster/tests/frame_hashes.rs
@@ -1,6 +1,7 @@
 #![allow(clippy::expect_used, clippy::panic)]
 
-use indicate_instrument_panels::{BUILTIN_PANELS, PANEL_H, PANEL_W, PfdConfig, draw_hsi, draw_pfd};
+use indicate_instrument_panels::{BUILTIN_PANELS, PfdConfig, draw_hsi, draw_pfd};
+use indicate_instrument_registry::DesignFrame;
 use indicate_instrument_scene::{MAX_SCENE_BYTES, SceneWriter};
 use indicate_instrument_state::{AircraftState, FreshnessPolicy, resolve};
 use sha2::{Digest, Sha256};
@@ -9,8 +10,9 @@ use std::vec::Vec;
 use crate::{FrameId, FramebufferDims, RenderStatus, render};
 
 // Frame hashes pinned from a byte-reproducible render on the reference
-// rasterizer, owned by each panel's descriptor (`raster_baseline`) so a
-// panel travels with its regression baseline. `libm` plus IEEE-754 f32
+// rasterizer, owned by each panel's descriptor (`raster_baselines`),
+// one per canonical frame, so a panel travels with its regression
+// baselines at every size it declares. `libm` plus IEEE-754 f32
 // make these identical across the supported CI architectures; a
 // mismatch is a determinism regression, not a value to re-pin
 // casually. The PFD hash covers the datum-qualified altitude tape: the
@@ -19,12 +21,26 @@ use crate::{FrameId, FramebufferDims, RenderStatus, render};
 // reference-typed heading: the rose turns with the fixture's explicit
 // SIM-declared independent sample — never quaternion yaw — and paints
 // the amber SIM reference label (NAV-01).
-fn pinned_baseline(id: &str) -> &'static str {
+fn pinned_baseline(id: &str, at: DesignFrame) -> &'static str {
     BUILTIN_PANELS
         .iter()
         .find(|panel| panel.id == id)
-        .and_then(|panel| panel.raster_baseline)
-        .expect("every builtin panel carries a raster baseline")
+        .and_then(|panel| {
+            panel
+                .raster_baselines
+                .iter()
+                .find(|(frame, _)| *frame == at)
+        })
+        .map(|(_, hash)| *hash)
+        .expect("every builtin panel carries a baseline at every canonical frame")
+}
+
+fn canonical_frames(id: &str) -> &'static [DesignFrame] {
+    BUILTIN_PANELS
+        .iter()
+        .find(|panel| panel.id == id)
+        .map(|panel| panel.canonical_frames)
+        .expect("every builtin panel pins its canonical frames")
 }
 
 /// The shared canonical "typical" state (ADR-0033): the same fixture
@@ -43,8 +59,8 @@ pub(super) fn encode(build: impl FnOnce(&mut SceneWriter<'_>)) -> Vec<u8> {
     buf
 }
 
-fn frame(scene: &[u8]) -> Vec<u8> {
-    let (w, h) = (PANEL_W as u32, PANEL_H as u32);
+fn frame(scene: &[u8], at: DesignFrame) -> Vec<u8> {
+    let (w, h) = (at.width as u32, at.height as u32);
     let mut fb = std::vec![0u8; (w * h * 4) as usize];
     let report = render(
         scene,
@@ -71,58 +87,81 @@ fn sha_hex(bytes: &[u8]) -> std::string::String {
 #[test]
 fn pfd_frame_hash_is_reproducible_and_pinned() {
     let data = resolve(&demo_state(), &FreshnessPolicy::default());
-    let scene = encode(|w| draw_pfd(&data, &PfdConfig::default(), None, w).expect("pfd"));
-    let first = frame(&scene);
-    let second = frame(&scene);
-    assert_eq!(
-        first, second,
-        "PFD frame is bit-reproducible across renders"
-    );
-    assert_eq!(sha_hex(&first), pinned_baseline("pfd"));
+    for at in canonical_frames("pfd") {
+        let scene = encode(|w| draw_pfd(&data, &PfdConfig::default(), None, *at, w).expect("pfd"));
+        let first = frame(&scene, *at);
+        let second = frame(&scene, *at);
+        assert_eq!(
+            first, second,
+            "PFD frame is bit-reproducible across renders"
+        );
+        assert_eq!(sha_hex(&first), pinned_baseline("pfd", *at));
+    }
 }
 
 #[test]
 fn hsi_frame_hash_is_reproducible_and_pinned() {
     let data = resolve(&demo_state(), &FreshnessPolicy::default());
-    let scene = encode(|w| draw_hsi(&data, None, w).expect("hsi"));
-    let first = frame(&scene);
-    let second = frame(&scene);
-    assert_eq!(
-        first, second,
-        "HSI frame is bit-reproducible across renders"
-    );
-    assert_eq!(sha_hex(&first), pinned_baseline("hsi"));
+    for at in canonical_frames("hsi") {
+        let scene = encode(|w| draw_hsi(&data, None, *at, w).expect("hsi"));
+        let first = frame(&scene, *at);
+        let second = frame(&scene, *at);
+        assert_eq!(
+            first, second,
+            "HSI frame is bit-reproducible across renders"
+        );
+        assert_eq!(sha_hex(&first), pinned_baseline("hsi", *at));
+    }
 }
 
 /// A shape gate, not a value check: the per-panel hash tests above own
-/// value correctness; this keeps a new builtin from shipping with no
-/// baseline at all (Registry::new does not require one).
+/// value correctness; this keeps a new builtin from shipping with a
+/// canonical frame nothing is pinned at (Registry::new permits an empty
+/// baseline slice, which is right for a set without raster coverage and
+/// wrong for these).
 #[test]
 fn all_builtin_panels_carry_a_baseline() {
     for panel in BUILTIN_PANELS {
-        let baseline = panel
-            .raster_baseline
-            .unwrap_or_else(|| panic!("{} ships without a raster baseline", panel.id));
-        assert_eq!(
-            baseline.len(),
-            64,
-            "{} baseline is not sha256 hex",
-            panel.id
-        );
-        assert!(baseline.bytes().all(|b| b.is_ascii_hexdigit()));
+        for at in panel.canonical_frames {
+            let pinned: Vec<&str> = panel
+                .raster_baselines
+                .iter()
+                .filter(|(frame, _)| frame == at)
+                .map(|(_, hash)| *hash)
+                .collect();
+            assert_eq!(
+                pinned.len(),
+                1,
+                "{} must pin exactly one baseline at {}x{}",
+                panel.id,
+                at.width,
+                at.height
+            );
+            let baseline = pinned[0];
+            assert_eq!(
+                baseline.len(),
+                64,
+                "{} baseline is not sha256 hex",
+                panel.id
+            );
+            assert!(baseline.bytes().all(|b| b.is_ascii_hexdigit()));
+        }
     }
 }
 
 #[test]
 fn monitor_frame_hash_is_reproducible_and_pinned() {
     let data = resolve(&demo_state(), &FreshnessPolicy::default());
-    let scene =
-        encode(|w| indicate_instrument_panels::draw_monitor(&data, None, w).expect("monitor"));
-    let first = frame(&scene);
-    let second = frame(&scene);
-    assert_eq!(
-        first, second,
-        "monitor frame is bit-reproducible across renders"
-    );
-    assert_eq!(sha_hex(&first), pinned_baseline("monitor"));
+    for at in canonical_frames("monitor") {
+        let scene = encode(|w| {
+            indicate_instrument_panels::draw_monitor(&data, None, *at, w).expect("monitor")
+        });
+        let first = frame(&scene, *at);
+        let second = frame(&scene, *at);
+        assert_eq!(
+            first, second,
+            "monitor frame is bit-reproducible across renders"
+        );
+        assert_eq!(sha_hex(&first), pinned_baseline("monitor", *at));
+    }
 }

--- a/crates/indicate-instrument-raster/src/raster/tests/readout_bounds.rs
+++ b/crates/indicate-instrument-raster/src/raster/tests/readout_bounds.rs
@@ -12,7 +12,7 @@
 //! fitting and the backend-side painting cannot diverge silently.
 
 use indicate_instrument_glyphs::{ADVANCE, CELL_H, CELL_W};
-use indicate_instrument_panels::{PANEL_W, PfdConfig, draw_pfd};
+use indicate_instrument_panels::{BUILTIN_FRAME, PANEL_W, PfdConfig, draw_pfd};
 use indicate_instrument_scene::{
     Anchor, Cmd, MAX_SCENE_BYTES, SceneCmds, SceneWriter, nominal_text_ink_width,
     nominal_text_width,
@@ -73,7 +73,14 @@ fn pfd_scene(alt_ft: f32, ias_kt: f32) -> Vec<u8> {
     let data = resolve(&state_at(alt_ft, ias_kt), &FreshnessPolicy::default());
     let mut buf = std::vec![0u8; MAX_SCENE_BYTES];
     let mut writer = SceneWriter::new(&mut buf).expect("writer");
-    draw_pfd(&data, &PfdConfig::default(), None, &mut writer).expect("pfd");
+    draw_pfd(
+        &data,
+        &PfdConfig::default(),
+        None,
+        BUILTIN_FRAME,
+        &mut writer,
+    )
+    .expect("pfd");
     let n = writer.finish();
     buf.truncate(n);
     buf

--- a/crates/indicate-instrument-raster/src/raster/tests/work_budget.rs
+++ b/crates/indicate-instrument-raster/src/raster/tests/work_budget.rs
@@ -4,7 +4,7 @@
 //! fit inside [`RenderWork::BUDGET`], and the counters must be a pure
 //! function of scene bytes and dimensions.
 
-use indicate_instrument_panels::{PANEL_H, PANEL_W, PfdConfig, draw_hsi, draw_pfd};
+use indicate_instrument_panels::{BUILTIN_FRAME, PANEL_H, PANEL_W, PfdConfig, draw_hsi, draw_pfd};
 use indicate_instrument_state::{FreshnessPolicy, resolve};
 use std::vec::Vec;
 
@@ -29,9 +29,14 @@ fn panel_scenes() -> Vec<(&'static str, Vec<u8>)> {
     std::vec![
         (
             "PFD",
-            encode(|w| draw_pfd(&data, &PfdConfig::default(), None, w).expect("pfd")),
+            encode(
+                |w| draw_pfd(&data, &PfdConfig::default(), None, BUILTIN_FRAME, w).expect("pfd")
+            ),
         ),
-        ("HSI", encode(|w| draw_hsi(&data, None, w).expect("hsi"))),
+        (
+            "HSI",
+            encode(|w| draw_hsi(&data, None, BUILTIN_FRAME, w).expect("hsi"))
+        ),
     ]
 }
 

--- a/crates/indicate-instrument-registry/src/digest.rs
+++ b/crates/indicate-instrument-registry/src/digest.rs
@@ -3,8 +3,9 @@
 //!
 //! The digest streams, per registered panel: the role-tagged,
 //! length-prefixed panel id and the contract-relevant descriptor
-//! fields, then per corpus state the role-tagged state id and emitted
-//! scene bytes — drawn with the empty config and no alerts, so it is
+//! fields, then per corpus state the role-tagged state id, and within
+//! it per canonical frame the role-tagged frame and the emitted scene
+//! bytes — drawn with the empty config and no alerts, so it is
 //! invariant to SVS by construction (theme independence holds because
 //! panels take no theme parameter at this boundary). Shells report the same digest or they are
 //! not showing the same panels; pixel hashes stay per-backend
@@ -13,7 +14,8 @@
 //! with a review note saying why.
 
 use indicate_instrument_descriptor::{
-    BackgroundCapability, CANONICAL_STATES, EMPTY_CONFIG, PanelDescriptor, PanelDrawError,
+    BackgroundCapability, CANONICAL_STATES, DesignFrame, EMPTY_CONFIG, PanelDescriptor,
+    PanelDrawError,
 };
 use indicate_instrument_scene::{SCENE_FORMAT_VERSION, SceneWriter};
 use indicate_instrument_state::{FreshnessPolicy, abi::v6, resolve};
@@ -56,9 +58,11 @@ pub enum DigestError {
 const ROLE_PANEL: u8 = 1;
 const ROLE_STATE: u8 = 2;
 const ROLE_SCENE: u8 = 3;
+const ROLE_FRAME: u8 = 4;
 
 /// Digests `registry` over the shared corpus plus each panel's own
-/// extreme states, drawing into `scratch` (size it
+/// extreme states, at every canonical frame each panel pins, drawing
+/// into `scratch` (size it
 /// [`indicate_instrument_scene::MAX_SCENE_BYTES`]).
 pub fn scene_digest(registry: &Registry, scratch: &mut [u8]) -> Result<[u8; 32], DigestError> {
     let mut ctx = Sha256Ctx::new();
@@ -78,14 +82,25 @@ pub fn scene_digest(registry: &Registry, scratch: &mut [u8]) -> Result<[u8; 32],
 
 /// Binds the contract-relevant descriptor fields, not just the id: two
 /// shells whose descriptors declare different required layers, groups,
-/// frames, background capability, or schemas are not showing the same
-/// instruments even if their scene bytes agree.
+/// frame ranges, background capability, or schemas are not showing the
+/// same instruments even if their scene bytes agree.
+///
+/// Raster baselines stay out: they pin one backend's pixels, and a
+/// deliberate re-pin there must not move cross-shell identity.
 fn digest_panel_contract(ctx: &mut Sha256Ctx, panel: &PanelDescriptor) {
     update_framed(ctx, ROLE_PANEL, panel.id.as_bytes());
     ctx.update(&[panel.required_layers]);
     ctx.update(&panel.required_groups.bits().to_le_bytes());
-    ctx.update(&panel.design_frame.width.to_le_bytes());
-    ctx.update(&panel.design_frame.height.to_le_bytes());
+    digest_frame(ctx, panel.frame_min);
+    digest_frame(ctx, panel.frame_max);
+    ctx.update(&panel.frame_step.0.to_le_bytes());
+    ctx.update(&panel.frame_step.1.to_le_bytes());
+    ctx.update(&panel.aspect_min.to_le_bytes());
+    ctx.update(&panel.aspect_max.to_le_bytes());
+    ctx.update(&(panel.canonical_frames.len() as u32).to_le_bytes());
+    for frame in panel.canonical_frames {
+        digest_frame(ctx, *frame);
+    }
     ctx.update(&[match panel.background {
         BackgroundCapability::NotUsed => 0,
         BackgroundCapability::Opaque => 1,
@@ -106,13 +121,31 @@ fn digest_state(
 ) -> Result<(), DigestError> {
     update_framed(ctx, ROLE_STATE, state_id.as_bytes());
     let data = resolve(&state, &FreshnessPolicy::default());
+    for frame in panel.canonical_frames {
+        digest_frame_scene(ctx, panel, state_id, &data, *frame, scratch)?;
+    }
+    Ok(())
+}
+
+fn digest_frame_scene(
+    ctx: &mut Sha256Ctx,
+    panel: &PanelDescriptor,
+    state_id: &'static str,
+    data: &indicate_instrument_state::PanelData,
+    frame: DesignFrame,
+    scratch: &mut [u8],
+) -> Result<(), DigestError> {
+    ctx.update(&[ROLE_FRAME]);
+    digest_frame(ctx, frame);
     let scratch_len = scratch.len();
     let mut writer =
         SceneWriter::new(scratch).map_err(|_| DigestError::Scratch { len: scratch_len })?;
-    (panel.draw)(&data, &EMPTY_CONFIG, None, &mut writer).map_err(|source| DigestError::Draw {
-        panel: panel.id,
-        state: state_id,
-        source,
+    (panel.draw)(data, &EMPTY_CONFIG, None, frame, &mut writer).map_err(|source| {
+        DigestError::Draw {
+            panel: panel.id,
+            state: state_id,
+            source,
+        }
     })?;
     let used = writer.finish();
     let Some(scene) = scratch.get(..used) else {
@@ -122,6 +155,14 @@ fn digest_state(
     };
     update_framed(ctx, ROLE_SCENE, scene);
     Ok(())
+}
+
+/// A frame is two fixed-width words, so it needs no length prefix; the
+/// role tag that precedes a frame item keeps it from aliasing anything
+/// else in the stream.
+fn digest_frame(ctx: &mut Sha256Ctx, frame: DesignFrame) {
+    ctx.update(&frame.width.to_le_bytes());
+    ctx.update(&frame.height.to_le_bytes());
 }
 
 /// Role-tagged, length-prefixed (`u32` LE) update: framing keeps

--- a/crates/indicate-instrument-registry/src/digest/tests.rs
+++ b/crates/indicate-instrument-registry/src/digest/tests.rs
@@ -15,10 +15,16 @@ fn draw_nothing(
     _data: &PanelData,
     _config: &ConfigBlob<'_>,
     _alerts: Option<&AlertOutput>,
+    _frame: DesignFrame,
     _scene: &mut SceneWriter<'_>,
 ) -> Result<(), PanelDrawError> {
     Ok(())
 }
+
+const FRAME: DesignFrame = DesignFrame {
+    width: 480.0,
+    height: 360.0,
+};
 
 const fn panel(id: &'static str) -> PanelDescriptor {
     PanelDescriptor {
@@ -26,15 +32,17 @@ const fn panel(id: &'static str) -> PanelDescriptor {
         title: "Panel",
         required_layers: 0b10,
         required_groups: GroupSet::EMPTY,
-        design_frame: DesignFrame {
-            width: 480.0,
-            height: 360.0,
-        },
+        frame_min: FRAME,
+        frame_max: FRAME,
+        frame_step: (1.0, 1.0),
+        aspect_min: 1.30,
+        aspect_max: 1.37,
+        canonical_frames: &[FRAME],
         background: BackgroundCapability::NotUsed,
         config_schema: &[],
         group_regions: &[],
         extreme_states: &[],
-        raster_baseline: None,
+        raster_baselines: &[],
         draw: draw_nothing,
     }
 }
@@ -61,6 +69,11 @@ fn the_digest_binds_the_descriptor_contract() {
         p.required_layers = 0b110;
         p
     }];
+    static WIDER_ASPECT: [PanelDescriptor; 1] = [{
+        let mut p = panel("alpha");
+        p.aspect_max = 1.5;
+        p
+    }];
     let mut scratch = std::vec![0u8; MAX_SCENE_BYTES];
     let digest = |panels: &'static [PanelDescriptor], scratch: &mut [u8]| {
         scene_digest(&Registry::new(panels).expect("composes"), scratch).expect("digests")
@@ -71,12 +84,115 @@ fn the_digest_binds_the_descriptor_contract() {
         digest(&WIDER_MASK, &mut scratch),
         "a weaker or stronger completeness gate is a different contract"
     );
+    assert_ne!(
+        base,
+        digest(&WIDER_ASPECT, &mut scratch),
+        "the frame constraints a shell may pick from are part of the contract"
+    );
+}
+
+const BIG: DesignFrame = DesignFrame {
+    width: 960.0,
+    height: 720.0,
+};
+
+/// A panel spanning two canonical frames, one exactly twice the other.
+const fn two_frame_panel() -> PanelDescriptor {
+    let mut p = panel("alpha");
+    p.frame_max = BIG;
+    p.frame_step = (480.0, 360.0);
+    p.canonical_frames = &[FRAME, BIG];
+    p
+}
+
+fn draw_frame_rect(
+    _data: &PanelData,
+    _config: &ConfigBlob<'_>,
+    _alerts: Option<&AlertOutput>,
+    frame: DesignFrame,
+    scene: &mut SceneWriter<'_>,
+) -> Result<(), PanelDrawError> {
+    scene.begin_layer(indicate_instrument_scene::LayerId::Attitude)?;
+    scene.rect(
+        indicate_instrument_scene::PaintMode::Fill,
+        0.0,
+        0.0,
+        frame.width,
+        frame.height,
+    )?;
+    scene.end_layer(indicate_instrument_scene::LayerId::Attitude)?;
+    Ok(())
+}
+
+/// The same drawing with the smallest frame's size baked in: identical
+/// bytes to [`draw_frame_rect`] at the floor, and stale everywhere else.
+fn draw_fixed_rect(
+    _data: &PanelData,
+    _config: &ConfigBlob<'_>,
+    _alerts: Option<&AlertOutput>,
+    _frame: DesignFrame,
+    scene: &mut SceneWriter<'_>,
+) -> Result<(), PanelDrawError> {
+    scene.begin_layer(indicate_instrument_scene::LayerId::Attitude)?;
+    scene.rect(
+        indicate_instrument_scene::PaintMode::Fill,
+        0.0,
+        0.0,
+        FRAME.width,
+        FRAME.height,
+    )?;
+    scene.end_layer(indicate_instrument_scene::LayerId::Attitude)?;
+    Ok(())
+}
+
+/// The frame is an emission input, and the digest takes it at every
+/// canonical size: two panels whose contract blocks are identical and
+/// whose drawings agree at the floor still differ once a second
+/// canonical frame is pinned — but only if the frame reaches the draw
+/// and the draw is repeated there.
+#[test]
+fn the_digest_draws_every_canonical_frame_and_the_panel_sees_it() {
+    static ONE_SIZED: [PanelDescriptor; 1] = [{
+        let mut p = panel("alpha");
+        p.draw = draw_frame_rect;
+        p
+    }];
+    static ONE_FIXED: [PanelDescriptor; 1] = [{
+        let mut p = panel("alpha");
+        p.draw = draw_fixed_rect;
+        p
+    }];
+    static TWO_SIZED: [PanelDescriptor; 1] = [{
+        let mut p = two_frame_panel();
+        p.draw = draw_frame_rect;
+        p
+    }];
+    static TWO_FIXED: [PanelDescriptor; 1] = [{
+        let mut p = two_frame_panel();
+        p.draw = draw_fixed_rect;
+        p
+    }];
+    let mut scratch = std::vec![0u8; MAX_SCENE_BYTES];
+    let digest = |panels: &'static [PanelDescriptor], scratch: &mut [u8]| {
+        scene_digest(&Registry::new(panels).expect("composes"), scratch).expect("digests")
+    };
+    assert_eq!(
+        digest(&ONE_SIZED, &mut scratch),
+        digest(&ONE_FIXED, &mut scratch),
+        "at the floor alone the two drawings are byte-identical"
+    );
+    assert_ne!(
+        digest(&TWO_SIZED, &mut scratch),
+        digest(&TWO_FIXED, &mut scratch),
+        "the second canonical frame is drawn, and the panel lays out against it"
+    );
 }
 
 fn draw_one_layer(
     _data: &PanelData,
     _config: &ConfigBlob<'_>,
     _alerts: Option<&AlertOutput>,
+    _frame: DesignFrame,
     scene: &mut SceneWriter<'_>,
 ) -> Result<(), PanelDrawError> {
     scene.begin_layer(indicate_instrument_scene::LayerId::Attitude)?;

--- a/crates/indicate-instrument-registry/src/registry.rs
+++ b/crates/indicate-instrument-registry/src/registry.rs
@@ -4,6 +4,11 @@ use indicate_instrument_scene::LAYER_COUNT;
 
 use indicate_instrument_descriptor::{PanelDescriptor, PanelSet};
 
+mod error;
+mod frame_range;
+
+pub use error::RegistryError;
+
 /// How a shell named the panels it composed.
 ///
 /// A shell with one provider crate passes a slice and never sees sets;
@@ -70,116 +75,6 @@ impl Iterator for Panels {
             },
         }
     }
-}
-
-/// Why a composition was refused.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, thiserror::Error)]
-pub enum RegistryError {
-    /// A shell with no panels has nothing to display.
-    #[error("a registry must contain at least one panel")]
-    Empty,
-    /// A composition naming no sets has nothing to display, and would
-    /// pass the per-panel checks vacuously.
-    #[error("a registry must contain at least one set")]
-    NoSets,
-    /// A set id violates the lowercase/digits/dashes charset.
-    #[error("set {set} has a malformed id")]
-    BadSetId {
-        /// Position in the composed set list.
-        set: usize,
-    },
-    /// Two sets share an id, so neither can be named unambiguously.
-    #[error("set {set} repeats an earlier set's id")]
-    DuplicateSetId {
-        /// Position of the second occurrence.
-        set: usize,
-    },
-    /// A set contributing no panels is a provider wired up wrongly, not
-    /// a shell that wanted nothing.
-    #[error("set {set} contributes no panels")]
-    EmptySet {
-        /// Position in the composed set list.
-        set: usize,
-    },
-    /// A panel id violates the lowercase/digits/dashes charset.
-    #[error("panel {index} has a malformed id")]
-    BadId {
-        /// Position in the flattened composition.
-        index: usize,
-    },
-    /// Two panels share an id.
-    #[error("panel {index} repeats an earlier panel's id")]
-    DuplicateId {
-        /// Position of the second occurrence.
-        index: usize,
-    },
-    /// An empty title cannot label health or layout surfaces.
-    #[error("panel {index} has an empty title")]
-    EmptyTitle {
-        /// Position in the flattened composition.
-        index: usize,
-    },
-    /// A panel that requires no layers would pass every completeness
-    /// check vacuously.
-    #[error("panel {index} declares no required layers")]
-    NoRequiredLayers {
-        /// Position in the flattened composition.
-        index: usize,
-    },
-    /// Required-layer bits beyond the defined scene layers.
-    #[error("panel {index} requires undefined layer bits {bits:#04x}")]
-    UndefinedLayerBits {
-        /// Position in the flattened composition.
-        index: usize,
-        /// The offending mask.
-        bits: u8,
-    },
-    /// A non-finite or non-positive design frame.
-    #[error("panel {index} has a degenerate design frame")]
-    BadDesignFrame {
-        /// Position in the flattened composition.
-        index: usize,
-    },
-    /// Schema keys must be strictly ascending (unique by construction).
-    #[error("panel {index} schema key {key} repeats or descends")]
-    SchemaKeysNotAscending {
-        /// Position in the flattened composition.
-        index: usize,
-        /// The out-of-order key.
-        key: u16,
-    },
-    /// A group region for a group the panel does not consume.
-    #[error("panel {index} declares a region for group {group} it does not require")]
-    RegionGroupNotRequired {
-        /// Position in the flattened composition.
-        index: usize,
-        /// The wire tag of the unrequired group.
-        group: u8,
-    },
-    /// A group region outside the design frame (or degenerate).
-    #[error("panel {index} declares a region for group {group} outside its design frame")]
-    RegionOutsideFrame {
-        /// Position in the flattened composition.
-        index: usize,
-        /// The wire tag of the group.
-        group: u8,
-    },
-    /// Two extreme states of one panel share an id.
-    #[error("panel {index} repeats the extreme-state id at position {position}")]
-    DuplicateExtremeId {
-        /// Position in the flattened composition.
-        index: usize,
-        /// Position of the second occurrence within the panel.
-        position: usize,
-    },
-    /// An extreme-state id violates the lowercase/digits/dashes charset.
-    #[error("panel {index} extreme state {position} has a malformed id")]
-    BadExtremeId {
-        /// Position in the flattened composition.
-        index: usize,
-        /// Position of the offending extreme state within the panel.
-        position: usize,
-    },
 }
 
 /// Bits a required-layer mask may set: one per defined scene layer.
@@ -296,14 +191,7 @@ fn validate_panel(index: usize, panel: &PanelDescriptor) -> Result<(), RegistryE
             bits: panel.required_layers,
         });
     }
-    let frame = panel.design_frame;
-    if !(frame.width.is_finite()
-        && frame.height.is_finite()
-        && frame.width > 0.0
-        && frame.height > 0.0)
-    {
-        return Err(RegistryError::BadDesignFrame { index });
-    }
+    frame_range::validate(index, panel)?;
     let mut previous: Option<u16> = None;
     for key in panel.config_schema {
         if previous.is_some_and(|previous| key.0 <= previous) {
@@ -318,12 +206,16 @@ fn validate_panel(index: usize, panel: &PanelDescriptor) -> Result<(), RegistryE
                 group: *group as u8,
             });
         }
+        // The floor is where a readout surface has to fit: a region
+        // that only fits at a larger frame does not describe the panel
+        // a shell may ask for at its smallest.
+        let floor = panel.frame_min;
         let inside = region.x >= 0.0
             && region.y >= 0.0
             && region.width > 0.0
             && region.height > 0.0
-            && region.x + region.width <= frame.width
-            && region.y + region.height <= frame.height;
+            && region.x + region.width <= floor.width
+            && region.y + region.height <= floor.height;
         if !inside {
             return Err(RegistryError::RegionOutsideFrame {
                 index,

--- a/crates/indicate-instrument-registry/src/registry/error.rs
+++ b/crates/indicate-instrument-registry/src/registry/error.rs
@@ -144,6 +144,22 @@ pub enum RegistryError {
         /// Position of the offending baseline within the panel.
         position: usize,
     },
+    /// The same frame is pinned twice in `canonical_frames`.
+    #[error("panel {index} repeats canonical frame {position}")]
+    DuplicateCanonicalFrame {
+        /// Position in the flattened composition.
+        index: usize,
+        /// Position of the second occurrence within the panel.
+        position: usize,
+    },
+    /// Two raster baselines name the same canonical frame.
+    #[error("panel {index} pins raster baseline {position} at an already-pinned frame")]
+    DuplicateRasterBaseline {
+        /// Position in the flattened composition.
+        index: usize,
+        /// Position of the second occurrence within the panel.
+        position: usize,
+    },
     /// Schema keys must be strictly ascending (unique by construction).
     #[error("panel {index} schema key {key} repeats or descends")]
     SchemaKeysNotAscending {

--- a/crates/indicate-instrument-registry/src/registry/error.rs
+++ b/crates/indicate-instrument-registry/src/registry/error.rs
@@ -1,0 +1,188 @@
+//! Why a composition was refused: one variant per rule, each carrying
+//! enough context to name the offending declaration without a debugger.
+
+/// Why a composition was refused.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, thiserror::Error)]
+pub enum RegistryError {
+    /// A shell with no panels has nothing to display.
+    #[error("a registry must contain at least one panel")]
+    Empty,
+    /// A composition naming no sets has nothing to display, and would
+    /// pass the per-panel checks vacuously.
+    #[error("a registry must contain at least one set")]
+    NoSets,
+    /// A set id violates the lowercase/digits/dashes charset.
+    #[error("set {set} has a malformed id")]
+    BadSetId {
+        /// Position in the composed set list.
+        set: usize,
+    },
+    /// Two sets share an id, so neither can be named unambiguously.
+    #[error("set {set} repeats an earlier set's id")]
+    DuplicateSetId {
+        /// Position of the second occurrence.
+        set: usize,
+    },
+    /// A set contributing no panels is a provider wired up wrongly, not
+    /// a shell that wanted nothing.
+    #[error("set {set} contributes no panels")]
+    EmptySet {
+        /// Position in the composed set list.
+        set: usize,
+    },
+    /// A panel id violates the lowercase/digits/dashes charset.
+    #[error("panel {index} has a malformed id")]
+    BadId {
+        /// Position in the flattened composition.
+        index: usize,
+    },
+    /// Two panels share an id.
+    #[error("panel {index} repeats an earlier panel's id")]
+    DuplicateId {
+        /// Position of the second occurrence.
+        index: usize,
+    },
+    /// An empty title cannot label health or layout surfaces.
+    #[error("panel {index} has an empty title")]
+    EmptyTitle {
+        /// Position in the flattened composition.
+        index: usize,
+    },
+    /// A panel that requires no layers would pass every completeness
+    /// check vacuously.
+    #[error("panel {index} declares no required layers")]
+    NoRequiredLayers {
+        /// Position in the flattened composition.
+        index: usize,
+    },
+    /// Required-layer bits beyond the defined scene layers.
+    #[error("panel {index} requires undefined layer bits {bits:#04x}")]
+    UndefinedLayerBits {
+        /// Position in the flattened composition.
+        index: usize,
+        /// The offending mask.
+        bits: u8,
+    },
+    /// A non-finite or non-positive frame bound.
+    #[error("panel {index} has a degenerate frame bound")]
+    BadFrameBounds {
+        /// Position in the flattened composition.
+        index: usize,
+    },
+    /// A maximum frame smaller than the minimum on some axis: the range
+    /// it describes is empty.
+    #[error("panel {index} declares a maximum frame below its minimum")]
+    FrameRangeInverted {
+        /// Position in the flattened composition.
+        index: usize,
+    },
+    /// A non-finite or non-positive quantization step. A zero step
+    /// would make every dimension either on-grid or nothing at all.
+    #[error("panel {index} has a degenerate frame step")]
+    BadFrameStep {
+        /// Position in the flattened composition.
+        index: usize,
+    },
+    /// Aspect bounds that are non-finite, non-positive, or inverted.
+    #[error("panel {index} has degenerate aspect bounds")]
+    BadAspectBounds {
+        /// Position in the flattened composition.
+        index: usize,
+    },
+    /// A panel pinning no evidence sizes is drawn at no frame at all by
+    /// the digest and the admission matrix.
+    #[error("panel {index} pins no canonical frames")]
+    NoCanonicalFrames {
+        /// Position in the flattened composition.
+        index: usize,
+    },
+    /// The readability floor is not among the pinned evidence sizes, so
+    /// nothing is ever drawn there.
+    #[error("panel {index} does not pin its minimum frame as canonical")]
+    CanonicalFramesMissingMin {
+        /// Position in the flattened composition.
+        index: usize,
+    },
+    /// The largest declared frame is not among the pinned evidence
+    /// sizes, so the top of the range is never exercised.
+    #[error("panel {index} does not pin its maximum frame as canonical")]
+    CanonicalFramesMissingMax {
+        /// Position in the flattened composition.
+        index: usize,
+    },
+    /// A canonical frame outside the declared range.
+    #[error("panel {index} canonical frame {position} is outside its declared range")]
+    CanonicalFrameOutOfRange {
+        /// Position in the flattened composition.
+        index: usize,
+        /// Position of the offending frame within the panel.
+        position: usize,
+    },
+    /// A canonical frame that is not `frame_min + k * frame_step`.
+    #[error("panel {index} canonical frame {position} is off the step grid")]
+    CanonicalFrameOffStep {
+        /// Position in the flattened composition.
+        index: usize,
+        /// Position of the offending frame within the panel.
+        position: usize,
+    },
+    /// A canonical frame whose ratio the declared layout does not
+    /// support. The per-axis corners alone may not be admissible
+    /// shapes, which is exactly why this is checked.
+    #[error("panel {index} canonical frame {position} violates its aspect bounds")]
+    CanonicalFrameAspect {
+        /// Position in the flattened composition.
+        index: usize,
+        /// Position of the offending frame within the panel.
+        position: usize,
+    },
+    /// A raster baseline pinned at a frame nothing is ever rendered at.
+    #[error("panel {index} raster baseline {position} names a frame that is not canonical")]
+    RasterBaselineNotCanonical {
+        /// Position in the flattened composition.
+        index: usize,
+        /// Position of the offending baseline within the panel.
+        position: usize,
+    },
+    /// Schema keys must be strictly ascending (unique by construction).
+    #[error("panel {index} schema key {key} repeats or descends")]
+    SchemaKeysNotAscending {
+        /// Position in the flattened composition.
+        index: usize,
+        /// The out-of-order key.
+        key: u16,
+    },
+    /// A group region for a group the panel does not consume.
+    #[error("panel {index} declares a region for group {group} it does not require")]
+    RegionGroupNotRequired {
+        /// Position in the flattened composition.
+        index: usize,
+        /// The wire tag of the unrequired group.
+        group: u8,
+    },
+    /// A group region outside the minimum frame (or degenerate): the
+    /// floor is where a readout surface has to fit.
+    #[error("panel {index} declares a region for group {group} outside its minimum frame")]
+    RegionOutsideFrame {
+        /// Position in the flattened composition.
+        index: usize,
+        /// The wire tag of the group.
+        group: u8,
+    },
+    /// Two extreme states of one panel share an id.
+    #[error("panel {index} repeats the extreme-state id at position {position}")]
+    DuplicateExtremeId {
+        /// Position in the flattened composition.
+        index: usize,
+        /// Position of the second occurrence within the panel.
+        position: usize,
+    },
+    /// An extreme-state id violates the lowercase/digits/dashes charset.
+    #[error("panel {index} extreme state {position} has a malformed id")]
+    BadExtremeId {
+        /// Position in the flattened composition.
+        index: usize,
+        /// Position of the offending extreme state within the panel.
+        position: usize,
+    },
+}

--- a/crates/indicate-instrument-registry/src/registry/frame_range.rs
+++ b/crates/indicate-instrument-registry/src/registry/frame_range.rs
@@ -56,6 +56,12 @@ fn validate_canonical(index: usize, panel: &PanelDescriptor) -> Result<(), Regis
         return Err(RegistryError::CanonicalFramesMissingMax { index });
     }
     for (position, frame) in panel.canonical_frames.iter().enumerate() {
+        // A repeated frame draws and digests the same scene twice and
+        // runs the whole admission matrix again for it, inflating the
+        // case count and the warning ratchet for no coverage.
+        if panel.canonical_frames[..position].contains(frame) {
+            return Err(RegistryError::DuplicateCanonicalFrame { index, position });
+        }
         if !in_range(*frame, panel) {
             return Err(RegistryError::CanonicalFrameOutOfRange { index, position });
         }
@@ -75,6 +81,15 @@ fn validate_baselines(index: usize, panel: &PanelDescriptor) -> Result<(), Regis
     for (position, (frame, _)) in panel.raster_baselines.iter().enumerate() {
         if !panel.canonical_frames.contains(frame) {
             return Err(RegistryError::RasterBaselineNotCanonical { index, position });
+        }
+        // One baseline per canonical frame: a second entry for the same
+        // frame is dead, because the lookup takes the first match, and
+        // two hashes for one rendering disagree about what is pinned.
+        if panel.raster_baselines[..position]
+            .iter()
+            .any(|(earlier, _)| earlier == frame)
+        {
+            return Err(RegistryError::DuplicateRasterBaseline { index, position });
         }
     }
     Ok(())

--- a/crates/indicate-instrument-registry/src/registry/frame_range.rs
+++ b/crates/indicate-instrument-registry/src/registry/frame_range.rs
@@ -1,0 +1,107 @@
+//! The declared frame range: bounds, quantization, aspect, and the
+//! evidence sizes pinned inside it.
+//!
+//! A shell picks the frame it draws a panel at, so what a panel declares
+//! here is the whole of what a shell may pick from. Every rule below is
+//! refused at composition rather than at draw time: a frame a panel
+//! cannot lay out against must be unaskable, not merely unhandled.
+
+use indicate_instrument_descriptor::{DesignFrame, PanelDescriptor};
+
+use super::error::RegistryError;
+
+/// Validates the frame bounds, the step grid, the aspect bounds, the
+/// canonical frames pinned inside them, and the baselines pinned
+/// against those.
+pub(super) fn validate(index: usize, panel: &PanelDescriptor) -> Result<(), RegistryError> {
+    validate_bounds(index, panel)?;
+    validate_canonical(index, panel)?;
+    validate_baselines(index, panel)
+}
+
+fn positive(value: f32) -> bool {
+    value.is_finite() && value > 0.0
+}
+
+fn validate_bounds(index: usize, panel: &PanelDescriptor) -> Result<(), RegistryError> {
+    let (min, max) = (panel.frame_min, panel.frame_max);
+    if !(positive(min.width) && positive(min.height) && positive(max.width) && positive(max.height))
+    {
+        return Err(RegistryError::BadFrameBounds { index });
+    }
+    if max.width < min.width || max.height < min.height {
+        return Err(RegistryError::FrameRangeInverted { index });
+    }
+    let (step_w, step_h) = panel.frame_step;
+    if !(positive(step_w) && positive(step_h)) {
+        return Err(RegistryError::BadFrameStep { index });
+    }
+    if !(positive(panel.aspect_min)
+        && positive(panel.aspect_max)
+        && panel.aspect_min <= panel.aspect_max)
+    {
+        return Err(RegistryError::BadAspectBounds { index });
+    }
+    Ok(())
+}
+
+fn validate_canonical(index: usize, panel: &PanelDescriptor) -> Result<(), RegistryError> {
+    if panel.canonical_frames.is_empty() {
+        return Err(RegistryError::NoCanonicalFrames { index });
+    }
+    if !panel.canonical_frames.contains(&panel.frame_min) {
+        return Err(RegistryError::CanonicalFramesMissingMin { index });
+    }
+    if !panel.canonical_frames.contains(&panel.frame_max) {
+        return Err(RegistryError::CanonicalFramesMissingMax { index });
+    }
+    for (position, frame) in panel.canonical_frames.iter().enumerate() {
+        if !in_range(*frame, panel) {
+            return Err(RegistryError::CanonicalFrameOutOfRange { index, position });
+        }
+        if !on_grid(frame.width, panel.frame_min.width, panel.frame_step.0)
+            || !on_grid(frame.height, panel.frame_min.height, panel.frame_step.1)
+        {
+            return Err(RegistryError::CanonicalFrameOffStep { index, position });
+        }
+        if !aspect_ok(*frame, panel) {
+            return Err(RegistryError::CanonicalFrameAspect { index, position });
+        }
+    }
+    Ok(())
+}
+
+fn validate_baselines(index: usize, panel: &PanelDescriptor) -> Result<(), RegistryError> {
+    for (position, (frame, _)) in panel.raster_baselines.iter().enumerate() {
+        if !panel.canonical_frames.contains(frame) {
+            return Err(RegistryError::RasterBaselineNotCanonical { index, position });
+        }
+    }
+    Ok(())
+}
+
+fn in_range(frame: DesignFrame, panel: &PanelDescriptor) -> bool {
+    frame.width >= panel.frame_min.width
+        && frame.width <= panel.frame_max.width
+        && frame.height >= panel.frame_min.height
+        && frame.height <= panel.frame_max.height
+}
+
+/// Whether `value` is `min + k * step` for a whole `k`.
+///
+/// Exact, with no tolerance: a step that cannot express the declared
+/// frames exactly is a declaration to fix, not a rounding to absorb.
+/// Admitting near-misses would put the digest and the baselines at
+/// frames the arithmetic cannot reproduce.
+fn on_grid(value: f32, min: f32, step: f32) -> bool {
+    let offset = value - min;
+    offset >= 0.0 && offset % step == 0.0
+}
+
+fn aspect_ok(frame: DesignFrame, panel: &PanelDescriptor) -> bool {
+    let aspect = frame.width / frame.height;
+    aspect >= panel.aspect_min && aspect <= panel.aspect_max
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/indicate-instrument-registry/src/registry/frame_range/tests.rs
+++ b/crates/indicate-instrument-registry/src/registry/frame_range/tests.rs
@@ -1,0 +1,202 @@
+#![allow(clippy::expect_used, clippy::panic)]
+
+//! One must-fail case per rule: a constraint the registry does not
+//! refuse is a constraint a shell can violate.
+
+use indicate_instrument_descriptor::{DesignFrame, PanelDescriptor};
+
+use super::super::tests::{FRAME, RANGED_MAX, panel, ranged};
+use super::super::{Registry, RegistryError};
+
+#[test]
+fn a_degenerate_frame_bound_is_refused() {
+    static FLAT: [PanelDescriptor; 1] = [{
+        let mut p = panel("pfd");
+        p.frame_min = DesignFrame {
+            width: 480.0,
+            height: 0.0,
+        };
+        p
+    }];
+    assert_eq!(
+        Registry::new(&FLAT).map(|_| ()),
+        Err(RegistryError::BadFrameBounds { index: 0 })
+    );
+}
+
+#[test]
+fn an_inverted_frame_range_is_refused() {
+    static BACKWARDS: [PanelDescriptor; 1] = [{
+        let mut p = panel("pfd");
+        p.frame_max = DesignFrame {
+            width: 440.0,
+            height: 360.0,
+        };
+        p
+    }];
+    assert_eq!(
+        Registry::new(&BACKWARDS).map(|_| ()),
+        Err(RegistryError::FrameRangeInverted { index: 0 })
+    );
+}
+
+#[test]
+fn a_degenerate_frame_step_is_refused() {
+    static ZERO: [PanelDescriptor; 1] = [{
+        let mut p = panel("pfd");
+        p.frame_step = (0.0, 1.0);
+        p
+    }];
+    assert_eq!(
+        Registry::new(&ZERO).map(|_| ()),
+        Err(RegistryError::BadFrameStep { index: 0 })
+    );
+}
+
+#[test]
+fn inverted_aspect_bounds_are_refused() {
+    static BACKWARDS: [PanelDescriptor; 1] = [{
+        let mut p = panel("pfd");
+        p.aspect_min = 2.0;
+        p.aspect_max = 1.0;
+        p
+    }];
+    assert_eq!(
+        Registry::new(&BACKWARDS).map(|_| ()),
+        Err(RegistryError::BadAspectBounds { index: 0 })
+    );
+}
+
+#[test]
+fn a_panel_pinning_no_canonical_frames_is_refused() {
+    static UNPINNED: [PanelDescriptor; 1] = [{
+        let mut p = panel("pfd");
+        p.canonical_frames = &[];
+        p
+    }];
+    assert_eq!(
+        Registry::new(&UNPINNED).map(|_| ()),
+        Err(RegistryError::NoCanonicalFrames { index: 0 })
+    );
+}
+
+/// Both ends of the declared range must be pinned, or the range
+/// contains a size nothing is ever drawn at.
+#[test]
+fn canonical_frames_must_include_both_ends_of_the_range() {
+    static NO_MIN: [PanelDescriptor; 1] = [{
+        let mut p = ranged("pfd");
+        p.canonical_frames = &[RANGED_MAX];
+        p
+    }];
+    assert_eq!(
+        Registry::new(&NO_MIN).map(|_| ()),
+        Err(RegistryError::CanonicalFramesMissingMin { index: 0 })
+    );
+    static NO_MAX: [PanelDescriptor; 1] = [{
+        let mut p = ranged("pfd");
+        p.canonical_frames = &[FRAME];
+        p
+    }];
+    assert_eq!(
+        Registry::new(&NO_MAX).map(|_| ()),
+        Err(RegistryError::CanonicalFramesMissingMax { index: 0 })
+    );
+}
+
+#[test]
+fn a_canonical_frame_outside_the_range_is_refused() {
+    static BEYOND: [PanelDescriptor; 1] = [{
+        let mut p = ranged("pfd");
+        p.canonical_frames = &[
+            FRAME,
+            RANGED_MAX,
+            DesignFrame {
+                width: 640.0,
+                height: 480.0,
+            },
+        ];
+        p
+    }];
+    assert_eq!(
+        Registry::new(&BEYOND).map(|_| ()),
+        Err(RegistryError::CanonicalFrameOutOfRange {
+            index: 0,
+            position: 2,
+        })
+    );
+}
+
+/// 520×380 is in range and inside the aspect bounds, and its height is
+/// 20 above the floor on a 30-unit grid — so only the step rule can
+/// refuse it.
+#[test]
+fn a_canonical_frame_off_the_step_grid_is_refused() {
+    static OFF: [PanelDescriptor; 1] = [{
+        let mut p = ranged("pfd");
+        p.canonical_frames = &[
+            FRAME,
+            RANGED_MAX,
+            DesignFrame {
+                width: 520.0,
+                height: 380.0,
+            },
+        ];
+        p
+    }];
+    assert_eq!(
+        Registry::new(&OFF).map(|_| ()),
+        Err(RegistryError::CanonicalFrameOffStep {
+            index: 0,
+            position: 2,
+        })
+    );
+}
+
+/// The reason the aspect bounds are checked per canonical frame rather
+/// than only at the corners: 600×360 is inside the per-axis range and
+/// on the grid, and is a shape the layout never declared.
+#[test]
+fn a_canonical_frame_outside_the_aspect_bounds_is_refused() {
+    static SQUAT: [PanelDescriptor; 1] = [{
+        let mut p = ranged("pfd");
+        p.canonical_frames = &[
+            FRAME,
+            RANGED_MAX,
+            DesignFrame {
+                width: 600.0,
+                height: 360.0,
+            },
+        ];
+        p
+    }];
+    assert_eq!(
+        Registry::new(&SQUAT).map(|_| ()),
+        Err(RegistryError::CanonicalFrameAspect {
+            index: 0,
+            position: 2,
+        })
+    );
+}
+
+#[test]
+fn a_raster_baseline_at_an_unrendered_frame_is_refused() {
+    static STRAY: [PanelDescriptor; 1] = [{
+        let mut p = panel("pfd");
+        p.raster_baselines = &[(
+            DesignFrame {
+                width: 240.0,
+                height: 180.0,
+            },
+            "00",
+        )];
+        p
+    }];
+    assert_eq!(
+        Registry::new(&STRAY).map(|_| ()),
+        Err(RegistryError::RasterBaselineNotCanonical {
+            index: 0,
+            position: 0,
+        })
+    );
+}

--- a/crates/indicate-instrument-registry/src/registry/frame_range/tests.rs
+++ b/crates/indicate-instrument-registry/src/registry/frame_range/tests.rs
@@ -200,3 +200,51 @@ fn a_raster_baseline_at_an_unrendered_frame_is_refused() {
         })
     );
 }
+
+/// A repeated canonical frame would digest the same scene twice and run
+/// the admission matrix again for it, inflating both counts for nothing.
+#[test]
+fn a_repeated_canonical_frame_is_refused() {
+    const MIN: DesignFrame = DesignFrame {
+        width: 480.0,
+        height: 360.0,
+    };
+    const MAX: DesignFrame = DesignFrame {
+        width: 600.0,
+        height: 450.0,
+    };
+    static TWICE: [PanelDescriptor; 1] = [{
+        let mut p = panel("pfd");
+        p.frame_min = MIN;
+        p.frame_max = MAX;
+        p.frame_step = (40.0, 30.0);
+        p.canonical_frames = &[MIN, MAX, MIN];
+        p.raster_baselines = &[];
+        p
+    }];
+    assert_eq!(
+        Registry::new(&TWICE).map(|_| ()),
+        Err(RegistryError::DuplicateCanonicalFrame {
+            index: 0,
+            position: 2,
+        })
+    );
+}
+
+/// The lookup takes the first match, so a second baseline at one frame
+/// is dead code that disagrees with the live one about what is pinned.
+#[test]
+fn two_raster_baselines_at_one_frame_are_refused() {
+    static CONFLICT: [PanelDescriptor; 1] = [{
+        let mut p = panel("pfd");
+        p.raster_baselines = &[(FRAME, "aa"), (FRAME, "bb")];
+        p
+    }];
+    assert_eq!(
+        Registry::new(&CONFLICT).map(|_| ()),
+        Err(RegistryError::DuplicateRasterBaseline {
+            index: 0,
+            position: 1,
+        })
+    );
+}

--- a/crates/indicate-instrument-registry/src/registry/tests.rs
+++ b/crates/indicate-instrument-registry/src/registry/tests.rs
@@ -17,6 +17,7 @@ fn draw_nothing(
     _data: &PanelData,
     _config: &ConfigBlob<'_>,
     _alerts: Option<&AlertOutput>,
+    _frame: DesignFrame,
     _scene: &mut SceneWriter<'_>,
 ) -> Result<(), PanelDrawError> {
     Ok(())
@@ -26,23 +27,47 @@ fn nothing_fed() -> AircraftState {
     AircraftState::default()
 }
 
-const fn panel(id: &'static str) -> PanelDescriptor {
+pub(super) const FRAME: DesignFrame = DesignFrame {
+    width: 480.0,
+    height: 360.0,
+};
+const CANONICAL: &[DesignFrame] = &[FRAME];
+
+pub(super) const fn panel(id: &'static str) -> PanelDescriptor {
     PanelDescriptor {
         id,
         title: "Panel",
         required_layers: 0b0000_0110,
         required_groups: GroupSet::of(&[GroupId::Attitude, GroupId::Air]),
-        design_frame: DesignFrame {
-            width: 480.0,
-            height: 360.0,
-        },
+        frame_min: FRAME,
+        frame_max: FRAME,
+        frame_step: (1.0, 1.0),
+        aspect_min: 1.30,
+        aspect_max: 1.37,
+        canonical_frames: CANONICAL,
         background: BackgroundCapability::NotUsed,
         config_schema: &[],
         group_regions: &[],
         extreme_states: &[],
-        raster_baseline: None,
+        raster_baselines: &[],
         draw: draw_nothing,
     }
+}
+
+/// A panel with a real range: 480×360 up to 600×450, both 4:3, on a
+/// 40×30 grid. The fixtures below need a range wide enough that a
+/// constraint can be violated inside it.
+pub(super) const RANGED_MAX: DesignFrame = DesignFrame {
+    width: 600.0,
+    height: 450.0,
+};
+
+pub(super) const fn ranged(id: &'static str) -> PanelDescriptor {
+    let mut p = panel(id);
+    p.frame_max = RANGED_MAX;
+    p.frame_step = (40.0, 30.0);
+    p.canonical_frames = &[FRAME, RANGED_MAX];
+    p
 }
 
 #[test]
@@ -99,22 +124,6 @@ fn layer_mask_abuse_is_refused() {
 }
 
 #[test]
-fn a_degenerate_design_frame_is_refused() {
-    static FLAT: [PanelDescriptor; 1] = [{
-        let mut p = panel("pfd");
-        p.design_frame = DesignFrame {
-            width: 480.0,
-            height: 0.0,
-        };
-        p
-    }];
-    assert_eq!(
-        Registry::new(&FLAT).map(|_| ()),
-        Err(RegistryError::BadDesignFrame { index: 0 })
-    );
-}
-
-#[test]
 fn schema_key_order_is_enforced() {
     use indicate_instrument_descriptor::ConfigKey;
     static UNSORTED: [PanelDescriptor; 1] = [{
@@ -165,6 +174,28 @@ fn group_regions_must_stay_honest() {
     }];
     assert_eq!(
         Registry::new(&OUTSIDE).map(|_| ()),
+        Err(RegistryError::RegionOutsideFrame {
+            index: 0,
+            group: GroupId::Attitude as u8,
+        })
+    );
+    // The floor is the frame a region must fit in: this one fits the
+    // ceiling comfortably and hangs off the bottom of the minimum.
+    static ONLY_FITS_THE_CEILING: [PanelDescriptor; 1] = [{
+        let mut p = ranged("pfd");
+        p.group_regions = &[(
+            GroupId::Attitude,
+            Region {
+                x: 0.0,
+                y: 0.0,
+                width: 480.0,
+                height: 400.0,
+            },
+        )];
+        p
+    }];
+    assert_eq!(
+        Registry::new(&ONLY_FITS_THE_CEILING).map(|_| ()),
         Err(RegistryError::RegionOutsideFrame {
             index: 0,
             group: GroupId::Attitude as u8,

--- a/docs/instruments/backend-contract.md
+++ b/docs/instruments/backend-contract.md
@@ -45,16 +45,21 @@ The descriptor declares what a shell may ask for:
 
 | Field | What it says |
 |---|---|
-| `frame_min` | The readability floor. Conspicuity must hold here (AIR-OUT-004), and group regions are validated against it. |
+| `frame_min` | The readability floor. Conspicuity must hold here ([`AIR-OUT-004`](requirements.md#air-out-004)), and group regions are validated against it. |
 | `frame_max` | The ceiling the work budget allows. |
 | `frame_step` | Per-axis quantization: admissible dimensions are `frame_min + k * step`. |
 | `aspect_min`, `aspect_max` | The width/height ratios the layout supports. The per-axis corners alone admit shapes no layout declared. |
 | `canonical_frames` | The pinned evidence sizes. Must include both ends of the range, and every entry must satisfy every rule above. |
 
-`Registry::new` refuses a *declaration* that breaks any of them, so a
-range naming frames its own panel could not lay out against never
-reaches a shell. Choosing a frame inside a valid range, and clamping to
-it, is the shell's job: nothing in the draw path re-checks the argument.
+`Registry::new` refuses a *declaration* that breaks any of them, and
+checks every canonical frame against all of them, so the sizes the
+evidence is pinned at are shapes the panel really declared.
+
+Note how far that reaches, and how far it does not: a valid range may
+still *contain* an in-range, on-grid frame that violates the aspect
+bounds. Choosing a frame inside the range, and clamping to what the
+panel supports, is the shell's job — nothing in the draw path re-checks
+the argument.
 Every shipped panel currently declares a degenerate range —
 `frame_min == frame_max == 480×360`, one canonical frame — so the only
 frame a conforming shell may ask any of them for is 480×360.

--- a/docs/instruments/backend-contract.md
+++ b/docs/instruments/backend-contract.md
@@ -35,18 +35,42 @@ traffic to tune. If a backend is slow, the cost is in the backend.
 
 ## The design frame
 
-A panel is authored in the logical frame its descriptor declares
-(`PanelDescriptor::design_frame`; 480×360 for every shipped panel).
+A panel is authored against a *range* of logical frames, and it is drawn
+at one of them. The frame is an argument to the draw call, not a
+descriptor constant and not a configuration key — configuration is an
+optional schema-gated blob that admission deliberately leaves empty, so
+a panel taking its size from a key could never be admitted.
 
-- Every backend clips at the design frame: ink outside it never reaches
-  a pixel, on any backend.
+The descriptor declares what a shell may ask for:
+
+| Field | What it says |
+|---|---|
+| `frame_min` | The readability floor. Conspicuity must hold here (AIR-OUT-004), and group regions are validated against it. |
+| `frame_max` | The ceiling the work budget allows. |
+| `frame_step` | Per-axis quantization: admissible dimensions are `frame_min + k * step`. |
+| `aspect_min`, `aspect_max` | The width/height ratios the layout supports. The per-axis corners alone admit shapes no layout declared. |
+| `canonical_frames` | The pinned evidence sizes. Must include both ends of the range, and every entry must satisfy every rule above. |
+
+`Registry::new` refuses a *declaration* that breaks any of them, so a
+range naming frames its own panel could not lay out against never
+reaches a shell. Choosing a frame inside a valid range, and clamping to
+it, is the shell's job: nothing in the draw path re-checks the argument.
+Every shipped panel currently declares a degenerate range —
+`frame_min == frame_max == 480×360`, one canonical frame — so the only
+frame a conforming shell may ask any of them for is 480×360.
+
+- Every backend clips at the frame it asked for: ink outside it never
+  reaches a pixel, on any backend.
 - Inside the frame, coordinates are logical units. Backends scale to
-  their surface; they never reinterpret geometry.
+  their surface; they never reinterpret geometry. A larger surface is
+  served either by scaling the frame up or, once a panel declares a real
+  range, by asking for a larger frame — the choice is the shell's, and
+  the mapping stays one uniform scale either way.
 - Unclipped text whose nominal ink extends past the frame edge is a
-  counted admission warning, ratcheted per panel by the conformance
-  harness. Growing the count is a deliberate, reviewed decision — never
-  drift. Fixing overflowing paint moves frame hashes and is its own
-  change, at which point the ratchet steps down.
+  counted admission warning, ratcheted per panel and per canonical frame
+  by the conformance harness. Growing the count is a deliberate,
+  reviewed decision — never drift. Fixing overflowing paint moves frame
+  hashes and is its own change, at which point the ratchet steps down.
 
 ## Where the vocabulary deliberately stops
 
@@ -56,10 +80,12 @@ stop looking for the version that adds it. The other is genuinely open,
 and is recorded here with its price rather than left to be discovered.
 
 **There is no `SCALE`, and there will not be one.** The transform ops
-are translate and rotate. A panel is authored in the frame its
-descriptor declares and a backend maps that whole frame to the viewport,
-so an instrument cannot be drawn at a different size *within* a scene.
-That is the contract: panels compose, instruments inside them do not.
+are translate and rotate. A panel is authored against the frame it is
+handed and a backend maps that whole frame to the viewport, so an
+instrument cannot be drawn at a different size *within* a scene. That is
+the contract: panels compose, instruments inside them do not. Sizing is
+a layout decision inside the panel — which is why the frame is an
+emission input rather than a transform over the output.
 
 The limitation this looks like is answered a layer up rather than by a
 transform. An instrument wanted at two-thirds size beside another is a

--- a/docs/instruments/evidence-artifacts/att01/panel.run.txt
+++ b/docs/instruments/evidence-artifacts/att01/panel.run.txt
@@ -2,9 +2,9 @@ Indicate evidence — captured verification run (SIM / NOT FOR FLIGHT)
 scope: ATT-01
 suite: PFD attitude panel
 command: cargo test -p indicate-instrument-panels
-config-digest: f660304b057bec44ce31a7602673bc1e9cd9e6b9
+config-digest: 836371a8dd7fab23231f9a17f461f562cd42433a
 tool-version: rustc 1.95.0 (59807616e 2026-04-14)
-run-id: local:f660304b057bec44ce31a7602673bc1e9cd9e6b9
+run-id: local:836371a8dd7fab23231f9a17f461f562cd42433a
 outcome: pass
 summary:
 test result: ok. 79 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out

--- a/docs/instruments/evidence-artifacts/att01/presentation.run.txt
+++ b/docs/instruments/evidence-artifacts/att01/presentation.run.txt
@@ -2,9 +2,9 @@ Indicate evidence — captured verification run (SIM / NOT FOR FLIGHT)
 scope: ATT-01
 suite: SO(3) presentation unit
 command: cargo test -p indicate-instrument-state
-config-digest: f660304b057bec44ce31a7602673bc1e9cd9e6b9
+config-digest: 836371a8dd7fab23231f9a17f461f562cd42433a
 tool-version: rustc 1.95.0 (59807616e 2026-04-14)
-run-id: local:f660304b057bec44ce31a7602673bc1e9cd9e6b9
+run-id: local:836371a8dd7fab23231f9a17f461f562cd42433a
 outcome: pass
 summary:
 test result: ok. 167 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out

--- a/docs/instruments/evidence-artifacts/att01/raster.run.txt
+++ b/docs/instruments/evidence-artifacts/att01/raster.run.txt
@@ -2,9 +2,9 @@ Indicate evidence — captured verification run (SIM / NOT FOR FLIGHT)
 scope: ATT-01
 suite: raster attitude behavior
 command: cargo test -p indicate-instrument-raster
-config-digest: f660304b057bec44ce31a7602673bc1e9cd9e6b9
+config-digest: 836371a8dd7fab23231f9a17f461f562cd42433a
 tool-version: rustc 1.95.0 (59807616e 2026-04-14)
-run-id: local:f660304b057bec44ce31a7602673bc1e9cd9e6b9
+run-id: local:836371a8dd7fab23231f9a17f461f562cd42433a
 outcome: pass
 summary:
 test result: ok. 86 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out

--- a/docs/instruments/evidence-graph.evg
+++ b/docs/instruments/evidence-graph.evg
@@ -157,34 +157,34 @@ locator docs/instruments/fha.md
 node RESULT-RASTER verification-result
 title raster extreme-attitude behavior — recorded pass
 attr command cargo test -p indicate-instrument-raster
-attr config-digest f660304b057bec44ce31a7602673bc1e9cd9e6b9
+attr config-digest 836371a8dd7fab23231f9a17f461f562cd42433a
 attr tool-version rustc 1.95.0 (59807616e 2026-04-14)
-attr source-digest git-blob:39567de102031c44439f4fce57661b565cf63ce8
+attr source-digest git-blob:a44456b2d4dbff51b8577ac9410f652e862830d1
 attr artifact docs/instruments/evidence-artifacts/att01/raster.run.txt
-attr output-digest sha256:3f2dc238625127e4337cfa9904e5dfa6beaa0cd4be3d0e8d7e407a6964004dda
-attr run-id local:f660304b057bec44ce31a7602673bc1e9cd9e6b9
+attr output-digest sha256:d27dd8e231d63619fc3779b5d6d0ecbafefd10c0d61c9f91ae5d2ca314b15394
+attr run-id local:836371a8dd7fab23231f9a17f461f562cd42433a
 attr outcome pass
 
 node RESULT-PRESENTATION verification-result
 title SO(3) presentation unit suite — recorded pass
 attr command cargo test -p indicate-instrument-state
-attr config-digest f660304b057bec44ce31a7602673bc1e9cd9e6b9
+attr config-digest 836371a8dd7fab23231f9a17f461f562cd42433a
 attr tool-version rustc 1.95.0 (59807616e 2026-04-14)
 attr source-digest git-blob:d11595580cab8264e75e9e82ab9994de6d8bdeac
 attr artifact docs/instruments/evidence-artifacts/att01/presentation.run.txt
-attr output-digest sha256:937eb84a8b5b8ad4c30554e05a809c833ffaa31dc7b4ad6ae4bcf4d7b896542b
-attr run-id local:f660304b057bec44ce31a7602673bc1e9cd9e6b9
+attr output-digest sha256:42ade6e10961d41d1de84ded7917faf75a64071eafc286173c7297bd8a8ca7bb
+attr run-id local:836371a8dd7fab23231f9a17f461f562cd42433a
 attr outcome pass
 
 node RESULT-PFD verification-result
 title PFD attitude panel suite — recorded pass
 attr command cargo test -p indicate-instrument-panels
-attr config-digest f660304b057bec44ce31a7602673bc1e9cd9e6b9
+attr config-digest 836371a8dd7fab23231f9a17f461f562cd42433a
 attr tool-version rustc 1.95.0 (59807616e 2026-04-14)
 attr source-digest git-blob:015edf11e26fa840cb410c086262cf4ed2621413
 attr artifact docs/instruments/evidence-artifacts/att01/panel.run.txt
-attr output-digest sha256:f478281129119a05c81bed83daea28ed711cf0c3d5d98fb9246e6df267393c38
-attr run-id local:f660304b057bec44ce31a7602673bc1e9cd9e6b9
+attr output-digest sha256:77b79aab7abc109f1e87ff127ef29ccbdffb671e732a6a5f9a30cec2ee2b96b2
+attr run-id local:836371a8dd7fab23231f9a17f461f562cd42433a
 attr outcome pass
 
 # --- Configuration and tool identity ---
@@ -192,8 +192,8 @@ attr outcome pass
 node CFG-WORKTREE configuration-item
 title engineering worktree baseline — the git working tree the recorded results were produced against (not certified SCM)
 attr scm git-worktree
-attr commit f660304b057bec44ce31a7602673bc1e9cd9e6b9
-attr tree 8cf0d6158f55c1a39e5ae59350046a0655c3e171
+attr commit 836371a8dd7fab23231f9a17f461f562cd42433a
+attr tree 04ed2f329c37888b044fad6011cf688b75eb3e9f
 
 node TOOL-CARGO-TEST tool
 title cargo test on Rust stable — not DO-330 tool-qualified

--- a/docs/instruments/panel-contract.md
+++ b/docs/instruments/panel-contract.md
@@ -47,14 +47,14 @@ Three tiers of obligation, and the difference matters:
 |---|---|
 | `required_layers` | **Load-bearing.** Admission asserts every declared band is present in every case. |
 | `required_groups` | **Load-bearing.** This *is* the withholding matrix: admission withholds each declared group in turn. |
-| `design_frame` | **Load-bearing.** Every geometry check is expressed in its units. |
+| `frame_min`, `frame_max`, `frame_step`, `aspect_min`, `aspect_max`, `canonical_frames` | **Load-bearing.** They decide which frames a shell may ask for, and admission runs the whole matrix at each canonical one. |
 | `background` | **Load-bearing.** An `Opaque` or `Cedeable` claim is proven against the emitted ink. |
 | `draw` | **Load-bearing.** Refusing to draw any case fails admission. |
 | `extreme_states` | **Load-bearing.** Each one multiplies the case matrix. |
 | `id`, `title` | Validated at registry init: charset, non-empty. |
 | `config_schema` | Validated at init (keys strictly ascending). Admission always draws the empty config. |
 | `group_regions` | **Declared, not currently read by admission.** See below. |
-| `raster_baseline` | Inert unless the panel is in a set the raster tests cover. |
+| `raster_baselines` | Inert unless the panel is in a set the raster tests cover. Each entry must name a canonical frame. |
 
 ### `required_layers` — declare what you always emit
 
@@ -86,6 +86,40 @@ its resolved status — the template's airspeed folds `Trust`, so
 withholding `Trust` genuinely dashes the number — that group belongs in
 the mask.
 
+### The frame range — declare what you can lay out against
+
+`draw` receives the frame as an argument, alongside the state, the
+config blob, and the alerts. Read it. A geometry constant that should
+have been `frame.width` is a panel that quietly ignores the size it was
+given, and no test can tell the difference while the declared range has
+one frame in it.
+
+The frame is deliberately *not* a config key. Configuration is an
+optional schema-gated blob and the admission harness draws the empty one
+on purpose, so a panel that took its size from configuration would be
+unadmittable by construction.
+
+What the registry checks at init:
+
+- `frame_min` and `frame_max` finite and positive, `min <= max` per
+  axis. `frame_min` is the readability floor — it is where conspicuity
+  has to hold, and it is the frame `group_regions` are validated
+  against.
+- `frame_step` finite and positive per axis. Admissible dimensions are
+  `frame_min + k * step`, exactly: the check applies no tolerance, so a
+  step that cannot express your frames is a declaration to fix.
+- Aspect bounds finite, positive, `min <= max`.
+- `canonical_frames` non-empty, containing both `frame_min` and
+  `frame_max`, with every entry in range, on the grid, and inside the
+  aspect bounds. The corners alone are not enough: 600×360 sits inside a
+  480×360-to-600×450 range on both axes and is a shape a 4:3 layout
+  never declared, which is what the aspect check is for.
+
+A fixed-layout panel declares `frame_min == frame_max`, one canonical
+frame, and any positive step — the honest statement that a shell may
+only ask for the size the geometry was authored for. Every shipped panel
+does exactly that today.
+
 ### The honesty rules, and their asymmetry
 
 This is the part of the contract that is easiest to get exactly
@@ -113,7 +147,7 @@ Two corollaries fall out of the same machinery:
 `Opaque` and `Cedeable` both promise a full-frame opaque cover, and
 admission proves it against the ink rather than taking the word: it
 looks for one axis-aligned, full-alpha rect fill covering the whole
-design frame in the `Background` band. A ground assembled from polygons,
+frame the panel was drawn at, in the `Background` band. A ground assembled from polygons,
 painted at alpha below full, drawn under a rotated transform, or under a
 clip that does not contain the frame **does not count**, and fails as
 `BackgroundContract`. A clip that does contain the frame is fine.
@@ -125,7 +159,7 @@ and composes as an overlay.
 ### `group_regions` — declared, and not yet load-bearing
 
 Regions say which surface of the panel a group's readout owns. They are
-validated for geometry at registry init — inside the frame, non-
+validated for geometry at registry init — inside `frame_min`, non-
 degenerate, only for groups the panel requires — and **admission does
 not currently read them**. The conformance crate says so in its own
 module documentation, and this contract will not paper over it.
@@ -150,12 +184,14 @@ Run it before opening a pull request, not after CI tells you:
 cargo test -p <your set crate>
 ```
 
-Per case — canonical states plus your extreme states, each fully fed and
-then once per withheld group — the harness checks that the draw returns,
-that the scene decodes and satisfies the layer envelope, that every
-required layer is present, that the background claim holds, that every
-glyph is in the controlled vocabulary, and that the provenance rules
-above hold. Ink outside the design frame is **counted, not refused** —
+Per case — every canonical frame × canonical states plus your extreme
+states, each fully fed and then once per withheld group — the harness
+checks that the draw returns, that the scene decodes and satisfies the
+layer envelope, that every required layer is present, that the
+background claim holds, that every glyph is in the controlled
+vocabulary, and that the provenance rules above hold. Every geometry
+check uses the frame being drawn, not a constant. Ink outside that frame
+is **counted, not refused** —
 and the ratchet that keeps the count from growing is an assertion *you*
 write in your own admission test, not something the harness does for
 you. A new set has no ratchet until its author pins one.
@@ -198,22 +234,27 @@ the vocabulary before inventing one.
 ## Digests, baselines, and who re-pins them
 
 - **The composition digest** covers the panels a registry composes, in
-  order, with their contract-relevant descriptor fields and their
-  emitted bytes. Adding a panel to a shipped set moves it. Set identity
-  is deliberately *not* in the digest, so publishing a new set does not
-  disturb a shell that does not compose it.
+  order, with their contract-relevant descriptor fields — the frame
+  range among them — and their bytes emitted per canonical state ×
+  canonical frame. Adding a panel to a shipped set moves it, and so does
+  widening a declared range. Set identity is deliberately *not* in the
+  digest, so publishing a new set does not disturb a shell that does not
+  compose it. Raster baselines are deliberately *not* in it either: they
+  pin one backend's pixels, and re-pinning them must not move
+  cross-shell identity.
 - **Who re-pins:** the author of the change that moves it, in the same
   change, with the reason in the commit message. Consumers advance their
   pins on the discipline in `README.md`. A digest that moves without a
   stated reason is indistinguishable from a regression.
-- **Raster baselines** are per-panel pinned frame hashes over the shared
-  typical state, asserted by the reference rasterizer (REN-03). A
-  mismatch means the paint changed. It is a regression unless the change
-  deliberately moved paint, in which case it re-pins once, for a stated
-  reason — never refreshed to make a red build green.
-- A new set outside `BUILTIN_PANELS` may leave `raster_baseline` at
-  `None` until it has rasterizer coverage; nothing asserts a baseline
-  that was never declared.
+- **Raster baselines** are per-panel, per-canonical-frame pinned frame
+  hashes over the shared typical state, asserted by the reference
+  rasterizer (REN-03). A mismatch means the paint changed. It is a
+  regression unless the change deliberately moved paint, in which case
+  it re-pins once, for a stated reason — never refreshed to make a red
+  build green.
+- A new set outside `BUILTIN_PANELS` may leave `raster_baselines` empty
+  until it has rasterizer coverage; nothing asserts a baseline that was
+  never declared.
 
 Contract values that a consumer pins — the state ABI, the scene format,
 the corpus, the composition digest, the shipped panel set — are named

--- a/sets/indicate-instrument-panels/src/alert_stack_tests.rs
+++ b/sets/indicate-instrument-panels/src/alert_stack_tests.rs
@@ -13,7 +13,7 @@ use indicate_instrument_scene::SceneWriter;
 use indicate_instrument_state::{PanelData, SignalStatus};
 
 use crate::pfd::tests::{flying, texts};
-use crate::{PfdConfig, draw_hsi, draw_pfd};
+use crate::{BUILTIN_FRAME, PfdConfig, draw_hsi, draw_pfd};
 
 fn stepped(events: &[AlertEvent], healthy: bool) -> AlertOutput {
     let mut manager = AlertManager::new();
@@ -38,7 +38,7 @@ fn saturated() -> AlertOutput {
 fn pfd_scene(data: &PanelData, alerts: Option<&AlertOutput>) -> Vec<u8> {
     let mut buf = std::vec![0u8; 32 * 1024];
     let mut w = SceneWriter::new(&mut buf).expect("fits");
-    draw_pfd(data, &PfdConfig::default(), alerts, &mut w).expect("pfd fits");
+    draw_pfd(data, &PfdConfig::default(), alerts, BUILTIN_FRAME, &mut w).expect("pfd fits");
     let len = w.finish();
     buf.truncate(len);
     buf
@@ -47,7 +47,7 @@ fn pfd_scene(data: &PanelData, alerts: Option<&AlertOutput>) -> Vec<u8> {
 fn hsi_scene(data: &PanelData, alerts: Option<&AlertOutput>) -> Vec<u8> {
     let mut buf = std::vec![0u8; 32 * 1024];
     let mut w = SceneWriter::new(&mut buf).expect("fits");
-    draw_hsi(data, alerts, &mut w).expect("hsi fits");
+    draw_hsi(data, alerts, BUILTIN_FRAME, &mut w).expect("hsi fits");
     let len = w.finish();
     buf.truncate(len);
     buf

--- a/sets/indicate-instrument-panels/src/descriptors.rs
+++ b/sets/indicate-instrument-panels/src/descriptors.rs
@@ -2,37 +2,54 @@
 //! composes (ADR-0029, ADR-0033).
 //!
 //! Each descriptor owns its panel's full contract — identity, masks,
-//! required groups, honest-status regions, its own extreme states, and
-//! the pinned raster baseline — so a shell consumes composition data
-//! and never holds a panel list, index, or mask of its own.
+//! required groups, the frame range it lays out against, honest-status
+//! regions, its own extreme states, and the pinned raster baselines —
+//! so a shell consumes composition data and never holds a panel list,
+//! index, or mask of its own.
+
+mod extreme_states;
 
 use indicate_alerts::AlertOutput;
 use indicate_instrument_descriptor::{
     BackgroundCapability, ConfigBlob, DesignFrame, ExtremeState, GroupSet, PanelDescriptor,
-    PanelDrawError, PanelSet, Region, states,
+    PanelDrawError, PanelSet, Region,
 };
 use indicate_instrument_scene::{LayerId, SceneWriter};
-use indicate_instrument_state::{
-    AirData, AircraftState, Attitude, DynSample, FdEngagement, FdMode, FdSample, GroupId,
-    HeadingReference, HeadingSample, Kinematics, MonitorText, NavData, NavFromTo, NavSource,
-    PanelData, Quat, Stamped, TextLine, TurnBasis, TurnSample,
-};
+use indicate_instrument_state::{GroupId, PanelData};
 
 use crate::pfd::PFD_CONFIG_SCHEMA;
-use crate::{PANEL_H, PANEL_W, PfdConfig, draw_hsi, draw_pfd};
+use crate::{BUILTIN_FRAME, PfdConfig, draw_hsi, draw_pfd};
 
 const fn layer_bit(layer: LayerId) -> u8 {
     1u8 << layer.to_u8()
 }
 
+/// Every panel here declares one admissible frame, so the only whole
+/// multiple of the step that lands in range is zero and every positive
+/// step describes the same admissible set. The registry asks only that
+/// it be positive.
+const FRAME_STEP: (f32, f32) = (1.0, 1.0);
+
+/// A bracket around the shipped 4:3 ratio rather than an equality: the
+/// frame's ratio is an f32 division, and a bound written as a decimal
+/// literal would not reliably equal it.
+const ASPECT_MIN: f32 = 1.30;
+/// Upper end of the supported width/height ratio.
+const ASPECT_MAX: f32 = 1.37;
+
+/// The pinned evidence sizes: one frame, which is both the floor and
+/// the ceiling of the declared range.
+const CANONICAL_FRAMES: &[DesignFrame] = &[BUILTIN_FRAME];
+
 fn draw_pfd_panel(
     data: &PanelData,
     config: &ConfigBlob<'_>,
     alerts: Option<&AlertOutput>,
+    frame: DesignFrame,
     scene: &mut SceneWriter<'_>,
 ) -> Result<(), PanelDrawError> {
-    let cfg = PfdConfig::from_config(config)?;
-    draw_pfd(data, &cfg, alerts, scene)?;
+    let cfg = PfdConfig::from_config(config, frame)?;
+    draw_pfd(data, &cfg, alerts, frame, scene)?;
     Ok(())
 }
 
@@ -40,13 +57,14 @@ fn draw_hsi_panel(
     data: &PanelData,
     config: &ConfigBlob<'_>,
     alerts: Option<&AlertOutput>,
+    frame: DesignFrame,
     scene: &mut SceneWriter<'_>,
 ) -> Result<(), PanelDrawError> {
     // The HSI takes no configuration; the empty schema makes any keyed
     // blob a shell-side rejection before this runs, and a re-check here
     // keeps the property when a shell skips its gate.
     config.require_schema(HSI_DESCRIPTOR.config_schema)?;
-    draw_hsi(data, alerts, scene)?;
+    draw_hsi(data, alerts, frame, scene)?;
     Ok(())
 }
 
@@ -68,10 +86,12 @@ pub const PFD_DESCRIPTOR: PanelDescriptor = PanelDescriptor {
         GroupId::Dynamics,
         GroupId::FlightDirector,
     ]),
-    design_frame: DesignFrame {
-        width: PANEL_W,
-        height: PANEL_H,
-    },
+    frame_min: BUILTIN_FRAME,
+    frame_max: BUILTIN_FRAME,
+    frame_step: FRAME_STEP,
+    aspect_min: ASPECT_MIN,
+    aspect_max: ASPECT_MAX,
+    canonical_frames: CANONICAL_FRAMES,
     background: BackgroundCapability::Cedeable,
     config_schema: PFD_CONFIG_SCHEMA,
     // Value-readout surfaces, keyed by the group whose data the number
@@ -147,21 +167,25 @@ pub const PFD_DESCRIPTOR: PanelDescriptor = PanelDescriptor {
     extreme_states: &[
         ExtremeState {
             id: "unusual-inverted",
-            build: pfd_unusual_inverted,
+            build: extreme_states::pfd_unusual_inverted,
         },
         ExtremeState {
             id: "readout-extremes",
-            build: pfd_readout_extremes,
+            build: extreme_states::pfd_readout_extremes,
         },
         ExtremeState {
             id: "director-engaged",
-            build: pfd_director_engaged,
+            build: extreme_states::pfd_director_engaged,
         },
     ],
-    // Reference-rasterizer frame hash over the shared typical state —
-    // pinned per panel here so a panel travels with its own regression
-    // baseline; the raster crate asserts it (REN-03).
-    raster_baseline: Some("43b49bde6bbf7372d704d54214d4a3d0b9cd3ad09e86862a8ffc20fd6ae05ef1"),
+    // Reference-rasterizer frame hash over the shared typical state, one
+    // per canonical frame — pinned per panel here so a panel travels
+    // with its own regression baselines; the raster crate asserts them
+    // (REN-03).
+    raster_baselines: &[(
+        BUILTIN_FRAME,
+        "43b49bde6bbf7372d704d54214d4a3d0b9cd3ad09e86862a8ffc20fd6ae05ef1",
+    )],
     draw: draw_pfd_panel,
 };
 
@@ -182,10 +206,12 @@ pub const HSI_DESCRIPTOR: PanelDescriptor = PanelDescriptor {
         GroupId::Heading,
         GroupId::Variation,
     ]),
-    design_frame: DesignFrame {
-        width: PANEL_W,
-        height: PANEL_H,
-    },
+    frame_min: BUILTIN_FRAME,
+    frame_max: BUILTIN_FRAME,
+    frame_step: FRAME_STEP,
+    aspect_min: ASPECT_MIN,
+    aspect_max: ASPECT_MAX,
+    canonical_frames: CANONICAL_FRAMES,
     background: BackgroundCapability::Opaque,
     config_schema: &[],
     group_regions: &[
@@ -244,14 +270,17 @@ pub const HSI_DESCRIPTOR: PanelDescriptor = PanelDescriptor {
     extreme_states: &[
         ExtremeState {
             id: "reciprocal-course",
-            build: hsi_reciprocal_course,
+            build: extreme_states::hsi_reciprocal_course,
         },
         ExtremeState {
             id: "track-up",
-            build: hsi_track_up,
+            build: extreme_states::hsi_track_up,
         },
     ],
-    raster_baseline: Some("66653ce135e6f2163fa48d805a0ab1a8f3d0ac51d778f7b1eb2aa4ec05bfbb7c"),
+    raster_baselines: &[(
+        BUILTIN_FRAME,
+        "66653ce135e6f2163fa48d805a0ab1a8f3d0ac51d778f7b1eb2aa4ec05bfbb7c",
+    )],
     draw: draw_hsi_panel,
 };
 
@@ -259,10 +288,11 @@ fn draw_monitor_panel(
     data: &PanelData,
     config: &ConfigBlob<'_>,
     alerts: Option<&AlertOutput>,
+    frame: DesignFrame,
     scene: &mut SceneWriter<'_>,
 ) -> Result<(), PanelDrawError> {
     config.require_schema(MONITOR_DESCRIPTOR.config_schema)?;
-    crate::monitor::draw_monitor(data, alerts, scene)?;
+    crate::monitor::draw_monitor(data, alerts, frame, scene)?;
     Ok(())
 }
 
@@ -274,10 +304,12 @@ pub const MONITOR_DESCRIPTOR: PanelDescriptor = PanelDescriptor {
     title: "Monitor",
     required_layers: layer_bit(LayerId::Tapes) | layer_bit(LayerId::Annunciation),
     required_groups: GroupSet::of(&[GroupId::MonitorText]),
-    design_frame: DesignFrame {
-        width: PANEL_W,
-        height: PANEL_H,
-    },
+    frame_min: BUILTIN_FRAME,
+    frame_max: BUILTIN_FRAME,
+    frame_step: FRAME_STEP,
+    aspect_min: ASPECT_MIN,
+    aspect_max: ASPECT_MAX,
+    canonical_frames: CANONICAL_FRAMES,
     // The panel owns its band with an opaque ground: text needs it, and
     // declaring anything weaker would hand a compositor a black
     // rectangle it was told is not painted.
@@ -296,151 +328,14 @@ pub const MONITOR_DESCRIPTOR: PanelDescriptor = PanelDescriptor {
     )],
     extreme_states: &[ExtremeState {
         id: "full-channel",
-        build: monitor_full_channel,
+        build: extreme_states::monitor_full_channel,
     }],
-    raster_baseline: Some("40f44383f3ad46a0bbd65f04afc1d80fb9d94c11acff8dc66edbfcf7b8fa4c01"),
+    raster_baselines: &[(
+        BUILTIN_FRAME,
+        "40f44383f3ad46a0bbd65f04afc1d80fb9d94c11acff8dc66edbfcf7b8fa4c01",
+    )],
     draw: draw_monitor_panel,
 };
-
-/// Inverted, nose-low, rolling hard: the unusual-attitude tier, the
-/// recovery chevrons, and the pitch ladder far from level — the PFD's
-/// own hardest drawing, unreachable from the gentle shared corpus.
-fn pfd_unusual_inverted() -> AircraftState {
-    let mut state = states::typical();
-    state.attitude = Stamped {
-        data: Some(Attitude {
-            quat: Quat::from_euler(2.8, -0.9, 4.0),
-            rates_rps: [1.5, -0.8, 0.9],
-        }),
-        age_ms: Some(40.0),
-    };
-    state.dynamics = Stamped {
-        data: Some(DynSample {
-            turn: Some(TurnSample {
-                rate_rps: -0.6,
-                basis: TurnBasis::HeadingRate,
-            }),
-            lateral_mps2: 3.5.into(),
-        }),
-        age_ms: Some(40.0),
-    };
-    state
-}
-
-/// Wide and negative readout values — the DISP-02 fit cases ("10300",
-/// "-1030"-class) — plus the heading on the 360/0 wrap.
-fn pfd_readout_extremes() -> AircraftState {
-    let mut state = states::typical();
-    state.air = Stamped {
-        data: Some(AirData {
-            ias_mps: Some(199.0),
-            baro_setting_hpa: Some(1049.7),
-        }),
-        age_ms: Some(40.0),
-    };
-    state.kinematics = Stamped {
-        data: Some(Kinematics {
-            pos_ned_m: [0.0, 0.0, 320.0],
-            vel_ned_mps: [-90.0, -2.0, 18.0],
-        }),
-        age_ms: Some(40.0),
-    };
-    state.heading = Stamped {
-        data: Some(HeadingSample {
-            heading_rad: 6.2828,
-            reference: HeadingReference::SimLocalTrue,
-        }),
-        age_ms: Some(40.0),
-    };
-    state
-}
-
-/// Course exactly reciprocal to the flown track, full-scale deviation,
-/// a zero-distance waypoint, and a heading on the 360/0 wrap.
-fn hsi_reciprocal_course() -> AircraftState {
-    let mut state = states::typical();
-    state.nav = Stamped {
-        data: Some(NavData {
-            source: NavSource::Gps,
-            // Exactly pi from the wrapped heading this fixture sets:
-            // the reciprocal the state id names, not an inherited one.
-            course_rad: 3.1412,
-            cdi_dots: -2.5,
-            fromto: NavFromTo::From,
-            vdev_dots: Some(2.5),
-            dist_nm: Some(0.0),
-            course_reference: HeadingReference::SimLocalTrue,
-            ..NavData::default()
-        }),
-        age_ms: Some(40.0),
-    };
-    state.heading = Stamped {
-        data: Some(HeadingSample {
-            heading_rad: 6.2828,
-            reference: HeadingReference::SimLocalTrue,
-        }),
-        age_ms: Some(40.0),
-    };
-    state
-}
-
-/// An engaged director commanding away from the current attitude: the
-/// dual-cue bars deflect in both axes and the mode annunciates. The
-/// withholding matrix then proves the bars and the mode label vanish
-/// with the group.
-fn pfd_director_engaged() -> AircraftState {
-    let mut state = states::typical();
-    state.director = Stamped {
-        data: Some(FdSample {
-            pitch_cmd_rad: 0.09,
-            roll_cmd_rad: -0.35,
-            mode: FdMode::Nav,
-            engagement: FdEngagement::Engaged,
-        }),
-        age_ms: Some(60.0),
-    };
-    state
-}
-
-/// The data-gateway profile (#260): a certified GPS navigator bridged
-/// over its serial protocol publishes position, track, and guidance —
-/// and no magnetic heading at all. The rose must present track-up,
-/// annunciated TRK, instead of going structurally inert.
-fn hsi_track_up() -> AircraftState {
-    let mut state = states::typical();
-    state.heading = Stamped {
-        data: None,
-        age_ms: None,
-    };
-    state
-}
-
-/// Eight maximum-length lines: the channel's full frame budget against
-/// the glyph vocabulary, with digits in every row for the honest-status
-/// family to police.
-fn monitor_full_channel() -> AircraftState {
-    let mut state = states::typical();
-    let mut lines = [TextLine::EMPTY; MonitorText::MAX_LINES];
-    for (row, slot) in lines.iter_mut().enumerate() {
-        let text = match row {
-            0 => "0123456789 ABCDEFGHIJKLMNOPQRS-.",
-            1 => "ENG 1 N1 101.5 EGT 899 FF 1204.7",
-            2 => "ENG 2 N1 100.9 EGT 901 FF 1198.2",
-            3 => "FUEL L 1250.5 R 1248.0 CTR 890.4",
-            4 => "HYD A 2987 B 3011 ELEC 28.4 27.9",
-            5 => "GEAR DOWN-LOCKED FLAPS 25 TRIM 4",
-            6 => "CABIN ALT 6500 RATE -300 DIFF 7.",
-            7 => "WXYZ-0123456789.0123456789-WXYZ.",
-            _ => "",
-        };
-        *slot = TextLine::new(text).unwrap_or(TextLine::EMPTY);
-    }
-    state.monitor_text = Stamped {
-        data: Some(MonitorText::new(9, &lines).unwrap_or_default()),
-        age_ms: Some(120.0),
-    };
-    state
-}
 
 /// The panels this crate ships, in shell display order.
 pub const BUILTIN_PANELS: &[PanelDescriptor] =
@@ -466,7 +361,7 @@ pub const BUILTIN_SET: PanelSet = PanelSet {
 /// value moves once per deliberate contract change, re-pinned with a
 /// review note saying why.
 pub const BUILTIN_SCENE_DIGEST: &str =
-    "bd85b8537f0b3e4abf8cf3ad3d36c6abfdceac15355639af2804d58dd9c61931";
+    "3efb08c55eadadc2b006ee6b006b29e4b3a3f8d4ec3ce1324f401dbc16dc85ca";
 
 #[cfg(test)]
 mod digest_tests;

--- a/sets/indicate-instrument-panels/src/descriptors/extreme_states.rs
+++ b/sets/indicate-instrument-panels/src/descriptors/extreme_states.rs
@@ -1,0 +1,150 @@
+//! The stress fixtures each shipped panel contributes beyond the shared
+//! canonical corpus: the situations a panel's own geometry makes hard,
+//! which no state authored for the whole family reaches.
+
+use indicate_instrument_descriptor::states;
+use indicate_instrument_state::{
+    AirData, AircraftState, Attitude, DynSample, FdEngagement, FdMode, FdSample, HeadingReference,
+    HeadingSample, Kinematics, MonitorText, NavData, NavFromTo, NavSource, Quat, Stamped, TextLine,
+    TurnBasis, TurnSample,
+};
+
+/// Inverted, nose-low, rolling hard: the unusual-attitude tier, the
+/// recovery chevrons, and the pitch ladder far from level — the PFD's
+/// own hardest drawing, unreachable from the gentle shared corpus.
+pub(super) fn pfd_unusual_inverted() -> AircraftState {
+    let mut state = states::typical();
+    state.attitude = Stamped {
+        data: Some(Attitude {
+            quat: Quat::from_euler(2.8, -0.9, 4.0),
+            rates_rps: [1.5, -0.8, 0.9],
+        }),
+        age_ms: Some(40.0),
+    };
+    state.dynamics = Stamped {
+        data: Some(DynSample {
+            turn: Some(TurnSample {
+                rate_rps: -0.6,
+                basis: TurnBasis::HeadingRate,
+            }),
+            lateral_mps2: 3.5.into(),
+        }),
+        age_ms: Some(40.0),
+    };
+    state
+}
+
+/// Wide and negative readout values — the DISP-02 fit cases ("10300",
+/// "-1030"-class) — plus the heading on the 360/0 wrap.
+pub(super) fn pfd_readout_extremes() -> AircraftState {
+    let mut state = states::typical();
+    state.air = Stamped {
+        data: Some(AirData {
+            ias_mps: Some(199.0),
+            baro_setting_hpa: Some(1049.7),
+        }),
+        age_ms: Some(40.0),
+    };
+    state.kinematics = Stamped {
+        data: Some(Kinematics {
+            pos_ned_m: [0.0, 0.0, 320.0],
+            vel_ned_mps: [-90.0, -2.0, 18.0],
+        }),
+        age_ms: Some(40.0),
+    };
+    state.heading = Stamped {
+        data: Some(HeadingSample {
+            heading_rad: 6.2828,
+            reference: HeadingReference::SimLocalTrue,
+        }),
+        age_ms: Some(40.0),
+    };
+    state
+}
+
+/// An engaged director commanding away from the current attitude: the
+/// dual-cue bars deflect in both axes and the mode annunciates. The
+/// withholding matrix then proves the bars and the mode label vanish
+/// with the group.
+pub(super) fn pfd_director_engaged() -> AircraftState {
+    let mut state = states::typical();
+    state.director = Stamped {
+        data: Some(FdSample {
+            pitch_cmd_rad: 0.09,
+            roll_cmd_rad: -0.35,
+            mode: FdMode::Nav,
+            engagement: FdEngagement::Engaged,
+        }),
+        age_ms: Some(60.0),
+    };
+    state
+}
+
+/// Course exactly reciprocal to the flown track, full-scale deviation,
+/// a zero-distance waypoint, and a heading on the 360/0 wrap.
+pub(super) fn hsi_reciprocal_course() -> AircraftState {
+    let mut state = states::typical();
+    state.nav = Stamped {
+        data: Some(NavData {
+            source: NavSource::Gps,
+            // Exactly pi from the wrapped heading this fixture sets:
+            // the reciprocal the state id names, not an inherited one.
+            course_rad: 3.1412,
+            cdi_dots: -2.5,
+            fromto: NavFromTo::From,
+            vdev_dots: Some(2.5),
+            dist_nm: Some(0.0),
+            course_reference: HeadingReference::SimLocalTrue,
+            ..NavData::default()
+        }),
+        age_ms: Some(40.0),
+    };
+    state.heading = Stamped {
+        data: Some(HeadingSample {
+            heading_rad: 6.2828,
+            reference: HeadingReference::SimLocalTrue,
+        }),
+        age_ms: Some(40.0),
+    };
+    state
+}
+
+/// The data-gateway profile: a certified GPS navigator bridged
+/// over its serial protocol publishes position, track, and guidance —
+/// and no magnetic heading at all. The rose must present track-up,
+/// annunciated TRK, instead of going structurally inert.
+pub(super) fn hsi_track_up() -> AircraftState {
+    let mut state = states::typical();
+    state.heading = Stamped {
+        data: None,
+        age_ms: None,
+    };
+    state
+}
+
+/// Eight maximum-length lines: the channel's full frame budget against
+/// the glyph vocabulary, with digits in every row for the honest-status
+/// family to police.
+pub(super) fn monitor_full_channel() -> AircraftState {
+    let mut state = states::typical();
+    let mut lines = [TextLine::EMPTY; MonitorText::MAX_LINES];
+    for (row, slot) in lines.iter_mut().enumerate() {
+        let text = match row {
+            0 => "0123456789 ABCDEFGHIJKLMNOPQRS-.",
+            1 => "ENG 1 N1 101.5 EGT 899 FF 1204.7",
+            2 => "ENG 2 N1 100.9 EGT 901 FF 1198.2",
+            3 => "FUEL L 1250.5 R 1248.0 CTR 890.4",
+            4 => "HYD A 2987 B 3011 ELEC 28.4 27.9",
+            5 => "GEAR DOWN-LOCKED FLAPS 25 TRIM 4",
+            6 => "CABIN ALT 6500 RATE -300 DIFF 7.",
+            7 => "WXYZ-0123456789.0123456789-WXYZ.",
+            _ => "",
+        };
+        *slot = TextLine::new(text).unwrap_or(TextLine::EMPTY);
+    }
+    state.monitor_text = Stamped {
+        data: Some(MonitorText::new(9, &lines).unwrap_or_default()),
+        age_ms: Some(120.0),
+    };
+    state
+}

--- a/sets/indicate-instrument-panels/src/descriptors/tests.rs
+++ b/sets/indicate-instrument-panels/src/descriptors/tests.rs
@@ -11,7 +11,7 @@ use indicate_instrument_state::{
 };
 
 use super::{BUILTIN_PANELS, HSI_DESCRIPTOR, PFD_DESCRIPTOR};
-use crate::{BackgroundMode, PfdConfig, draw_hsi, draw_pfd};
+use crate::{BUILTIN_FRAME, BackgroundMode, PfdConfig, draw_hsi, draw_pfd};
 
 fn resolved() -> PanelData {
     let state = AircraftState {
@@ -39,7 +39,7 @@ fn scene_via_descriptor(
     let data = resolved();
     let mut buf = vec![0u8; 64 * 1024];
     let mut writer = SceneWriter::new(&mut buf).expect("fits");
-    (descriptor.draw)(&data, config, None, &mut writer).expect("draws");
+    (descriptor.draw)(&data, config, None, BUILTIN_FRAME, &mut writer).expect("draws");
     let used = writer.finish();
     buf[..used].to_vec()
 }
@@ -65,7 +65,7 @@ fn the_monitor_stress_fixture_rows_are_full() {
     // silently emptied would weaken the stress case without failing
     // anything. Every row must be exactly at capacity.
     use indicate_instrument_state::TextLine;
-    let state = super::monitor_full_channel();
+    let state = super::extreme_states::monitor_full_channel();
     let text = state.monitor_text.data.expect("fixture feeds the channel");
     assert!(!text.is_malformed());
     for (row, line) in text.lines().iter().enumerate() {
@@ -87,7 +87,14 @@ fn descriptor_draws_match_the_direct_entry_points() {
     let data = resolved();
     let mut direct_buf = vec![0u8; 64 * 1024];
     let mut writer = SceneWriter::new(&mut direct_buf).expect("fits");
-    draw_pfd(&data, &PfdConfig::default(), None, &mut writer).expect("draws");
+    draw_pfd(
+        &data,
+        &PfdConfig::default(),
+        None,
+        BUILTIN_FRAME,
+        &mut writer,
+    )
+    .expect("draws");
     let used = writer.finish();
     assert_eq!(
         scene_via_descriptor(&PFD_DESCRIPTOR, &EMPTY_CONFIG),
@@ -97,7 +104,7 @@ fn descriptor_draws_match_the_direct_entry_points() {
 
     let mut hsi_buf = vec![0u8; 64 * 1024];
     let mut writer = SceneWriter::new(&mut hsi_buf).expect("fits");
-    draw_hsi(&data, None, &mut writer).expect("draws");
+    draw_hsi(&data, None, BUILTIN_FRAME, &mut writer).expect("draws");
     let used = writer.finish();
     assert_eq!(
         scene_via_descriptor(&HSI_DESCRIPTOR, &EMPTY_CONFIG),
@@ -131,7 +138,7 @@ fn svs_background_cedes_exactly_like_none() {
         };
         let mut buf = vec![0u8; 64 * 1024];
         let mut writer = SceneWriter::new(&mut buf).expect("fits");
-        draw_pfd(&data, &cfg, None, &mut writer).expect("draws");
+        draw_pfd(&data, &cfg, None, BUILTIN_FRAME, &mut writer).expect("draws");
         let used = writer.finish();
         scenes.push(buf[..used].to_vec());
     }
@@ -155,7 +162,7 @@ fn an_svs_config_blob_decodes_and_still_cedes() {
     bytes.extend_from_slice(&1u16.to_le_bytes());
     bytes.push(1);
     let blob = ConfigBlob::parse(&bytes).expect("well-formed");
-    let cfg = PfdConfig::from_config(&blob).expect("decodes");
+    let cfg = PfdConfig::from_config(&blob, BUILTIN_FRAME).expect("decodes");
     assert!(matches!(
         cfg.background,
         BackgroundMode::Svs { quality: 1, .. }
@@ -187,7 +194,7 @@ fn svs_keys_are_validated_and_refused_when_inert() {
     bytes.extend_from_slice(&[1, 2, 3]);
     let blob = ConfigBlob::parse(&bytes).expect("well-formed framing");
     assert_eq!(
-        PfdConfig::from_config(&blob),
+        PfdConfig::from_config(&blob, BUILTIN_FRAME),
         Err(ConfigError::BadValue {
             key: keys::SVS_VIEWPORT.0,
             len: 3,
@@ -206,7 +213,7 @@ fn svs_keys_are_validated_and_refused_when_inert() {
     }
     let blob = ConfigBlob::parse(&inert).expect("well-formed framing");
     assert_eq!(
-        PfdConfig::from_config(&blob),
+        PfdConfig::from_config(&blob, BUILTIN_FRAME),
         Err(ConfigError::InertKey {
             key: keys::SVS_VIEWPORT.0,
         })
@@ -223,7 +230,7 @@ fn svs_keys_are_validated_and_refused_when_inert() {
     }
     let blob = ConfigBlob::parse(&outside).expect("well-formed framing");
     assert_eq!(
-        PfdConfig::from_config(&blob),
+        PfdConfig::from_config(&blob, BUILTIN_FRAME),
         Err(ConfigError::BadValue {
             key: keys::SVS_VIEWPORT.0,
             len: 16,
@@ -242,7 +249,7 @@ fn a_collapsed_v_speed_ladder_is_refused() {
     }
     let blob = ConfigBlob::parse(&bytes).expect("well-formed framing");
     assert_eq!(
-        PfdConfig::from_config(&blob),
+        PfdConfig::from_config(&blob, BUILTIN_FRAME),
         Err(ConfigError::BadValue {
             key: keys::V_SPEEDS.0,
             len: 20,
@@ -260,5 +267,5 @@ fn the_hsi_rejects_any_configuration_key() {
     let data = resolved();
     let mut buf = vec![0u8; 64 * 1024];
     let mut writer = SceneWriter::new(&mut buf).expect("fits");
-    assert!((HSI_DESCRIPTOR.draw)(&data, &blob, None, &mut writer).is_err());
+    assert!((HSI_DESCRIPTOR.draw)(&data, &blob, None, BUILTIN_FRAME, &mut writer).is_err());
 }

--- a/sets/indicate-instrument-panels/src/hsi.rs
+++ b/sets/indicate-instrument-panels/src/hsi.rs
@@ -2,13 +2,12 @@
 //! bug, ground-track diamond, course deviation indicator, and data boxes.
 
 use indicate_alerts::AlertOutput;
+use indicate_instrument_descriptor::DesignFrame;
 use indicate_instrument_scene::{Anchor, LayerId, PaintMode, SceneError, SceneWriter};
 use indicate_instrument_state::HeadingReference;
 use indicate_instrument_state::{GroupId, NavSource, PanelData, RoseBasis, SignalStatus};
 
 use indicate_instrument_symbology::{annunciation, palette, safety, source_label, status_paint};
-
-use crate::{PANEL_H, PANEL_W};
 
 mod boxes;
 mod cdi;
@@ -28,11 +27,12 @@ pub(crate) const ROSE_R: f32 = 160.0;
 pub fn draw_hsi(
     data: &PanelData,
     alerts: Option<&AlertOutput>,
+    frame: DesignFrame,
     scene: &mut SceneWriter<'_>,
 ) -> Result<(), SceneError> {
     scene.begin_layer(LayerId::Background)?;
     scene.fill_color(palette::BLACK)?;
-    scene.rect(PaintMode::Fill, 0.0, 0.0, PANEL_W, PANEL_H)?;
+    scene.rect(PaintMode::Fill, 0.0, 0.0, frame.width, frame.height)?;
     scene.end_layer(LayerId::Background)?;
 
     // The rose basis is resolve's selection — the same one every

--- a/sets/indicate-instrument-panels/src/hsi/source_tests.rs
+++ b/sets/indicate-instrument-panels/src/hsi/source_tests.rs
@@ -56,7 +56,7 @@ fn frame(
 fn texts(data: &PanelData) -> Vec<String> {
     let mut buf = std::vec![0u8; 32 * 1024];
     let mut writer = SceneWriter::new(&mut buf).expect("buffer fits");
-    super::draw_hsi(data, None, &mut writer).expect("panel fits buffer");
+    super::draw_hsi(data, None, crate::BUILTIN_FRAME, &mut writer).expect("panel fits buffer");
     let len = writer.finish();
     SceneCmds::new(&buf[..len])
         .expect("valid scene")

--- a/sets/indicate-instrument-panels/src/hsi/tests.rs
+++ b/sets/indicate-instrument-panels/src/hsi/tests.rs
@@ -9,6 +9,7 @@ use indicate_instrument_state::{
 };
 
 use super::draw_hsi;
+use crate::BUILTIN_FRAME;
 
 /// Heading comes from the explicit SIM-declared independent sample —
 /// the attitude quaternion still describes the same yaw, but nothing
@@ -53,7 +54,7 @@ fn quat_yaw(yaw: f32) -> indicate_instrument_state::Quat {
 fn render(data: &PanelData) -> Vec<u8> {
     let mut buf = std::vec![0u8; 32 * 1024];
     let mut w = SceneWriter::new(&mut buf).expect("fits");
-    draw_hsi(data, None, &mut w).expect("panel fits buffer");
+    draw_hsi(data, None, BUILTIN_FRAME, &mut w).expect("panel fits buffer");
     let len = w.finish();
     buf.truncate(len);
     buf

--- a/sets/indicate-instrument-panels/src/lib.rs
+++ b/sets/indicate-instrument-panels/src/lib.rs
@@ -1,11 +1,13 @@
 //! PFD and HSI panels as pure state→scene functions (ADR-0017).
 //!
 //! Each panel is a function from resolved display state
-//! ([`indicate_instrument_state::PanelData`]) to abstract drawing commands
+//! ([`indicate_instrument_state::PanelData`]) and a logical frame to
+//! abstract drawing commands
 //! ([`indicate_instrument_scene::SceneWriter`]); no panel knows what
-//! renders it. Panels draw in a fixed logical space of
-//! [`PANEL_W`]×[`PANEL_H`] units (the Garmin-G5 proportions the geometry
-//! constants come from); backends scale that space to their viewport.
+//! renders it. Every panel here declares [`BUILTIN_FRAME`] as its floor,
+//! its ceiling, and its one canonical size (the Garmin-G5 proportions
+//! the geometry constants come from), so the frame it is drawn at is
+//! always that one; backends scale it to their viewport.
 //!
 //! Signal statuses are honored, never hidden: `Missing` renders dashes,
 //! `Stale`/`Degraded` render amber flags, `Failed` renders a red X in
@@ -24,6 +26,8 @@ mod hsi;
 mod monitor;
 mod pfd;
 
+use indicate_instrument_descriptor::DesignFrame;
+
 pub use descriptors::{
     BUILTIN_PANELS, BUILTIN_SCENE_DIGEST, BUILTIN_SET, HSI_DESCRIPTOR, MONITOR_DESCRIPTOR,
     PFD_DESCRIPTOR,
@@ -32,8 +36,19 @@ pub use hsi::draw_hsi;
 pub use monitor::draw_monitor;
 pub use pfd::{BackgroundMode, PFD_CONFIG_SCHEMA, PfdConfig, SvsViewport, VSpeeds, draw_pfd};
 
-/// Logical panel width all panels draw against.
+/// Logical width of [`BUILTIN_FRAME`].
 pub const PANEL_W: f32 = 480.0;
 
-/// Logical panel height all panels draw against.
+/// Logical height of [`BUILTIN_FRAME`].
 pub const PANEL_H: f32 = 360.0;
+
+/// The one frame every panel in this set declares and is drawn at.
+///
+/// Panel geometry reads the frame it is handed, never this constant.
+/// The declared range is degenerate, so the two are the same value at
+/// every call a shell can make — which is what keeps the constant an
+/// honest name for the shipped size rather than a second source of it.
+pub const BUILTIN_FRAME: DesignFrame = DesignFrame {
+    width: PANEL_W,
+    height: PANEL_H,
+};

--- a/sets/indicate-instrument-panels/src/monitor.rs
+++ b/sets/indicate-instrument-panels/src/monitor.rs
@@ -9,11 +9,10 @@
 //! text.
 
 use indicate_alerts::AlertOutput;
+use indicate_instrument_descriptor::DesignFrame;
 use indicate_instrument_scene::{Anchor, LayerId, PaintMode, SceneError, SceneWriter};
 use indicate_instrument_state::{GroupId, PanelData, SignalStatus};
 use indicate_instrument_symbology::{annunciation, palette, safety, status_paint};
-
-use crate::{PANEL_H, PANEL_W};
 
 const LINE_H: f32 = 36.0;
 const TEXT_X: f32 = 24.0;
@@ -26,13 +25,14 @@ const FIRST_LINE_Y: f32 = 84.0;
 pub fn draw_monitor(
     data: &PanelData,
     alerts: Option<&AlertOutput>,
+    frame: DesignFrame,
     scene: &mut SceneWriter<'_>,
 ) -> Result<(), SceneError> {
     let channel = &data.monitor_text;
 
     scene.begin_layer(LayerId::Background)?;
     scene.fill_color(palette::BLACK)?;
-    scene.rect(PaintMode::Fill, 0.0, 0.0, PANEL_W, PANEL_H)?;
+    scene.rect(PaintMode::Fill, 0.0, 0.0, frame.width, frame.height)?;
     scene.end_layer(LayerId::Background)?;
 
     scene.begin_layer(LayerId::Tapes)?;
@@ -63,10 +63,10 @@ pub fn draw_monitor(
     scene.begin_layer(LayerId::Annunciation)?;
     match channel.status {
         SignalStatus::Failed => {
-            status_paint::draw_red_x(scene, 0.0, 0.0, PANEL_W, PANEL_H, "MON")?;
+            status_paint::draw_red_x(scene, 0.0, 0.0, frame.width, frame.height, "MON")?;
         }
         SignalStatus::Stale | SignalStatus::Degraded => {
-            status_paint::draw_flag(scene, PANEL_W - 60.0, 36.0, "MON")?;
+            status_paint::draw_flag(scene, frame.width - 60.0, 36.0, "MON")?;
         }
         SignalStatus::Missing | SignalStatus::Valid => {}
     }

--- a/sets/indicate-instrument-panels/src/pfd.rs
+++ b/sets/indicate-instrument-panels/src/pfd.rs
@@ -3,12 +3,11 @@
 //! tapes → symbology → annunciation, ADR-0017).
 
 use indicate_alerts::AlertOutput;
+use indicate_instrument_descriptor::DesignFrame;
 use indicate_instrument_scene::{Anchor, LayerId, PaintMode, SceneError, SceneWriter};
 use indicate_instrument_state::{ChevronSense, FdEngagement, GroupId, PanelData, SignalStatus};
 
 use indicate_instrument_symbology::{annunciation, palette, safety, source_label, status_paint};
-
-use crate::{PANEL_H, PANEL_W};
 
 mod horizon;
 mod panel_config;
@@ -96,6 +95,7 @@ pub fn draw_pfd(
     data: &PanelData,
     cfg: &PfdConfig,
     alerts: Option<&AlertOutput>,
+    frame: DesignFrame,
     scene: &mut SceneWriter<'_>,
 ) -> Result<(), SceneError> {
     let att_status = data.roll_rad.status.worst(data.pitch_rad.status);
@@ -105,10 +105,11 @@ pub fn draw_pfd(
         BackgroundMode::Horizon => {
             scene.begin_layer(LayerId::Background)?;
             scene.fill_color(palette::BLACK)?;
-            scene.rect(PaintMode::Fill, 0.0, 0.0, PANEL_W, PANEL_H)?;
+            scene.rect(PaintMode::Fill, 0.0, 0.0, frame.width, frame.height)?;
             if att_status.shows_value() {
                 horizon::draw_background(
                     scene,
+                    frame,
                     data.roll_rad.value,
                     data.pitch_rad.value,
                     data.presentation.min_reverse_band_rad,

--- a/sets/indicate-instrument-panels/src/pfd/director_tests.rs
+++ b/sets/indicate-instrument-panels/src/pfd/director_tests.rs
@@ -13,7 +13,7 @@ use indicate_instrument_state::{
     Stamped, resolve,
 };
 
-use crate::{PfdConfig, draw_pfd};
+use crate::{BUILTIN_FRAME, PfdConfig, draw_pfd};
 
 fn with_director(engagement: FdEngagement, age_ms: Option<f32>) -> PanelData {
     let state = AircraftState {
@@ -47,7 +47,14 @@ fn with_director(engagement: FdEngagement, age_ms: Option<f32>) -> PanelData {
 fn render(data: &PanelData) -> Vec<u8> {
     let mut buf = vec![0u8; 64 * 1024];
     let mut writer = SceneWriter::new(&mut buf).expect("fits");
-    draw_pfd(data, &PfdConfig::default(), None, &mut writer).expect("draws");
+    draw_pfd(
+        data,
+        &PfdConfig::default(),
+        None,
+        BUILTIN_FRAME,
+        &mut writer,
+    )
+    .expect("draws");
     let used = writer.finish();
     buf[..used].to_vec()
 }

--- a/sets/indicate-instrument-panels/src/pfd/horizon.rs
+++ b/sets/indicate-instrument-panels/src/pfd/horizon.rs
@@ -1,10 +1,12 @@
 //! Optional sky/ground fill and critical attitude symbology.
 //!
-//! Geometry follows the G5 proportions: 7.2 px per degree of pitch
-//! (±25° across the 360-px panel height), roll arc radius 144 px
-//! spanning ±60° of bank.
+//! Geometry follows the G5 proportions: 7.2 px per degree of pitch, and
+//! a roll arc of radius 144 px spanning ±60° of bank. The pitch span the
+//! frame can show follows from its height, so the sky/ground fill takes
+//! the frame it is drawn in.
 
 use core::f32::consts::PI;
+use indicate_instrument_descriptor::DesignFrame;
 use indicate_instrument_scene::{Anchor, PaintMode, SceneError, SceneWriter};
 use indicate_instrument_state::GroupId;
 use indicate_instrument_state::units::RAD_TO_DEG;
@@ -14,10 +16,6 @@ use indicate_instrument_symbology::{fmt_label, palette, safety};
 
 pub(super) const PX_PER_DEG_PITCH: f32 = 7.2;
 const ROLL_ARC_R: f32 = 144.0;
-/// Half the panel height expressed in degrees of pitch: the pitch at which
-/// the level horizon reaches the top/bottom edge. Beyond it the true
-/// horizon has left the viewport.
-const VIEWPORT_HALF_PITCH_DEG: f32 = (crate::PANEL_H / 2.0) / PX_PER_DEG_PITCH;
 /// Pitch-ladder marks are culled beyond this radius so they stay inside
 /// the roll arc (the pyG5 clip).
 const LADDER_MAX_Y: f32 = 104.0;
@@ -34,12 +32,17 @@ const LADDER_MAX_Y: f32 = 104.0;
 /// only the color field is held.
 pub fn draw_background(
     scene: &mut SceneWriter<'_>,
+    frame: DesignFrame,
     roll_rad: f32,
     pitch_rad: f32,
     min_reverse_band_rad: f32,
 ) -> Result<(), SceneError> {
+    // Half the frame height in degrees of pitch: the pitch at which a
+    // level horizon reaches the top or bottom edge, and so the point
+    // beyond which the true horizon has left the viewport.
+    let viewport_half_pitch_deg = (frame.height / 2.0) / PX_PER_DEG_PITCH;
     let band_deg = min_reverse_band_rad * RAD_TO_DEG;
-    let fill_limit_deg = VIEWPORT_HALF_PITCH_DEG - band_deg;
+    let fill_limit_deg = viewport_half_pitch_deg - band_deg;
     let pitch_deg = (pitch_rad * RAD_TO_DEG).clamp(-fill_limit_deg, fill_limit_deg);
     let horizon_y = pitch_deg * PX_PER_DEG_PITCH;
 

--- a/sets/indicate-instrument-panels/src/pfd/panel_config.rs
+++ b/sets/indicate-instrument-panels/src/pfd/panel_config.rs
@@ -1,9 +1,8 @@
 //! PFD configuration decoding from the shell-delivered blob (ADR-0033).
 
-use indicate_instrument_descriptor::{ConfigBlob, ConfigError, ConfigKey, keys};
+use indicate_instrument_descriptor::{ConfigBlob, ConfigError, ConfigKey, DesignFrame, keys};
 
 use super::{BackgroundMode, PfdConfig, SvsViewport, VSpeeds};
-use crate::{PANEL_H, PANEL_W};
 
 /// Every key the PFD understands; a shell refuses anything else before
 /// the blob reaches this decoder, and the decoder refuses it again.
@@ -22,12 +21,19 @@ impl PfdConfig {
     /// background is refused as inert: silently ignoring an option a
     /// caller believes is set would misstate what the panel displays
     /// (ADR-0033).
-    pub fn from_config(config: &ConfigBlob<'_>) -> Result<PfdConfig, ConfigError> {
+    ///
+    /// The viewport is bounded by `frame`, the frame the panel is being
+    /// drawn at: imagery cannot be requested where the panel does not
+    /// draw, and where that is depends on the frame it was given.
+    pub fn from_config(
+        config: &ConfigBlob<'_>,
+        frame: DesignFrame,
+    ) -> Result<PfdConfig, ConfigError> {
         config.require_schema(PFD_CONFIG_SCHEMA)?;
-        let viewport = decode_viewport(config)?;
+        let viewport = decode_viewport(config, frame)?;
         let quality = decode_quality(config)?;
         Ok(PfdConfig {
-            background: decode_background(config, viewport, quality)?,
+            background: decode_background(config, frame, viewport, quality)?,
             v_speeds: decode_v_speeds(config)?,
         })
     }
@@ -35,6 +41,7 @@ impl PfdConfig {
 
 fn decode_background(
     config: &ConfigBlob<'_>,
+    frame: DesignFrame,
     viewport: Option<SvsViewport>,
     quality: Option<u8>,
 ) -> Result<BackgroundMode, ConfigError> {
@@ -58,8 +65,8 @@ fn decode_background(
             viewport: viewport.unwrap_or(SvsViewport {
                 x: 0.0,
                 y: 0.0,
-                width: PANEL_W,
-                height: PANEL_H,
+                width: frame.width,
+                height: frame.height,
             }),
             quality: quality.unwrap_or(0),
         }),
@@ -70,7 +77,10 @@ fn decode_background(
     }
 }
 
-fn decode_viewport(config: &ConfigBlob<'_>) -> Result<Option<SvsViewport>, ConfigError> {
+fn decode_viewport(
+    config: &ConfigBlob<'_>,
+    frame: DesignFrame,
+) -> Result<Option<SvsViewport>, ConfigError> {
     let Some(bytes) = config.get(keys::SVS_VIEWPORT) else {
         return Ok(None);
     };
@@ -79,14 +89,14 @@ fn decode_viewport(config: &ConfigBlob<'_>) -> Result<Option<SvsViewport>, Confi
         len: bytes.len(),
     };
     let [x, y, width, height] = decode_f32s::<4>(bytes).ok_or_else(bad)?;
-    // Within the design frame, as the descriptor field documents —
-    // imagery cannot be requested where the panel does not draw.
+    // Inside the frame being drawn — imagery cannot be requested where
+    // the panel does not draw.
     let sane = x >= 0.0
         && y >= 0.0
         && width > 0.0
         && height > 0.0
-        && x + width <= PANEL_W
-        && y + height <= PANEL_H;
+        && x + width <= frame.width
+        && y + height <= frame.height;
     if sane {
         Ok(Some(SvsViewport {
             x,

--- a/sets/indicate-instrument-panels/src/pfd/tests.rs
+++ b/sets/indicate-instrument-panels/src/pfd/tests.rs
@@ -11,6 +11,7 @@ use indicate_instrument_state::{
 
 pub(crate) use super::PfdConfig;
 use super::{VSpeeds, draw_pfd};
+use crate::BUILTIN_FRAME;
 
 pub(crate) fn flying() -> PanelData {
     let state = AircraftState {
@@ -51,7 +52,7 @@ pub(crate) fn flying() -> PanelData {
 pub(crate) fn render(data: &PanelData, cfg: &PfdConfig) -> Vec<u8> {
     let mut buf = std::vec![0u8; 32 * 1024];
     let mut w = SceneWriter::new(&mut buf).expect("fits");
-    draw_pfd(data, cfg, None, &mut w).expect("panel fits buffer");
+    draw_pfd(data, cfg, None, BUILTIN_FRAME, &mut w).expect("panel fits buffer");
     let len = w.finish();
     buf.truncate(len);
     buf

--- a/sets/indicate-instrument-template/src/template.rs
+++ b/sets/indicate-instrument-template/src/template.rs
@@ -21,6 +21,14 @@ const FRAME_W: f32 = 240.0;
 /// Design-frame height.
 const FRAME_H: f32 = 120.0;
 
+/// The one frame this panel declares — floor, ceiling, and the single
+/// pinned evidence size. A panel that grows a real range declares a
+/// wider one and lays out against whichever frame `draw` is handed.
+const TEMPLATE_FRAME: DesignFrame = DesignFrame {
+    width: FRAME_W,
+    height: FRAME_H,
+};
+
 const LABEL_X: f32 = 16.0;
 const LABEL_Y: f32 = 34.0;
 const LABEL_SIZE: f32 = 16.0;
@@ -44,16 +52,24 @@ const fn layer_bit(layer: LayerId) -> u8 {
     1u8 << layer.to_u8()
 }
 
-/// Draws the template panel from resolved state.
+/// Draws the template panel from resolved state in the frame it is
+/// handed.
 ///
 /// Two bands, in ascending order: `Background` carries the opaque ground
 /// the descriptor promises, `Tapes` the label and the readout. Each
 /// `begin_layer`/`end_layer` pair emits the mandatory state-isolation
 /// save and restore, which is the layer envelope admission checks.
+///
+/// `frame` is the logical space to lay out against, and it arrives as
+/// an argument rather than as configuration: the admission harness
+/// draws the empty config on purpose, so a panel that took its size
+/// from a config key could never be admitted. Geometry reads the
+/// argument; the descriptor's range says which frames may arrive.
 fn draw_template_panel(
     data: &PanelData,
     config: &ConfigBlob<'_>,
     _alerts: Option<&AlertOutput>,
+    frame: DesignFrame,
     scene: &mut SceneWriter<'_>,
 ) -> Result<(), PanelDrawError> {
     // The empty schema already makes any keyed blob a shell-side
@@ -68,7 +84,7 @@ fn draw_template_panel(
     // looks. A clip is fine only if it contains the frame.
     scene.begin_layer(LayerId::Background)?;
     scene.fill_color(palette::BLACK)?;
-    scene.rect(PaintMode::Fill, 0.0, 0.0, FRAME_W, FRAME_H)?;
+    scene.rect(PaintMode::Fill, 0.0, 0.0, frame.width, frame.height)?;
     scene.end_layer(LayerId::Background)?;
 
     scene.begin_layer(LayerId::Tapes)?;
@@ -147,13 +163,32 @@ pub const TEMPLATE_DESCRIPTOR: PanelDescriptor = PanelDescriptor {
     // nothing, so the value dashes out even though the air data is still
     // there. A group a panel merely reads past belongs nowhere here.
     required_groups: GroupSet::of(&[GroupId::Air, GroupId::Trust]),
-    // The logical space this panel draws against. It need not match any
-    // other panel's; the registry asks only that it be finite and
-    // positive, and every geometry check downstream is expressed in it.
-    design_frame: DesignFrame {
-        width: FRAME_W,
-        height: FRAME_H,
-    },
+    // The range of logical spaces this panel draws against. It need not
+    // match any other panel's. `frame_min` is the readability floor —
+    // conspicuity has to hold there, and group regions are checked
+    // against it — and `frame_max` is the ceiling the budgets allow.
+    // Declaring them equal is the honest statement for a panel with a
+    // fixed layout: a shell can then only ask for the one frame the
+    // geometry was authored for.
+    frame_min: TEMPLATE_FRAME,
+    frame_max: TEMPLATE_FRAME,
+    // Admissible dimensions are `frame_min + k * step` per axis, which
+    // keeps a real range's behaviour space finite. With one admissible
+    // frame the only whole `k` is zero, so any positive step says the
+    // same thing.
+    frame_step: (1.0, 1.0),
+    // The width/height ratios the layout supports. Per-axis bounds alone
+    // would admit shapes no layout was designed for, so the ratio is
+    // bounded on its own. These bracket this panel's 2:1 rather than
+    // stating it exactly: the ratio is an f32 division, and a decimal
+    // literal is not reliably equal to it.
+    aspect_min: 1.95,
+    aspect_max: 2.05,
+    // The pinned evidence sizes: the frames the digest, the admission
+    // matrix, and any raster baselines are taken at. The registry
+    // requires both ends of the range to appear here, and every entry to
+    // be admissible in its own right.
+    canonical_frames: &[TEMPLATE_FRAME],
     // A compositor plans around this declaration, so admission refuses
     // both directions: painting a band declared `NotUsed`, and failing
     // to cover a band declared owned. `Opaque` is the honest answer for
@@ -185,12 +220,14 @@ pub const TEMPLATE_DESCRIPTOR: PanelDescriptor = PanelDescriptor {
     // reaches, contributes its own here. This one has nothing to add.
     extreme_states: &[],
     // The pinned reference-rasterizer hash of this panel's typical
-    // frame, once a baseline travels with the descriptor. `None` is the
-    // honest value until then, not a placeholder to fill with anything.
-    raster_baseline: None,
-    // The entry point: pure resolved state to scene. A panel never
-    // reaches for a clock, a source, or a shell — everything it may draw
-    // from arrives in the arguments.
+    // frame, one entry per canonical frame, once baselines travel with
+    // the descriptor. Empty is the honest value until then, not a
+    // placeholder to fill with anything; each entry a panel does declare
+    // must name a frame it is actually rendered at.
+    raster_baselines: &[],
+    // The entry point: pure resolved state and a frame to scene. A panel
+    // never reaches for a clock, a source, or a shell — everything it
+    // may draw from arrives in the arguments.
     draw: draw_template_panel,
 };
 

--- a/tools/instrument-bench/src/main.rs
+++ b/tools/instrument-bench/src/main.rs
@@ -1,8 +1,9 @@
 //! Standalone bench shell (ADR-0029): the third, deliberately unalike
 //! shell. It composes the same registry the web shell consumes, runs
 //! the admission harness, computes the cross-shell scene digest against
-//! the pinned value, and rasterizes every panel × canonical state —
-//! optionally writing PPM frames — with no host and no protocol. A
+//! the pinned value, and rasterizes every panel × canonical state ×
+//! canonical frame — optionally writing PPM frames — with no host and
+//! no protocol. A
 //! nonzero exit is a conformance failure, never a partial pass.
 
 mod output;
@@ -16,7 +17,8 @@ use indicate_instrument_conformance::{AdmissionError, admit};
 use indicate_instrument_panels::{BUILTIN_PANELS, BUILTIN_SCENE_DIGEST};
 use indicate_instrument_raster::{FrameId, FramebufferDims, RenderStatus, render};
 use indicate_instrument_registry::{
-    CANONICAL_STATES, EMPTY_CONFIG, PanelDrawError, Registry, RegistryError, scene_digest,
+    CANONICAL_STATES, DesignFrame, EMPTY_CONFIG, PanelDrawError, Registry, RegistryError,
+    scene_digest,
 };
 use indicate_instrument_scene::{MAX_SCENE_BYTES, SceneWriter};
 use indicate_instrument_state::{FreshnessPolicy, resolve};
@@ -109,18 +111,20 @@ fn main() -> Result<(), BenchError> {
     }
     print_line(&format!("scene digest: {digest} (matches pin)"));
 
+    let mut rasterized = 0usize;
     for panel in registry.panels() {
         for state in CANONICAL_STATES {
-            let frame = rasterize(panel, state.id, (state.build)(), &mut scratch)?;
-            if let Some(dir) = &out_dir {
-                write_ppm(dir, panel.id, state.id, panel.design_frame, &frame)?;
+            for frame in panel.canonical_frames {
+                let pixels = rasterize(panel, state.id, (state.build)(), *frame, &mut scratch)?;
+                rasterized += 1;
+                if let Some(dir) = &out_dir {
+                    write_ppm(dir, panel.id, state.id, *frame, &pixels)?;
+                }
             }
         }
     }
     print_line(&format!(
-        "rasterized {} panels x {} states",
-        registry.panels().count(),
-        CANONICAL_STATES.len()
+        "rasterized {rasterized} panel x state x canonical frame renders"
     ));
     Ok(())
 }
@@ -139,6 +143,7 @@ fn rasterize(
     panel: &'static indicate_instrument_registry::PanelDescriptor,
     state_id: &'static str,
     state: indicate_instrument_state::AircraftState,
+    frame: DesignFrame,
     scratch: &mut [u8],
 ) -> Result<Vec<u8>, BenchError> {
     let data = resolve(&state, &FreshnessPolicy::default());
@@ -146,16 +151,15 @@ fn rasterize(
         panel: panel.id,
         state: state_id,
     })?;
-    (panel.draw)(&data, &EMPTY_CONFIG, None, &mut writer).map_err(|source| BenchError::Draw {
-        panel: panel.id,
-        state: state_id,
-        source,
+    (panel.draw)(&data, &EMPTY_CONFIG, None, frame, &mut writer).map_err(|source| {
+        BenchError::Draw {
+            panel: panel.id,
+            state: state_id,
+            source,
+        }
     })?;
     let used = writer.finish();
-    let (w, h) = (
-        panel.design_frame.width as u32,
-        panel.design_frame.height as u32,
-    );
+    let (w, h) = (frame.width as u32, frame.height as u32);
     let mut framebuffer = vec![0u8; (w * h * 4) as usize];
     let report = render(
         scratch.get(..used).unwrap_or(&[]),
@@ -180,17 +184,20 @@ fn write_ppm(
     dir: &PathBuf,
     panel_id: &str,
     state_id: &str,
-    frame: indicate_instrument_registry::DesignFrame,
+    frame: DesignFrame,
     rgba: &[u8],
 ) -> Result<(), BenchError> {
-    let path = dir.join(format!("{panel_id}-{state_id}.ppm"));
+    let (w, h) = (frame.width as usize, frame.height as usize);
+    // The frame is in the filename: a panel with several canonical
+    // frames writes one image per size, and they must not overwrite
+    // each other.
+    let path = dir.join(format!("{panel_id}-{state_id}-{w}x{h}.ppm"));
     let io = |source| BenchError::Io {
         path: path.clone(),
         source,
     };
     std::fs::create_dir_all(dir).map_err(io)?;
     let mut out = Vec::new();
-    let (w, h) = (frame.width as usize, frame.height as usize);
     out.extend_from_slice(format!("P6\n{w} {h}\n255\n").as_bytes());
     for pixel in rgba.chunks_exact(4) {
         out.extend_from_slice(&pixel[..3]);


### PR DESCRIPTION
Fixes #12.

Implements the issue's model and its migration phases 1–2. Phase 3 — panels adopting real ranges — is deliberately excluded: the issue itself says each is its own change with its own layout refactor, canonical frames, baselines, and admission at every frame.

## The model

Emission becomes a pure function of (state, config, alerts, **frame**). The frame is a **draw parameter, not a config key**, for the reason the issue gives: config blobs are optional schema-gated wire blobs and admission deliberately draws the empty config, so a frame carried as config would make every size-adaptive panel unadmittable by construction.

A descriptor now declares the range it supports rather than one constant:

| Field | Meaning |
|---|---|
| `frame_min` | the readability floor — AIR-OUT-004's conspicuity must hold here, which is what a minimum is *for* |
| `frame_max` | the ceiling the budgets allow |
| `frame_step` | quantization, keeping the behaviour space and evidence matrix finite |
| `aspect_min` / `aspect_max` | shapes the layout supports (min/max alone admit shapes it never was) |
| `canonical_frames` | the sizes evidence is pinned at |
| `raster_baselines` | one baseline per canonical frame |

## Validation — eleven new refusals, each with a test that fires it

The subtle one the issue calls out explicitly: the per-axis corners alone may not be an admissible *shape*, so every canonical frame is checked against range, step grid, **and** aspect bounds, and both ends of the range must be pinned. `a_canonical_frame_outside_the_aspect_bounds_is_refused` uses 600×360 — inside both per-axis corners, a shape 4:3 never declared.

## The digest moved once, and that is the deliberate move

`bd85b853…` → `3efb08c5…`. The per-panel contract block gained the frame constraints, and scenes are drawn per canonical state × canonical frame.

**No paint moved.** All three REN-03 raster frame hashes are byte-identical to `main` — I diffed them directly — which is exactly what separates a format move from a regression. Admission is still 121 cases with the 83-warning ratchet intact, as it must be at one canonical frame per panel. The corpus is untouched.

Re-pinned with the reason, and `CHANGELOG.md` gains a 0.2.0 entry naming all five contract values (the release-marker guard requires it).

## Byte-identical behaviour

Every shipped panel declares the degenerate range — `frame_min == frame_max ==` its old constant, one canonical frame — and the panels take their geometry **from the parameter** rather than the constant. That is what proves the plumbing carries the value rather than the panels ignoring it; at one frame the values are identical, so output is unchanged.

## Evidence

The raster attitude suite's source calls `draw_pfd`, whose signature changed, so its blob moved and its recorded digest stopped matching. All three suites were re-run (86 / 167 / 79 — unchanged counts, as behaviour is unchanged) and re-captured. The other two bound sources are untouched and their digests are unchanged.

Both HARD gates `VALID`; all 26 negative fixtures still fail correctly.

**Follow-up required:** squash-merging orphans this baseline, so a re-anchor to the merged commit lands immediately after, as with #16/#17 and #20/#21.

## Not implemented, and why

The issue sketches deriving the absolute `RenderWork` budget per canonical frame from the samples-per-pixel ceiling. That is a real part of the model but not reachable without a panel that has more than one canonical frame; it belongs with phase 3.