### PR TITLE
Evidence: re-anchor the ATT-01 baseline to the merged frame squash

### DIFF
--- a/crates/indicate-evidence/tests/fixtures/att01-run-output-baselined.txt
+++ b/crates/indicate-evidence/tests/fixtures/att01-run-output-baselined.txt
@@ -2,9 +2,9 @@ Pilotage evidence — captured verification run (SIM / NOT FOR FLIGHT)
 scope: ATT-01
 suite: fixture band behavior
 command: cargo test -p indicate-instrument-raster
-config-digest: 836371a8dd7fab23231f9a17f461f562cd42433a
+config-digest: 63b7ac8cb57a7d969cd52cbc80845e6f9dc0df4e
 tool-version: rustc 1.95.0
-run-id: local:836371a8dd7fab23231f9a17f461f562cd42433a
+run-id: local:63b7ac8cb57a7d969cd52cbc80845e6f9dc0df4e
 outcome: pass
 summary:
 test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out

--- a/crates/indicate-evidence/tests/fixtures/attitude-slice.evg
+++ b/crates/indicate-evidence/tests/fixtures/attitude-slice.evg
@@ -17,12 +17,12 @@ attr test band_matches_reference
 
 node RESULT-BAND verification-result
 attr command cargo test -p indicate-instrument-raster
-attr config-digest 836371a8dd7fab23231f9a17f461f562cd42433a
+attr config-digest 63b7ac8cb57a7d969cd52cbc80845e6f9dc0df4e
 attr tool-version rustc 1.95.0
 attr source-digest git-blob:f399b5de714ad59fc3c75ba830354c8e95e958fd
 attr artifact tests/fixtures/att01-run-output-baselined.txt
-attr output-digest sha256:e6f2deb70e5329029516be3a52a984fb1e33a17ad817fe6f418d20eb03458575
-attr run-id local:836371a8dd7fab23231f9a17f461f562cd42433a
+attr output-digest sha256:ff1f73a06f2b39f424425ec111471d2689c92ccaee33fe2b70dba69a451f059b
+attr run-id local:63b7ac8cb57a7d969cd52cbc80845e6f9dc0df4e
 attr outcome pass
 node CFG-BASE configuration-item
 node TOOL-CARGO tool

--- a/crates/indicate-evidence/tests/fixtures/unresolved-review-entry.evg
+++ b/crates/indicate-evidence/tests/fixtures/unresolved-review-entry.evg
@@ -27,12 +27,12 @@ attr test band_matches_reference
 
 node RESULT-BAND verification-result
 attr command cargo test -p indicate-instrument-raster
-attr config-digest 836371a8dd7fab23231f9a17f461f562cd42433a
+attr config-digest 63b7ac8cb57a7d969cd52cbc80845e6f9dc0df4e
 attr tool-version rustc 1.95.0
 attr source-digest git-blob:f399b5de714ad59fc3c75ba830354c8e95e958fd
 attr artifact tests/fixtures/att01-run-output-baselined.txt
-attr output-digest sha256:e6f2deb70e5329029516be3a52a984fb1e33a17ad817fe6f418d20eb03458575
-attr run-id local:836371a8dd7fab23231f9a17f461f562cd42433a
+attr output-digest sha256:ff1f73a06f2b39f424425ec111471d2689c92ccaee33fe2b70dba69a451f059b
+attr run-id local:63b7ac8cb57a7d969cd52cbc80845e6f9dc0df4e
 attr outcome pass
 
 node CFG-BASE configuration-item

--- a/docs/instruments/evidence-artifacts/att01/panel.run.txt
+++ b/docs/instruments/evidence-artifacts/att01/panel.run.txt
@@ -2,9 +2,9 @@ Indicate evidence — captured verification run (SIM / NOT FOR FLIGHT)
 scope: ATT-01
 suite: PFD attitude panel
 command: cargo test -p indicate-instrument-panels
-config-digest: 836371a8dd7fab23231f9a17f461f562cd42433a
+config-digest: 63b7ac8cb57a7d969cd52cbc80845e6f9dc0df4e
 tool-version: rustc 1.95.0 (59807616e 2026-04-14)
-run-id: local:836371a8dd7fab23231f9a17f461f562cd42433a
+run-id: local:63b7ac8cb57a7d969cd52cbc80845e6f9dc0df4e
 outcome: pass
 summary:
 test result: ok. 79 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out

--- a/docs/instruments/evidence-artifacts/att01/presentation.run.txt
+++ b/docs/instruments/evidence-artifacts/att01/presentation.run.txt
@@ -2,9 +2,9 @@ Indicate evidence — captured verification run (SIM / NOT FOR FLIGHT)
 scope: ATT-01
 suite: SO(3) presentation unit
 command: cargo test -p indicate-instrument-state
-config-digest: 836371a8dd7fab23231f9a17f461f562cd42433a
+config-digest: 63b7ac8cb57a7d969cd52cbc80845e6f9dc0df4e
 tool-version: rustc 1.95.0 (59807616e 2026-04-14)
-run-id: local:836371a8dd7fab23231f9a17f461f562cd42433a
+run-id: local:63b7ac8cb57a7d969cd52cbc80845e6f9dc0df4e
 outcome: pass
 summary:
 test result: ok. 167 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out

--- a/docs/instruments/evidence-artifacts/att01/raster.run.txt
+++ b/docs/instruments/evidence-artifacts/att01/raster.run.txt
@@ -2,9 +2,9 @@ Indicate evidence — captured verification run (SIM / NOT FOR FLIGHT)
 scope: ATT-01
 suite: raster attitude behavior
 command: cargo test -p indicate-instrument-raster
-config-digest: 836371a8dd7fab23231f9a17f461f562cd42433a
+config-digest: 63b7ac8cb57a7d969cd52cbc80845e6f9dc0df4e
 tool-version: rustc 1.95.0 (59807616e 2026-04-14)
-run-id: local:836371a8dd7fab23231f9a17f461f562cd42433a
+run-id: local:63b7ac8cb57a7d969cd52cbc80845e6f9dc0df4e
 outcome: pass
 summary:
 test result: ok. 86 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out

--- a/docs/instruments/evidence-graph.evg
+++ b/docs/instruments/evidence-graph.evg
@@ -157,34 +157,34 @@ locator docs/instruments/fha.md
 node RESULT-RASTER verification-result
 title raster extreme-attitude behavior — recorded pass
 attr command cargo test -p indicate-instrument-raster
-attr config-digest 836371a8dd7fab23231f9a17f461f562cd42433a
+attr config-digest 63b7ac8cb57a7d969cd52cbc80845e6f9dc0df4e
 attr tool-version rustc 1.95.0 (59807616e 2026-04-14)
 attr source-digest git-blob:a44456b2d4dbff51b8577ac9410f652e862830d1
 attr artifact docs/instruments/evidence-artifacts/att01/raster.run.txt
-attr output-digest sha256:d27dd8e231d63619fc3779b5d6d0ecbafefd10c0d61c9f91ae5d2ca314b15394
-attr run-id local:836371a8dd7fab23231f9a17f461f562cd42433a
+attr output-digest sha256:d09d102a40128a84cb3927cf7ddd617ea49d1fba0710953265631ae33f013e14
+attr run-id local:63b7ac8cb57a7d969cd52cbc80845e6f9dc0df4e
 attr outcome pass
 
 node RESULT-PRESENTATION verification-result
 title SO(3) presentation unit suite — recorded pass
 attr command cargo test -p indicate-instrument-state
-attr config-digest 836371a8dd7fab23231f9a17f461f562cd42433a
+attr config-digest 63b7ac8cb57a7d969cd52cbc80845e6f9dc0df4e
 attr tool-version rustc 1.95.0 (59807616e 2026-04-14)
 attr source-digest git-blob:d11595580cab8264e75e9e82ab9994de6d8bdeac
 attr artifact docs/instruments/evidence-artifacts/att01/presentation.run.txt
-attr output-digest sha256:42ade6e10961d41d1de84ded7917faf75a64071eafc286173c7297bd8a8ca7bb
-attr run-id local:836371a8dd7fab23231f9a17f461f562cd42433a
+attr output-digest sha256:30ab9712f3ef0d44efa1a05adc3a61b44c4250b4bc9dfe510ce6e1465cc68285
+attr run-id local:63b7ac8cb57a7d969cd52cbc80845e6f9dc0df4e
 attr outcome pass
 
 node RESULT-PFD verification-result
 title PFD attitude panel suite — recorded pass
 attr command cargo test -p indicate-instrument-panels
-attr config-digest 836371a8dd7fab23231f9a17f461f562cd42433a
+attr config-digest 63b7ac8cb57a7d969cd52cbc80845e6f9dc0df4e
 attr tool-version rustc 1.95.0 (59807616e 2026-04-14)
 attr source-digest git-blob:015edf11e26fa840cb410c086262cf4ed2621413
 attr artifact docs/instruments/evidence-artifacts/att01/panel.run.txt
-attr output-digest sha256:77b79aab7abc109f1e87ff127ef29ccbdffb671e732a6a5f9a30cec2ee2b96b2
-attr run-id local:836371a8dd7fab23231f9a17f461f562cd42433a
+attr output-digest sha256:9dc62dd6980794e40459e56b748601add126d6f4b0381d1e8f2587bfbcf5f3bc
+attr run-id local:63b7ac8cb57a7d969cd52cbc80845e6f9dc0df4e
 attr outcome pass
 
 # --- Configuration and tool identity ---
@@ -192,8 +192,8 @@ attr outcome pass
 node CFG-WORKTREE configuration-item
 title engineering worktree baseline — the git working tree the recorded results were produced against (not certified SCM)
 attr scm git-worktree
-attr commit 836371a8dd7fab23231f9a17f461f562cd42433a
-attr tree 04ed2f329c37888b044fad6011cf688b75eb3e9f
+attr commit 63b7ac8cb57a7d969cd52cbc80845e6f9dc0df4e
+attr tree 4d35be1c196dd5f10ecbebfdf66a136dd757047c
 
 node TOOL-CARGO-TEST tool
 title cargo test on Rust stable — not DO-330 tool-qualified


### PR DESCRIPTION
Follow-up to #24, flagged there as required — same lifecycle as #17 after #16 and #21 after #20.

The squash rewrote the lane commit `CFG-WORKTREE` and every result declared, orphaning the baseline; both HARD gates are red on main until this lands.

**Moves:** the config item's commit and tree, every result's `config-digest`/`run-id`, and the output digests that follow. The evidence crate's two positive fixtures carry the same anchor.

**Does not move:** the `source-digest` values. The squash preserved the bound test sources byte-for-byte, so nothing was re-run and nothing claims to have been.

Both HARD gates `verdict: VALID`; evidence crate tests green.