### PR TITLE
Screen composition: panels mix, inset, and overlap by declaration (#11)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,11 +54,26 @@ worth knowing before the next one is cut.
   `Annunciation`/`Failure` ink bound per panel × canonical frame, which
   a composition validates obscuration against. The monitor's is `None`,
   which is a measurement rather than an omission.
+- **The criticality band now folds in the alert stack, and this is a
+  safety fix.** Admission drew every case with no alerts, so the
+  measured `Annunciation`/`Failure` bound excluded the shared alert
+  stack entirely — while a composed frame fans one `AlertOutput` to
+  every slot. A declared obscuration could therefore cover warning rows,
+  which is exactly what AIR-OUT-011 forbids and what the contract says
+  is impossible. The case matrix gains an alert axis (each case drawn
+  quiet and with a saturated stack), so admission runs 242 cases instead
+  of 121 and counts 166 frame-overflow warnings instead of 83. All three
+  `BUILTIN_CRITICALITY_BANDS` entries moved; the monitor's is no longer
+  `None`.
+- **An unwitnessed band refuses obscuration.** A band measured empty is
+  the absence of a witness, not a proof of absence, and it now refuses
+  any overlap (`CriticalityUnwitnessed`) instead of admitting it.
 - **New pinned data: three composed-frame hashes.** The reference
   rasterizer gains `render_composition`, which paints a validated
   composition into one framebuffer, and pins REN-03-style hashes for a
   side-by-side screen, an opaque inset over a PFD, and a `NotUsed`
-  overlay. The overlay's show-through is asserted as a property, not
+  overlay. The inset and overlay fixtures moved above the PFD's band
+  once alerts were folded in, so two of the three hashes are new. The overlay's show-through is asserted as a property, not
   only as a hash. `indicate-instrument-raster` gains normal
   dependencies on the registry, the state crate, and the alert model;
   the arrow points that way and no crate gained a dependency on the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,39 @@ from a rewritten one. Entries are newest first, and the tag's message
 repeats the same five values so `git show <tag>` answers the question
 without a checkout. `CONTRIBUTING.md` has the release steps.
 
+## [Unreleased]
+
+Screen composition ([`AIR-OUT-011`](docs/instruments/requirements.md)).
+None of the five values above moved, so this is not a release — but a
+consumer gains a sixth pinnable value and two new refusals, and both are
+worth knowing before the next one is cut.
+
+- **New pinnable value: the screen-composition digest.** Its own domain
+  string (`pilotage-screen-composition-digest-v1`), covering the screen
+  frame, the ordered slots (panel id, rect, `occludes`), and the scene
+  digest beneath. `tools/instrument-bench` composes a fixture screen and
+  reproduces `071bd35c…`. Per-slot configuration is shell-supplied at
+  draw time and is deliberately not in it.
+- **New ceiling: `MAX_COMPOSITION_SLOTS` = 8.** Every composed-frame
+  budget is a sum over slots, so this is what makes those sums finite.
+  The value is a declared ceiling, not a measured one: no full-screen
+  six-pack has been benched against it.
+- **`group_regions` became load-bearing.** Admission asserts
+  non-vacuity: every declared region must be populated by a visible run
+  claiming its group, somewhere in the panel's case matrix, at
+  `frame_min`. A region over blank space fails as `GroupRegionEmpty`.
+  What is deliberately *not* asserted is that all of a group's claimed
+  ink sits inside its regions — a numeral must carry a claim, so every
+  ladder rung and compass tick carries its group's, and those sit
+  outside the readout box by design. All three shipped panels satisfy
+  the rule as authored; no region and no panel changed.
+- **New pinned data: `BUILTIN_CRITICALITY_BANDS`.** The measured
+  `Annunciation`/`Failure` ink bound per panel × canonical frame, which
+  a composition validates obscuration against. The monitor's is `None`,
+  which is a measurement rather than an omission.
+- The scene digest, the corpus, and every REN-03 raster frame hash are
+  unchanged.
+
 ## [0.2.0] — 2026-08-07
 
 The design frame becomes an emission input. `DrawFn` gains a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,8 +54,17 @@ worth knowing before the next one is cut.
   `Annunciation`/`Failure` ink bound per panel × canonical frame, which
   a composition validates obscuration against. The monitor's is `None`,
   which is a measurement rather than an omission.
-- The scene digest, the corpus, and every REN-03 raster frame hash are
-  unchanged.
+- **New pinned data: three composed-frame hashes.** The reference
+  rasterizer gains `render_composition`, which paints a validated
+  composition into one framebuffer, and pins REN-03-style hashes for a
+  side-by-side screen, an opaque inset over a PFD, and a `NotUsed`
+  overlay. The overlay's show-through is asserted as a property, not
+  only as a hash. `indicate-instrument-raster` gains normal
+  dependencies on the registry, the state crate, and the alert model;
+  the arrow points that way and no crate gained a dependency on the
+  rasterizer.
+- The scene digest, the corpus, the screen-composition digest, and every
+  REN-03 per-panel frame hash are unchanged.
 
 ## [0.2.0] — 2026-08-07
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -208,6 +208,7 @@ dependencies = [
 name = "indicate-instrument-raster"
 version = "0.1.0"
 dependencies = [
+ "indicate-alerts",
  "indicate-instrument-glyphs",
  "indicate-instrument-panels",
  "indicate-instrument-registry",

--- a/crates/README.md
+++ b/crates/README.md
@@ -78,7 +78,7 @@ normal dependency of one.**
 | Crate | Role |
 |---|---|
 | `indicate-instrument-registry` | Composition of descriptors into a validated registry, and the cross-shell scene digest. |
-| `indicate-instrument-raster` | Reference software rasterizer: bit-exact pinned frame hashes, corpus authorship, target-timing evidence (`evidence/`). |
+| `indicate-instrument-raster` | Reference software rasterizer: bit-exact pinned frame hashes, the composed-screen harness, corpus authorship, target-timing evidence (`evidence/`). |
 | `indicate-instrument-conformance` | Panel admission harness (host-side, allocates; deliberately outside the `no_std` closure). |
 | `indicate-evidence` | Standard-neutral lifecycle evidence graph and gate (`evidence-gate` binary); guards `docs/instruments/evidence-graph.evg`. |
 

--- a/crates/README.md
+++ b/crates/README.md
@@ -19,9 +19,14 @@ hashed or pinned by someone downstream, and do not track what the crates
 are called. Rewriting one buys a tidier grep and costs every consumer a
 re-pin for no change in what is painted.
 
-| Survivor | Why it stays |
+A new identifier of that kind is minted in the same scheme rather than a
+fresh one, so the table below is the whole convention and not a list of
+exceptions to it.
+
+| String | Why it reads `pilotage` |
 |---|---|
 | `SCENE_DIGEST_DOMAIN` (`b"pilotage-scene-digest-v1"`) | Hashed into every composition digest; changing it moves `BUILTIN_SCENE_DIGEST` and reddens every consumer pin. |
+| `COMPOSITION_DIGEST_DOMAIN` (`b"pilotage-screen-composition-digest-v1"`) | **Newly minted**, not carried over: a domain separator's whole job is to be one fixed string consumers pin, so it was spelled to match the row above rather than starting a second convention. |
 | `sha256(b"pilotage")` in the sha256 unit tests | A hash input, not a name. The vector and its expected digest are self-consistent whatever the bytes spell. |
 | Recorded run records that were not re-executed — the reference CDC capture notes, and the evidence crate's own fixtures | A record is a statement about a run that happened. Records whose suites *were* re-run under the new names were re-captured instead, and say so. |
 | `Pilotage` in prose naming the cockpit, its repository, or its browser shell | Correct — those name a consumer, which is what the word is for. |

--- a/crates/indicate-instrument-conformance/Cargo.toml
+++ b/crates/indicate-instrument-conformance/Cargo.toml
@@ -9,6 +9,7 @@ publish = false
 workspace = true
 
 [dependencies]
+indicate-alerts = { workspace = true }
 indicate-instrument-glyphs = { workspace = true }
 indicate-instrument-registry = { workspace = true }
 indicate-instrument-scene = { workspace = true }
@@ -16,5 +17,4 @@ indicate-instrument-state = { workspace = true }
 thiserror = { workspace = true }
 
 [dev-dependencies]
-indicate-alerts = { workspace = true }
 indicate-instrument-panels = { workspace = true }

--- a/crates/indicate-instrument-conformance/src/admission.rs
+++ b/crates/indicate-instrument-conformance/src/admission.rs
@@ -1,4 +1,4 @@
-//! The admission matrix and its five check families.
+//! The admission matrix and its check families.
 //!
 //! The matrix runs at every canonical frame a panel pins, and every
 //! geometry check is expressed against the frame being drawn rather
@@ -16,13 +16,15 @@
 //! numeric run must claim the state group its value derives from
 //! ([`Cmd::Attribute`]), and a claimed run may not be visible when its
 //! group shows no value — wherever it is drawn. Declared
-//! `group_regions` no longer drive this family; they remain the
-//! descriptor's statement of which readout surface belongs to which
-//! group (the dash-out declaration a shell may present).
+//! `group_regions` are a separate family with a separate purpose: each
+//! declared readout surface must be one the group's readout really
+//! uses, so a compositor above plans obscuration against a populated
+//! declaration rather than an empty rectangle.
 
 use indicate_instrument_glyphs::PANEL_VOCABULARY;
 use indicate_instrument_registry::{
-    CANONICAL_STATES, DesignFrame, EMPTY_CONFIG, PanelDescriptor, PanelDrawError, Registry,
+    CANONICAL_STATES, DesignFrame, EMPTY_CONFIG, PanelCriticality, PanelDescriptor, PanelDrawError,
+    Registry,
 };
 use indicate_instrument_scene::{
     Cmd, LayerError, MAX_SCENE_BYTES, SceneCmds, SceneWriter, validate_layers,
@@ -32,12 +34,20 @@ use indicate_instrument_state::{
 };
 
 mod background;
+mod criticality;
+mod error;
 mod geometry;
+mod ink;
 mod provenance;
+mod regions;
 
 use background::check_background;
 use geometry::{Ctm, Rect, text_rect};
 use provenance::check_provenance;
+use regions::check_non_vacuity;
+
+pub use criticality::criticality_bands;
+pub use error::AdmissionError;
 
 /// One admission run's outcome: how much was covered, and what was
 /// tolerated. Failures are typed errors, never entries here.
@@ -47,6 +57,9 @@ pub struct AdmissionReport {
     pub cases: usize,
     /// Tolerated-but-counted observations.
     pub warnings: Vec<AdmissionWarning>,
+    /// The measured criticality band of every panel × canonical frame,
+    /// for a consumer to pin and a composition to plan around.
+    pub criticality: Vec<PanelCriticality>,
 }
 
 /// A tolerated observation, counted so growth is visible.
@@ -68,145 +81,6 @@ pub enum AdmissionWarning {
     },
 }
 
-/// Why a panel failed admission.
-#[derive(Debug, Clone, PartialEq, thiserror::Error)]
-pub enum AdmissionError {
-    /// The panel refused to draw a corpus case.
-    #[error("panel {panel} failed to draw state {state} (withheld: {withheld:?})")]
-    Draw {
-        /// The refusing panel.
-        panel: &'static str,
-        /// The corpus state.
-        state: &'static str,
-        /// The withheld group, if the case withholds one.
-        withheld: Option<GroupId>,
-        /// The panel's own reason.
-        #[source]
-        source: PanelDrawError,
-    },
-    /// The emitted scene violates the layer contract.
-    #[error("panel {panel} scene for {state} (withheld: {withheld:?}) breaks the layer contract")]
-    LayerContract {
-        /// The drawing panel.
-        panel: &'static str,
-        /// The corpus state.
-        state: &'static str,
-        /// The withheld group, if any.
-        withheld: Option<GroupId>,
-    },
-    /// A required layer band is absent from the emitted scene.
-    #[error(
-        "panel {panel} scene for {state} (withheld: {withheld:?}) is missing required layers {missing:#04x}"
-    )]
-    MissingRequiredLayers {
-        /// The drawing panel.
-        panel: &'static str,
-        /// The corpus state.
-        state: &'static str,
-        /// The withheld group, if any.
-        withheld: Option<GroupId>,
-        /// Required-but-absent layer bits.
-        missing: u8,
-    },
-    /// The scene does not decode.
-    #[error("panel {panel} scene for {state} does not decode")]
-    Decode {
-        /// The drawing panel.
-        panel: &'static str,
-        /// The corpus state.
-        state: &'static str,
-    },
-    /// A text run uses a character outside the controlled vocabulary.
-    #[error("panel {panel} draws {ch:?} in {state}, outside the controlled vocabulary")]
-    GlyphCoverage {
-        /// The drawing panel.
-        panel: &'static str,
-        /// The corpus state.
-        state: &'static str,
-        /// The uncovered character.
-        ch: char,
-    },
-    /// A visible run claims a group that shows no value in the drawn
-    /// state — the panel painted a number for data it was not given.
-    #[error(
-        "panel {panel} shows {text:?} claimed from {group:?} in {state} while {group:?} shows no value"
-    )]
-    FabricatedNumeral {
-        /// The drawing panel.
-        panel: &'static str,
-        /// The corpus state.
-        state: &'static str,
-        /// The claimed group.
-        group: GroupId,
-        /// The offending run.
-        text: String,
-    },
-    /// A numeric run carries no provenance claim. Totality is what
-    /// makes the claim rule sound: an unclaimed numeral would escape
-    /// every withholding case.
-    #[error("panel {panel} draws numeric text {text:?} in {state} with no provenance claim")]
-    UntaggedNumeral {
-        /// The drawing panel.
-        panel: &'static str,
-        /// The corpus state.
-        state: &'static str,
-        /// The unclaimed run.
-        text: String,
-    },
-    /// A run claims a group outside the panel's required set (or an
-    /// unknown tag) — a claim the withholding matrix could never test.
-    #[error(
-        "panel {panel} claims tag {tag:#04x} for {text:?} in {state}, outside its required groups"
-    )]
-    ForeignClaim {
-        /// The drawing panel.
-        panel: &'static str,
-        /// The corpus state.
-        state: &'static str,
-        /// The claimed tag byte.
-        tag: u8,
-        /// The claiming run.
-        text: String,
-    },
-    /// A visible run claims configuration provenance under the
-    /// harness's fixed empty configuration — it derives from nothing.
-    #[error(
-        "panel {panel} shows {text:?} in {state} claiming configuration provenance under the empty configuration"
-    )]
-    ConfigClaim {
-        /// The drawing panel.
-        panel: &'static str,
-        /// The corpus state.
-        state: &'static str,
-        /// The claiming run.
-        text: String,
-    },
-    /// A provenance claim not immediately followed by the text run it
-    /// covers — a dangling or stacked claim is structurally malformed.
-    #[error("panel {panel} scene for {state} carries a provenance claim that covers no text run")]
-    MisplacedClaim {
-        /// The drawing panel.
-        panel: &'static str,
-        /// The corpus state.
-        state: &'static str,
-    },
-    /// The Background band contradicts the declared capability: a
-    /// compositor plans around this declaration, so both directions are
-    /// refused — painting a band declared `NotUsed`, and failing to
-    /// opaquely cover a band declared owned.
-    #[error("panel {panel} declares background {declared} but its {state} scene {defect} the band")]
-    BackgroundContract {
-        /// The drawing panel.
-        panel: &'static str,
-        /// The corpus state.
-        state: &'static str,
-        /// The declared capability.
-        declared: &'static str,
-        /// What the scene actually did: "paints" or "does not cover".
-        defect: &'static str,
-    },
-}
-
 /// One decoded text run as a conservative design-space ink rectangle.
 #[derive(Debug, Clone, PartialEq)]
 struct TextRun {
@@ -214,8 +88,8 @@ struct TextRun {
     text: String,
     /// The provenance claim prefixing the run, if any.
     attribution: Option<u8>,
-    /// Whether a clip was active when the run painted.
-    clipped: bool,
+    /// The clip in force when the run painted, if any.
+    clip: Option<Rect>,
     /// Whether the ink rectangle intersects the active clip — a tape
     /// label scrolled past its strip's clip edge paints nothing.
     visible: bool,
@@ -225,11 +99,30 @@ impl TextRun {
     fn numeric(&self) -> bool {
         self.text.chars().any(|c| c.is_ascii_digit())
     }
+
+    fn clipped(&self) -> bool {
+        self.clip.is_some()
+    }
+
+    /// The ink that reaches the surface: the nominal run rectangle
+    /// cropped by whatever clip was in force.
+    fn painted_rect(&self) -> Rect {
+        match self.clip {
+            None => self.rect,
+            Some(clip) => self.rect.intersect(&clip),
+        }
+    }
 }
 
 /// Runs the full admission matrix over `registry`.
 pub fn admit(registry: &Registry) -> Result<AdmissionReport, AdmissionError> {
-    let mut report = AdmissionReport::default();
+    // Bands are measured before the judgements, so a report that
+    // survives the matrix always carries them, and so the measurement
+    // itself depends on nothing the matrix decides.
+    let mut report = AdmissionReport {
+        criticality: criticality_bands(registry)?,
+        ..AdmissionReport::default()
+    };
     for panel in registry.panels() {
         admit_panel(panel, &mut report)?;
     }
@@ -243,7 +136,10 @@ fn admit_panel(
     for frame in panel.canonical_frames {
         admit_panel_at_frame(panel, *frame, report)?;
     }
-    Ok(())
+    // A per-panel fact rather than a per-case one: the witness a region
+    // needs may only appear in one case of the matrix, so the verdict
+    // waits until every case has been drawn.
+    check_non_vacuity(panel)
 }
 
 fn admit_panel_at_frame(
@@ -251,20 +147,32 @@ fn admit_panel_at_frame(
     frame: DesignFrame,
     report: &mut AdmissionReport,
 ) -> Result<(), AdmissionError> {
+    for (state_id, withheld, state) in case_matrix(panel) {
+        check_case(panel, state_id, withheld, state, frame, report)?;
+    }
+    Ok(())
+}
+
+/// Every case one panel is judged over: each canonical and extreme
+/// state fully fed, then once per declared group with that group
+/// withheld.
+fn case_matrix(
+    panel: &'static PanelDescriptor,
+) -> Vec<(&'static str, Option<GroupId>, AircraftState)> {
     let states = CANONICAL_STATES
         .iter()
         .map(|s| (s.id, s.build))
         .chain(panel.extreme_states.iter().map(|e| (e.id, e.build)));
+    let mut cases = Vec::new();
     for (state_id, build) in states {
-        check_case(panel, state_id, None, build(), frame, report)?;
+        cases.push((state_id, None, build()));
         for group in GroupId::ALL {
             if panel.required_groups.contains(group) {
-                let withheld = withhold_group(&build(), group);
-                check_case(panel, state_id, Some(group), withheld, frame, report)?;
+                cases.push((state_id, Some(group), withhold_group(&build(), group)));
             }
         }
     }
-    Ok(())
+    cases
 }
 
 fn check_case(
@@ -294,7 +202,7 @@ fn check_case(
                 });
             }
         }
-        if !bounds.contains(&run.rect) && !run.clipped {
+        if !bounds.contains(&run.rect) && !run.clipped() {
             report.warnings.push(AdmissionWarning::FrameOverflow {
                 panel: panel.id,
                 state: state_id,
@@ -405,7 +313,7 @@ fn collect_runs(scene: &[u8]) -> Result<Vec<TextRun>, RunsDefect> {
                     rect,
                     text: text.to_string(),
                     attribution: pending.take(),
-                    clipped: clip.is_some(),
+                    clip,
                 });
             }
             Ok(Cmd::Save) => stack.push(stack.last().copied().ok_or(RunsDefect::Decode)?),

--- a/crates/indicate-instrument-conformance/src/admission.rs
+++ b/crates/indicate-instrument-conformance/src/admission.rs
@@ -21,6 +21,7 @@
 //! uses, so a compositor above plans obscuration against a populated
 //! declaration rather than an empty rectangle.
 
+use indicate_alerts::AlertOutput;
 use indicate_instrument_glyphs::PANEL_VOCABULARY;
 use indicate_instrument_registry::{
     CANONICAL_STATES, DesignFrame, EMPTY_CONFIG, PanelCriticality, PanelDescriptor, PanelDrawError,
@@ -33,6 +34,7 @@ use indicate_instrument_state::{
     AircraftState, FreshnessPolicy, GroupId, PanelData, resolve, withhold_group,
 };
 
+mod alerts;
 mod background;
 mod criticality;
 mod error;
@@ -41,6 +43,7 @@ mod ink;
 mod provenance;
 mod regions;
 
+use alerts::saturated_stack;
 use background::check_background;
 use geometry::{Ctm, Rect, text_rect};
 use provenance::check_provenance;
@@ -76,6 +79,11 @@ pub enum AdmissionWarning {
         state: &'static str,
         /// The frame the panel was drawn at.
         frame: DesignFrame,
+        /// Whether the alert stack was drawn in this case. A run that
+        /// overhangs only with alerts fed is a different fact from one
+        /// that overhangs on a quiet frame, and the ratchet counts them
+        /// separately.
+        alerted: bool,
         /// The text run's content.
         text: String,
     },
@@ -147,28 +155,61 @@ fn admit_panel_at_frame(
     frame: DesignFrame,
     report: &mut AdmissionReport,
 ) -> Result<(), AdmissionError> {
-    for (state_id, withheld, state) in case_matrix(panel) {
-        check_case(panel, state_id, withheld, state, frame, report)?;
+    for case in case_matrix(panel) {
+        check_case(panel, &case, frame, report)?;
     }
     Ok(())
 }
 
+/// One case of the admission matrix.
+struct Case {
+    state_id: &'static str,
+    withheld: Option<GroupId>,
+    state: AircraftState,
+    /// The alert state fed to the draw. `None` is the quiet frame; the
+    /// saturated stack is the other end of the axis.
+    alerts: Option<AlertOutput>,
+}
+
+impl Case {
+    /// Whether alerts were fed, for the error and warning context: a
+    /// defect that only appears with the stack drawn is a different
+    /// fact from one that appears without it.
+    fn alerted(&self) -> bool {
+        self.alerts.is_some()
+    }
+}
+
 /// Every case one panel is judged over: each canonical and extreme
 /// state fully fed, then once per declared group with that group
-/// withheld.
-fn case_matrix(
-    panel: &'static PanelDescriptor,
-) -> Vec<(&'static str, Option<GroupId>, AircraftState)> {
+/// withheld — and each of those twice, quiet and with the saturated
+/// alert stack.
+///
+/// The alert axis is not decoration. A composed frame fans one
+/// `AlertOutput` to every slot, so a band measured only on quiet frames
+/// would omit the shared stack and licence covering warning rows.
+fn case_matrix(panel: &'static PanelDescriptor) -> Vec<Case> {
     let states = CANONICAL_STATES
         .iter()
         .map(|s| (s.id, s.build))
         .chain(panel.extreme_states.iter().map(|e| (e.id, e.build)));
+    let saturated = saturated_stack();
     let mut cases = Vec::new();
     for (state_id, build) in states {
-        cases.push((state_id, None, build()));
+        let mut withholdings = vec![(None, build())];
         for group in GroupId::ALL {
             if panel.required_groups.contains(group) {
-                cases.push((state_id, Some(group), withhold_group(&build(), group)));
+                withholdings.push((Some(group), withhold_group(&build(), group)));
+            }
+        }
+        for (withheld, state) in withholdings {
+            for alerts in [None, Some(saturated)] {
+                cases.push(Case {
+                    state_id,
+                    withheld,
+                    state,
+                    alerts,
+                });
             }
         }
     }
@@ -177,15 +218,14 @@ fn case_matrix(
 
 fn check_case(
     panel: &'static PanelDescriptor,
-    state_id: &'static str,
-    withheld: Option<GroupId>,
-    state: AircraftState,
+    case: &Case,
     frame: DesignFrame,
     report: &mut AdmissionReport,
 ) -> Result<(), AdmissionError> {
-    let data = resolve(&state, &FreshnessPolicy::default());
-    let runs = draw_runs(panel, state_id, withheld, &data, frame)?;
-    check_provenance(panel, state_id, withheld, &runs)?;
+    let state_id = case.state_id;
+    let data = resolve(&case.state, &FreshnessPolicy::default());
+    let runs = draw_runs(panel, case, &data, frame)?;
+    check_provenance(panel, state_id, case.withheld, &runs)?;
     let bounds = Rect {
         min_x: 0.0,
         min_y: 0.0,
@@ -207,6 +247,7 @@ fn check_case(
                 panel: panel.id,
                 state: state_id,
                 frame,
+                alerted: case.alerted(),
                 text: run.text.clone(),
             });
         }
@@ -217,18 +258,21 @@ fn check_case(
 
 fn draw_runs(
     panel: &'static PanelDescriptor,
-    state_id: &'static str,
-    withheld: Option<GroupId>,
+    case: &Case,
     data: &PanelData,
     frame: DesignFrame,
 ) -> Result<Vec<TextRun>, AdmissionError> {
+    let state_id = case.state_id;
     let mut buf = vec![0u8; MAX_SCENE_BYTES];
     let scene =
-        draw_scene(panel, data, frame, &mut buf).map_err(|source| AdmissionError::Draw {
-            panel: panel.id,
-            state: state_id,
-            withheld,
-            source,
+        draw_scene(panel, data, case.alerts.as_ref(), frame, &mut buf).map_err(|source| {
+            AdmissionError::Draw {
+                panel: panel.id,
+                state: state_id,
+                withheld: case.withheld,
+                alerted: case.alerted(),
+                source,
+            }
         })?;
     let layers = validate_layers(scene).map_err(|error| match error {
         LayerError::Decode(_) => AdmissionError::Decode {
@@ -238,7 +282,8 @@ fn draw_runs(
         _ => AdmissionError::LayerContract {
             panel: panel.id,
             state: state_id,
-            withheld,
+            withheld: case.withheld,
+            alerted: case.alerted(),
         },
     })?;
     let missing = panel.required_layers & !layers.present;
@@ -246,7 +291,8 @@ fn draw_runs(
         return Err(AdmissionError::MissingRequiredLayers {
             panel: panel.id,
             state: state_id,
-            withheld,
+            withheld: case.withheld,
+            alerted: case.alerted(),
             missing,
         });
     }
@@ -273,11 +319,12 @@ enum RunsDefect {
 fn draw_scene<'b>(
     panel: &PanelDescriptor,
     data: &PanelData,
+    alerts: Option<&AlertOutput>,
     frame: DesignFrame,
     buf: &'b mut [u8],
 ) -> Result<&'b [u8], PanelDrawError> {
     let mut writer = SceneWriter::new(buf)?;
-    (panel.draw)(data, &EMPTY_CONFIG, None, frame, &mut writer)?;
+    (panel.draw)(data, &EMPTY_CONFIG, alerts, frame, &mut writer)?;
     let used = writer.finish();
     Ok(buf.get(..used).unwrap_or(&[]))
 }

--- a/crates/indicate-instrument-conformance/src/admission/alerts.rs
+++ b/crates/indicate-instrument-conformance/src/admission/alerts.rs
@@ -1,0 +1,52 @@
+//! The alert axis of the case matrix.
+//!
+//! A composed frame fans one `AlertOutput` to every slot, so a panel's
+//! criticality band is only honest if it was measured with alerts fed.
+//! Measuring with `None` alone would record a band that excludes the
+//! shared alert stack entirely, and a composition would then be told it
+//! may cover warning rows.
+//!
+//! One extra case per state is enough because the stack's extent is
+//! bounded and [`saturated_stack`] reaches all of it.
+
+use indicate_alerts::{
+    AlertCondition, AlertContext, AlertEvent, AlertManager, AlertOutput, AlertProfile,
+    MiscompareFault,
+};
+
+/// The alert output that drives the shared stack to its full extent.
+///
+/// Three things together bound it, and this fixture does all three:
+///
+/// - a **faulted** alerting path, which paints the `ALRT FAIL` marker
+///   four rows above the stack base — the topmost row the stack can
+///   reach, and, at nine characters, tied for the widest;
+/// - **more alerts than the stack shows**, which fills every visible row
+///   and raises the `MORE` marker below them;
+/// - a **warning** among them, so the highest class is represented.
+///
+/// A band measured over this case therefore contains the stack of every
+/// other alert output, which is what lets one extra case per state
+/// stand in for the whole alert axis.
+pub(super) fn saturated_stack() -> AlertOutput {
+    let mut events =
+        [AlertEvent::Assert(AlertCondition::Miscompare(MiscompareFault::Attitude)); 32];
+    for (index, event) in events.iter_mut().enumerate().skip(1) {
+        // Distinct identities: the manager keys on identity, so
+        // repeating one condition would fill a single slot.
+        *event = AlertEvent::Assert(AlertCondition::FrameMismatch { code: index as u8 });
+    }
+    let mut manager = AlertManager::new();
+    manager.step(
+        &AlertProfile::simulator(),
+        &events,
+        AlertContext {
+            // A faulted path is the only way to reach the stack's top
+            // row, and it is a real posture: the alerting path may
+            // degrade while the panels keep drawing.
+            alerting_path_healthy: false,
+            ..AlertContext::default()
+        },
+        1_000,
+    )
+}

--- a/crates/indicate-instrument-conformance/src/admission/background.rs
+++ b/crates/indicate-instrument-conformance/src/admission/background.rs
@@ -4,8 +4,8 @@
 use indicate_instrument_registry::{BackgroundCapability, DesignFrame, PanelDescriptor};
 use indicate_instrument_scene::{Cmd, LayerId, PaintMode, SceneCmds};
 
-use super::AdmissionError;
-use super::geometry::{Ctm, Rect};
+use super::error::AdmissionError;
+use super::geometry::{Gs, Rect, track_state};
 
 /// The declared background capability must be the scene's actual
 /// behavior in every corpus case: `NotUsed` may not paint in the band
@@ -49,23 +49,6 @@ pub(super) fn check_background(
     })
 }
 
-/// Graphics state as the real state machine carries it: Save pushes
-/// transform, clip, and paint state together; Restore pops all three.
-#[derive(Clone, Copy)]
-struct Gs {
-    ctm: Ctm,
-    clip: Option<Rect>,
-    fill_alpha: u8,
-}
-
-impl Gs {
-    const DEFAULT: Self = Self {
-        ctm: Ctm::IDENTITY,
-        clip: None,
-        fill_alpha: 255,
-    };
-}
-
 /// Whether any paint lands in the Background band, and whether the
 /// band carries a proven full-frame opaque fill: an axis-aligned
 /// full-alpha `Rect` whose mapped bounds contain the frame and whose
@@ -102,54 +85,6 @@ fn scan_background(scene: &[u8], width: f32, height: f32) -> Option<(bool, bool)
         }
     }
     Some((painted, covered))
-}
-
-/// Applies a state command to the graphics-state stack, exactly as the
-/// real state machine would.
-fn track_state(stack: &mut Vec<Gs>, cmd: &Cmd<'_>) {
-    match *cmd {
-        Cmd::Save => {
-            if let Some(top) = stack.last().copied() {
-                stack.push(top);
-            }
-        }
-        Cmd::Restore => {
-            stack.pop();
-            if stack.is_empty() {
-                stack.push(Gs::DEFAULT);
-            }
-        }
-        Cmd::Translate { x, y } => {
-            if let Some(gs) = stack.last_mut() {
-                gs.ctm.translate(x, y);
-            }
-        }
-        Cmd::Rotate { radians } => {
-            if let Some(gs) = stack.last_mut() {
-                gs.ctm.rotate(radians);
-            }
-        }
-        Cmd::FillColor { color } => {
-            if let Some(gs) = stack.last_mut() {
-                gs.fill_alpha = color.a;
-            }
-        }
-        Cmd::ClipRect { x, y, w, h } => {
-            if let Some(gs) = stack.last_mut() {
-                let mapped = gs.ctm.map_rect(&Rect {
-                    min_x: x,
-                    min_y: y,
-                    max_x: x + w,
-                    max_y: y + h,
-                });
-                gs.clip = Some(match gs.clip {
-                    None => mapped,
-                    Some(previous) => previous.intersect(&mapped),
-                });
-            }
-        }
-        _ => {}
-    }
 }
 
 /// Whether this command is a proven full-frame opaque fill under the

--- a/crates/indicate-instrument-conformance/src/admission/criticality.rs
+++ b/crates/indicate-instrument-conformance/src/admission/criticality.rs
@@ -49,28 +49,33 @@ fn measure(
     buf: &mut [u8],
 ) -> Result<PanelCriticality, AdmissionError> {
     let mut bound: Option<Rect> = None;
-    for (state_id, withheld, state) in case_matrix(panel) {
-        let data = resolve(&state, &FreshnessPolicy::default());
+    for case in case_matrix(panel) {
+        let state_id = case.state_id;
+        let data = resolve(&case.state, &FreshnessPolicy::default());
         let scene =
-            draw_scene(panel, &data, frame, buf).map_err(|source| AdmissionError::Draw {
-                panel: panel.id,
-                state: state_id,
-                withheld,
-                source,
+            draw_scene(panel, &data, case.alerts.as_ref(), frame, buf).map_err(|source| {
+                AdmissionError::Draw {
+                    panel: panel.id,
+                    state: state_id,
+                    withheld: case.withheld,
+                    alerted: case.alerted(),
+                    source,
+                }
             })?;
         let report = validate_layers(scene).map_err(|_| AdmissionError::LayerContract {
             panel: panel.id,
             state: state_id,
-            withheld,
+            withheld: case.withheld,
+            alerted: case.alerted(),
         })?;
-        let case = criticality_ink(scene, &report, frame).map_err(|_| AdmissionError::Decode {
+        let ink = criticality_ink(scene, &report, frame).map_err(|_| AdmissionError::Decode {
             panel: panel.id,
             state: state_id,
         })?;
-        bound = match (bound, case) {
-            (Some(union), Some(case)) => Some(union.union(&case)),
+        bound = match (bound, ink) {
+            (Some(union), Some(ink)) => Some(union.union(&ink)),
             (existing, None) => existing,
-            (None, case) => case,
+            (None, ink) => ink,
         };
     }
     Ok(PanelCriticality {

--- a/crates/indicate-instrument-conformance/src/admission/criticality.rs
+++ b/crates/indicate-instrument-conformance/src/admission/criticality.rs
@@ -1,0 +1,90 @@
+//! Derived criticality bands: the measured bound of where a panel puts
+//! warnings, failure indications, and simulation labelling.
+//!
+//! `group_regions` declares ordinary readout surfaces. Criticality
+//! content has no such declaration and deliberately gains none — a
+//! panel able to name its own warning surface could also understate it,
+//! and a compositor planning obscuration around an understated bound
+//! would cover a warning it was told was elsewhere. So the bound is
+//! measured: the union design-space ink of the `Annunciation` and
+//! `Failure` bands over the whole canonical × extreme × withheld case
+//! matrix, at every frame the panel pins.
+//!
+//! The matrix is what makes the union honest. A warning that only
+//! paints when a source fails paints in a withholding case, and a
+//! degraded layout that moves a flag moves it in an extreme state; a
+//! bound taken from the typical case alone would miss both.
+
+use indicate_instrument_registry::{
+    DesignFrame, PanelCriticality, PanelDescriptor, Region, Registry,
+};
+use indicate_instrument_scene::{MAX_SCENE_BYTES, validate_layers};
+use indicate_instrument_state::{FreshnessPolicy, resolve};
+
+use super::error::AdmissionError;
+use super::geometry::Rect;
+use super::ink::criticality_ink;
+use super::{case_matrix, draw_scene};
+
+/// Measures every registered panel's criticality band, one entry per
+/// panel × canonical frame.
+///
+/// Deliberately independent of the rest of the matrix: a band is a
+/// measurement, not a judgement, and a consumer re-pinning one must not
+/// need every other check to pass first.
+pub fn criticality_bands(registry: &Registry) -> Result<Vec<PanelCriticality>, AdmissionError> {
+    let mut out = Vec::new();
+    let mut buf = vec![0u8; MAX_SCENE_BYTES];
+    for panel in registry.panels() {
+        for frame in panel.canonical_frames {
+            out.push(measure(panel, *frame, &mut buf)?);
+        }
+    }
+    Ok(out)
+}
+
+fn measure(
+    panel: &'static PanelDescriptor,
+    frame: DesignFrame,
+    buf: &mut [u8],
+) -> Result<PanelCriticality, AdmissionError> {
+    let mut bound: Option<Rect> = None;
+    for (state_id, withheld, state) in case_matrix(panel) {
+        let data = resolve(&state, &FreshnessPolicy::default());
+        let scene =
+            draw_scene(panel, &data, frame, buf).map_err(|source| AdmissionError::Draw {
+                panel: panel.id,
+                state: state_id,
+                withheld,
+                source,
+            })?;
+        let report = validate_layers(scene).map_err(|_| AdmissionError::LayerContract {
+            panel: panel.id,
+            state: state_id,
+            withheld,
+        })?;
+        let case = criticality_ink(scene, &report, frame).map_err(|_| AdmissionError::Decode {
+            panel: panel.id,
+            state: state_id,
+        })?;
+        bound = match (bound, case) {
+            (Some(union), Some(case)) => Some(union.union(&case)),
+            (existing, None) => existing,
+            (None, case) => case,
+        };
+    }
+    Ok(PanelCriticality {
+        panel: panel.id,
+        frame,
+        band: bound.map(as_region),
+    })
+}
+
+fn as_region(rect: Rect) -> Region {
+    Region {
+        x: rect.min_x,
+        y: rect.min_y,
+        width: rect.max_x - rect.min_x,
+        height: rect.max_y - rect.min_y,
+    }
+}

--- a/crates/indicate-instrument-conformance/src/admission/error.rs
+++ b/crates/indicate-instrument-conformance/src/admission/error.rs
@@ -1,0 +1,163 @@
+//! Why a panel failed admission: one variant per check family, each
+//! carrying the context its message needs.
+
+use indicate_instrument_registry::{DesignFrame, PanelDrawError, Region};
+use indicate_instrument_state::GroupId;
+
+/// Why a panel failed admission.
+#[derive(Debug, Clone, PartialEq, thiserror::Error)]
+pub enum AdmissionError {
+    /// The panel refused to draw a corpus case.
+    #[error("panel {panel} failed to draw state {state} (withheld: {withheld:?})")]
+    Draw {
+        /// The refusing panel.
+        panel: &'static str,
+        /// The corpus state.
+        state: &'static str,
+        /// The withheld group, if the case withholds one.
+        withheld: Option<GroupId>,
+        /// The panel's own reason.
+        #[source]
+        source: PanelDrawError,
+    },
+    /// The emitted scene violates the layer contract.
+    #[error("panel {panel} scene for {state} (withheld: {withheld:?}) breaks the layer contract")]
+    LayerContract {
+        /// The drawing panel.
+        panel: &'static str,
+        /// The corpus state.
+        state: &'static str,
+        /// The withheld group, if any.
+        withheld: Option<GroupId>,
+    },
+    /// A required layer band is absent from the emitted scene.
+    #[error(
+        "panel {panel} scene for {state} (withheld: {withheld:?}) is missing required layers {missing:#04x}"
+    )]
+    MissingRequiredLayers {
+        /// The drawing panel.
+        panel: &'static str,
+        /// The corpus state.
+        state: &'static str,
+        /// The withheld group, if any.
+        withheld: Option<GroupId>,
+        /// Required-but-absent layer bits.
+        missing: u8,
+    },
+    /// The scene does not decode.
+    #[error("panel {panel} scene for {state} does not decode")]
+    Decode {
+        /// The drawing panel.
+        panel: &'static str,
+        /// The corpus state.
+        state: &'static str,
+    },
+    /// A text run uses a character outside the controlled vocabulary.
+    #[error("panel {panel} draws {ch:?} in {state}, outside the controlled vocabulary")]
+    GlyphCoverage {
+        /// The drawing panel.
+        panel: &'static str,
+        /// The corpus state.
+        state: &'static str,
+        /// The uncovered character.
+        ch: char,
+    },
+    /// A visible run claims a group that shows no value in the drawn
+    /// state — the panel painted a number for data it was not given.
+    #[error(
+        "panel {panel} shows {text:?} claimed from {group:?} in {state} while {group:?} shows no value"
+    )]
+    FabricatedNumeral {
+        /// The drawing panel.
+        panel: &'static str,
+        /// The corpus state.
+        state: &'static str,
+        /// The claimed group.
+        group: GroupId,
+        /// The offending run.
+        text: String,
+    },
+    /// A numeric run carries no provenance claim. Totality is what
+    /// makes the claim rule sound: an unclaimed numeral would escape
+    /// every withholding case.
+    #[error("panel {panel} draws numeric text {text:?} in {state} with no provenance claim")]
+    UntaggedNumeral {
+        /// The drawing panel.
+        panel: &'static str,
+        /// The corpus state.
+        state: &'static str,
+        /// The unclaimed run.
+        text: String,
+    },
+    /// A run claims a group outside the panel's required set (or an
+    /// unknown tag) — a claim the withholding matrix could never test.
+    #[error(
+        "panel {panel} claims tag {tag:#04x} for {text:?} in {state}, outside its required groups"
+    )]
+    ForeignClaim {
+        /// The drawing panel.
+        panel: &'static str,
+        /// The corpus state.
+        state: &'static str,
+        /// The claimed tag byte.
+        tag: u8,
+        /// The claiming run.
+        text: String,
+    },
+    /// A visible run claims configuration provenance under the
+    /// harness's fixed empty configuration — it derives from nothing.
+    #[error(
+        "panel {panel} shows {text:?} in {state} claiming configuration provenance under the empty configuration"
+    )]
+    ConfigClaim {
+        /// The drawing panel.
+        panel: &'static str,
+        /// The corpus state.
+        state: &'static str,
+        /// The claiming run.
+        text: String,
+    },
+    /// A provenance claim not immediately followed by the text run it
+    /// covers — a dangling or stacked claim is structurally malformed.
+    #[error("panel {panel} scene for {state} carries a provenance claim that covers no text run")]
+    MisplacedClaim {
+        /// The drawing panel.
+        panel: &'static str,
+        /// The corpus state.
+        state: &'static str,
+    },
+    /// The Background band contradicts the declared capability: a
+    /// compositor plans around this declaration, so both directions are
+    /// refused — painting a band declared `NotUsed`, and failing to
+    /// opaquely cover a band declared owned.
+    #[error("panel {panel} declares background {declared} but its {state} scene {defect} the band")]
+    BackgroundContract {
+        /// The drawing panel.
+        panel: &'static str,
+        /// The corpus state.
+        state: &'static str,
+        /// The declared capability.
+        declared: &'static str,
+        /// What the scene actually did: "paints" or "does not cover".
+        defect: &'static str,
+    },
+    /// A declared region caught no claimed ink in any case of the
+    /// panel's matrix. A composition plans obscuration around declared
+    /// regions, so a region pointing at empty space protects a surface
+    /// the readout does not use and leaves the surface it does use
+    /// undeclared.
+    #[error(
+        "panel {panel} declares {region:?} for {group:?} at frame {frame:?}, and no case draws {group:?} ink inside it"
+    )]
+    GroupRegionEmpty {
+        /// The declaring panel.
+        panel: &'static str,
+        /// The group the empty region claims to serve.
+        group: GroupId,
+        /// The region nothing populated.
+        region: Region,
+        /// The frame regions are declared against, and the frame the
+        /// search ran at.
+        frame: DesignFrame,
+    },
+}

--- a/crates/indicate-instrument-conformance/src/admission/error.rs
+++ b/crates/indicate-instrument-conformance/src/admission/error.rs
@@ -8,7 +8,9 @@ use indicate_instrument_state::GroupId;
 #[derive(Debug, Clone, PartialEq, thiserror::Error)]
 pub enum AdmissionError {
     /// The panel refused to draw a corpus case.
-    #[error("panel {panel} failed to draw state {state} (withheld: {withheld:?})")]
+    #[error(
+        "panel {panel} failed to draw state {state} (withheld: {withheld:?}, alerts: {alerted})"
+    )]
     Draw {
         /// The refusing panel.
         panel: &'static str,
@@ -16,12 +18,16 @@ pub enum AdmissionError {
         state: &'static str,
         /// The withheld group, if the case withholds one.
         withheld: Option<GroupId>,
+        /// Whether the saturated alert stack was fed.
+        alerted: bool,
         /// The panel's own reason.
         #[source]
         source: PanelDrawError,
     },
     /// The emitted scene violates the layer contract.
-    #[error("panel {panel} scene for {state} (withheld: {withheld:?}) breaks the layer contract")]
+    #[error(
+        "panel {panel} scene for {state} (withheld: {withheld:?}, alerts: {alerted}) breaks the layer contract"
+    )]
     LayerContract {
         /// The drawing panel.
         panel: &'static str,
@@ -29,10 +35,12 @@ pub enum AdmissionError {
         state: &'static str,
         /// The withheld group, if any.
         withheld: Option<GroupId>,
+        /// Whether the saturated alert stack was fed.
+        alerted: bool,
     },
     /// A required layer band is absent from the emitted scene.
     #[error(
-        "panel {panel} scene for {state} (withheld: {withheld:?}) is missing required layers {missing:#04x}"
+        "panel {panel} scene for {state} (withheld: {withheld:?}, alerts: {alerted}) is missing required layers {missing:#04x}"
     )]
     MissingRequiredLayers {
         /// The drawing panel.
@@ -41,6 +49,8 @@ pub enum AdmissionError {
         state: &'static str,
         /// The withheld group, if any.
         withheld: Option<GroupId>,
+        /// Whether the saturated alert stack was fed.
+        alerted: bool,
         /// Required-but-absent layer bits.
         missing: u8,
     },

--- a/crates/indicate-instrument-conformance/src/admission/geometry.rs
+++ b/crates/indicate-instrument-conformance/src/admission/geometry.rs
@@ -2,8 +2,12 @@
 //! semantics the reference rasterizer applies (post-multiplied
 //! translate/rotate, y-down clockwise rotation), with rotated shapes
 //! reduced to conservative axis-aligned bounds.
+//!
+//! The graphics state here mirrors the rasterizer's own: `Save` pushes
+//! transform, clip, and paint together and `Restore` pops all three, so
+//! a check that walks a scene sees what a backend would.
 
-use indicate_instrument_scene::{HAlign, VAlign, nominal_text_ink_width};
+use indicate_instrument_scene::{Cmd, HAlign, VAlign, nominal_text_ink_width};
 
 /// An axis-aligned rectangle in design-frame units.
 #[derive(Debug, Clone, Copy, PartialEq)]
@@ -15,6 +19,39 @@ pub(super) struct Rect {
 }
 
 impl Rect {
+    /// A rectangle covering nothing, so unioning it in changes nothing.
+    pub(super) const EMPTY: Rect = Rect {
+        min_x: f32::INFINITY,
+        min_y: f32::INFINITY,
+        max_x: f32::NEG_INFINITY,
+        max_y: f32::NEG_INFINITY,
+    };
+
+    pub(super) fn is_empty(&self) -> bool {
+        !(self.max_x > self.min_x && self.max_y > self.min_y)
+    }
+
+    /// The smallest rectangle containing both.
+    pub(super) fn union(&self, other: &Rect) -> Rect {
+        Rect {
+            min_x: self.min_x.min(other.min_x),
+            min_y: self.min_y.min(other.min_y),
+            max_x: self.max_x.max(other.max_x),
+            max_y: self.max_y.max(other.max_y),
+        }
+    }
+
+    /// Grows every edge outward by `margin` — a stroked shape inks half
+    /// its line width beyond the geometry it is drawn from.
+    pub(super) fn inflate(&self, margin: f32) -> Rect {
+        Rect {
+            min_x: self.min_x - margin,
+            min_y: self.min_y - margin,
+            max_x: self.max_x + margin,
+            max_y: self.max_y + margin,
+        }
+    }
+
     pub(super) fn intersects(&self, other: &Rect) -> bool {
         self.min_x < other.max_x
             && other.min_x < self.max_x
@@ -115,6 +152,85 @@ impl Ctm {
             out.max_y = out.max_y.max(y);
         }
         out
+    }
+}
+
+/// Graphics state as the real state machine carries it: Save pushes
+/// transform, clip, and paint state together; Restore pops all three.
+#[derive(Clone, Copy)]
+pub(super) struct Gs {
+    pub(super) ctm: Ctm,
+    pub(super) clip: Option<Rect>,
+    pub(super) fill_alpha: u8,
+    pub(super) stroke_width: f32,
+}
+
+impl Gs {
+    /// The state a scene starts in, matching the rasterizer's own
+    /// defaults.
+    pub(super) const DEFAULT: Self = Self {
+        ctm: Ctm::IDENTITY,
+        clip: None,
+        fill_alpha: 255,
+        stroke_width: 1.0,
+    };
+
+    /// How far a stroked shape inks beyond its geometry.
+    pub(super) fn stroke_margin(&self) -> f32 {
+        (self.stroke_width / 2.0).max(0.0)
+    }
+}
+
+/// Applies one command to the graphics-state stack, exactly as the real
+/// state machine would. Drawing commands leave it untouched.
+pub(super) fn track_state(stack: &mut Vec<Gs>, cmd: &Cmd<'_>) {
+    match *cmd {
+        Cmd::Save => {
+            if let Some(top) = stack.last().copied() {
+                stack.push(top);
+            }
+        }
+        Cmd::Restore => {
+            stack.pop();
+            if stack.is_empty() {
+                stack.push(Gs::DEFAULT);
+            }
+        }
+        Cmd::Translate { x, y } => {
+            if let Some(gs) = stack.last_mut() {
+                gs.ctm.translate(x, y);
+            }
+        }
+        Cmd::Rotate { radians } => {
+            if let Some(gs) = stack.last_mut() {
+                gs.ctm.rotate(radians);
+            }
+        }
+        Cmd::FillColor { color } => {
+            if let Some(gs) = stack.last_mut() {
+                gs.fill_alpha = color.a;
+            }
+        }
+        Cmd::Stroke { width, .. } => {
+            if let Some(gs) = stack.last_mut() {
+                gs.stroke_width = width;
+            }
+        }
+        Cmd::ClipRect { x, y, w, h } => {
+            if let Some(gs) = stack.last_mut() {
+                let mapped = gs.ctm.map_rect(&Rect {
+                    min_x: x,
+                    min_y: y,
+                    max_x: x + w,
+                    max_y: y + h,
+                });
+                gs.clip = Some(match gs.clip {
+                    None => mapped,
+                    Some(previous) => previous.intersect(&mapped),
+                });
+            }
+        }
+        _ => {}
     }
 }
 

--- a/crates/indicate-instrument-conformance/src/admission/ink.rs
+++ b/crates/indicate-instrument-conformance/src/admission/ink.rs
@@ -114,6 +114,15 @@ fn ink_bounds(cmd: &Cmd<'_>, margin: f32) -> Option<Rect> {
             anchor.v,
             text.chars().count(),
         )),
+        // State and structure commands ink nothing, and so does
+        // `Cmd::Unknown` — today. That is safe only because every
+        // painting opcode this revision defines is matched above, and
+        // an unknown opcode is by definition one no backend in the
+        // family paints. The opcode set is append-only, so the day a
+        // new *painting* opcode is added, a band measured by an older
+        // build of this harness would silently understate itself:
+        // adding a painting opcode means adding its arm here, in the
+        // same change.
         _ => None,
     }
 }

--- a/crates/indicate-instrument-conformance/src/admission/ink.rs
+++ b/crates/indicate-instrument-conformance/src/admission/ink.rs
@@ -1,0 +1,146 @@
+//! Design-space ink bounds for a chosen set of scene bands.
+//!
+//! Where the run collector reduces text to rectangles, this reduces
+//! *every* painting command to one — a filled shape's own extent, a
+//! stroked shape's extent grown by half its line width — so a band's
+//! bound covers what a backend would put on the surface rather than
+//! only its lettering.
+//!
+//! Bounds are clamped to the frame the panel was drawn at, because
+//! every backend clips there: ink outside the frame reaches no pixel,
+//! so counting it would overstate the band.
+
+use indicate_instrument_registry::DesignFrame;
+use indicate_instrument_scene::{Cmd, LayerId, LayerReport, PaintMode, SceneCmds};
+
+use super::geometry::{Gs, Rect, track_state};
+
+/// The scene did not decode.
+pub(super) struct InkDecodeError;
+
+/// The union design-space ink bound of the `Annunciation` and `Failure`
+/// bands, or `None` when neither band inks inside the frame.
+///
+/// Membership is decided by [`LayerReport::ranges`]: a command belongs
+/// to a band when its own offset falls in that band's byte range. The
+/// graphics state is tracked across the whole scene rather than from
+/// the range's start, because a band's transform is whatever the
+/// commands before it left — which the layer contract's mandatory
+/// isolation envelope makes the initial state, but reading it rather
+/// than assuming it costs nothing.
+pub(super) fn criticality_ink(
+    scene: &[u8],
+    report: &LayerReport,
+    frame: DesignFrame,
+) -> Result<Option<Rect>, InkDecodeError> {
+    let bands = [
+        band_range(report, LayerId::Annunciation),
+        band_range(report, LayerId::Failure),
+    ];
+    let frame_rect = Rect {
+        min_x: 0.0,
+        min_y: 0.0,
+        max_x: frame.width,
+        max_y: frame.height,
+    };
+    let mut cmds = SceneCmds::new(scene).map_err(|_| InkDecodeError)?;
+    let mut stack = vec![Gs::DEFAULT];
+    let mut bound = Rect::EMPTY;
+    loop {
+        let at = scene.len().saturating_sub(cmds.remaining());
+        let Some(cmd) = cmds.next() else { break };
+        let cmd = cmd.map_err(|_| InkDecodeError)?;
+        track_state(&mut stack, &cmd);
+        if !bands
+            .iter()
+            .flatten()
+            .any(|(start, end)| at >= *start && at < *end)
+        {
+            continue;
+        }
+        let gs = stack.last().ok_or(InkDecodeError)?;
+        let Some(local) = ink_bounds(&cmd, gs.stroke_margin()) else {
+            continue;
+        };
+        let mut painted = gs.ctm.map_rect(&local);
+        if let Some(clip) = gs.clip {
+            painted = painted.intersect(&clip);
+        }
+        painted = painted.intersect(&frame_rect);
+        if !painted.is_empty() {
+            bound = bound.union(&painted);
+        }
+    }
+    Ok((!bound.is_empty()).then_some(bound))
+}
+
+fn band_range(report: &LayerReport, layer: LayerId) -> Option<(usize, usize)> {
+    report.ranges.get(usize::from(layer.to_u8())).copied()?
+}
+
+/// One painting command's local-space ink rectangle, with a stroked
+/// shape grown by `margin`. State and structure commands ink nothing.
+fn ink_bounds(cmd: &Cmd<'_>, margin: f32) -> Option<Rect> {
+    match *cmd {
+        Cmd::Rect { mode, x, y, w, h } => {
+            Some(corners(x, y, x + w, y + h).inflate(edge(mode, margin)))
+        }
+        Cmd::Circle { mode, cx, cy, r } => {
+            Some(corners(cx - r, cy - r, cx + r, cy + r).inflate(edge(mode, margin)))
+        }
+        // A sweep's true extent needs the quadrants it crosses; the
+        // whole circle is the conservative answer and a band bound may
+        // only ever be too generous.
+        Cmd::Arc { cx, cy, r, .. } => Some(corners(cx - r, cy - r, cx + r, cy + r).inflate(margin)),
+        // A zero-extent segment still inks its line width.
+        Cmd::Line { x1, y1, x2, y2 } => {
+            Some(corners(x1.min(x2), y1.min(y2), x1.max(x2), y1.max(y2)).inflate(margin))
+        }
+        Cmd::Polyline { points } => hull(points.iter()).map(|rect| rect.inflate(margin)),
+        Cmd::Polygon { mode, points } => {
+            hull(points.iter()).map(|rect| rect.inflate(edge(mode, margin)))
+        }
+        Cmd::Text {
+            x,
+            y,
+            size,
+            anchor,
+            text,
+        } => Some(super::geometry::text_rect(
+            x,
+            y,
+            size,
+            anchor.h,
+            anchor.v,
+            text.chars().count(),
+        )),
+        _ => None,
+    }
+}
+
+/// How far past its geometry a shape drawn in `mode` inks.
+fn edge(mode: PaintMode, margin: f32) -> f32 {
+    match mode {
+        PaintMode::Stroke | PaintMode::FillStroke => margin,
+        PaintMode::Fill => 0.0,
+    }
+}
+
+fn corners(min_x: f32, min_y: f32, max_x: f32, max_y: f32) -> Rect {
+    Rect {
+        min_x,
+        min_y,
+        max_x,
+        max_y,
+    }
+}
+
+fn hull(points: impl Iterator<Item = [f32; 2]>) -> Option<Rect> {
+    let mut bound = Rect::EMPTY;
+    let mut any = false;
+    for [x, y] in points {
+        any = true;
+        bound = bound.union(&corners(x, y, x, y));
+    }
+    any.then_some(bound)
+}

--- a/crates/indicate-instrument-conformance/src/admission/regions.rs
+++ b/crates/indicate-instrument-conformance/src/admission/regions.rs
@@ -1,0 +1,116 @@
+//! The declared-region family: a group's readout surface must be a
+//! surface the group's readout actually uses.
+//!
+//! `group_regions` says where a group's *value* is drawn — the pointed
+//! readout, the data box — and deliberately not the scale ladder or the
+//! tick labels beside it, which carry the same group's claim because a
+//! numeral must carry one. That authoring rule is what makes a region
+//! useful, so the assertion here cannot be "all this group's claimed
+//! ink is inside", which no tape or rose panel could ever satisfy.
+//!
+//! The assertion is non-vacuity: **every declared region must be
+//! populated by at least one visible run claiming its group.** A region
+//! pointing at empty space is the real hazard, because the composition
+//! layer plans obscuration around regions — it would protect a surface
+//! where the readout is not and leave uncovered the surface where the
+//! readout is. A region is a claim that this is where the group's value
+//! appears, and this makes the claim answerable.
+//!
+//! A region counts as populated when it holds the *centre* of a
+//! claimed run's ink. Whole-rectangle containment would be the obvious
+//! reading and is the wrong one: run rectangles here are conservative
+//! nominal metrics, deliberately wider than the glyphs, while a region
+//! is drawn around the visual box — so a readout sitting dead centre in
+//! its own box fails containment by a few units and would be reported
+//! as pointing at empty space, which is the opposite of the truth. Bare
+//! overlap is the other extreme and too weak: a ladder rung grazing a
+//! region's corner is not that region's readout. The centre test asks
+//! the question the family exists to ask — is the group's value drawn
+//! *at* this surface.
+//!
+//! Two scoping rules, both consequences of what a region means rather
+//! than tolerances:
+//!
+//! - The witness is sought across the panel's whole case matrix, not
+//!   per case. A readout that dashes out under withholding paints no
+//!   claimed run in that case, and it is still the same readout.
+//! - The search runs at [`PanelDescriptor::frame_min`], the frame
+//!   regions are declared and validated against. A panel laid out at a
+//!   larger frame puts its readouts somewhere else, and floor
+//!   coordinates describe that layout no better than they describe
+//!   another panel's.
+
+use indicate_instrument_registry::{PanelDescriptor, Region};
+use indicate_instrument_state::{FreshnessPolicy, GroupId, resolve};
+
+use super::TextRun;
+use super::error::AdmissionError;
+use super::geometry::Rect;
+use super::{case_matrix, draw_runs};
+
+/// Asserts that every region `panel` declares is populated by claimed
+/// ink somewhere in its case matrix.
+pub(super) fn check_non_vacuity(panel: &'static PanelDescriptor) -> Result<(), AdmissionError> {
+    if panel.group_regions.is_empty() {
+        return Ok(());
+    }
+    let frame = panel.frame_min;
+    let mut populated = vec![false; panel.group_regions.len()];
+    for (state_id, withheld, state) in case_matrix(panel) {
+        let data = resolve(&state, &FreshnessPolicy::default());
+        let runs = draw_runs(panel, state_id, withheld, &data, frame)?;
+        witness(panel, &runs, &mut populated);
+    }
+    for (index, (group, region)) in panel.group_regions.iter().enumerate() {
+        if !populated.get(index).copied().unwrap_or(false) {
+            return Err(AdmissionError::GroupRegionEmpty {
+                panel: panel.id,
+                group: *group,
+                region: *region,
+                frame,
+            });
+        }
+    }
+    Ok(())
+}
+
+/// Marks every region this case populated.
+fn witness(panel: &PanelDescriptor, runs: &[TextRun], populated: &mut [bool]) {
+    for run in runs {
+        let Some(claimed) = run.claimed_group(panel) else {
+            continue;
+        };
+        if !run.visible {
+            continue;
+        }
+        let (x, y) = centre(&run.painted_rect());
+        for (index, (owner, region)) in panel.group_regions.iter().enumerate() {
+            if *owner != claimed {
+                continue;
+            }
+            if holds(region, x, y)
+                && let Some(seen) = populated.get_mut(index)
+            {
+                *seen = true;
+            }
+        }
+    }
+}
+
+fn centre(ink: &Rect) -> (f32, f32) {
+    ((ink.min_x + ink.max_x) / 2.0, (ink.min_y + ink.max_y) / 2.0)
+}
+
+fn holds(region: &Region, x: f32, y: f32) -> bool {
+    x >= region.x && x <= region.right() && y >= region.y && y <= region.bottom()
+}
+
+impl TextRun {
+    /// The state group this run claims, when the claim is one the
+    /// panel's withholding matrix covers. Claims outside it are already
+    /// refused by the provenance family, which runs first.
+    fn claimed_group(&self, panel: &PanelDescriptor) -> Option<GroupId> {
+        let tag = self.attribution?;
+        GroupId::from_u8(tag).filter(|group| panel.required_groups.contains(*group))
+    }
+}

--- a/crates/indicate-instrument-conformance/src/admission/regions.rs
+++ b/crates/indicate-instrument-conformance/src/admission/regions.rs
@@ -56,9 +56,9 @@ pub(super) fn check_non_vacuity(panel: &'static PanelDescriptor) -> Result<(), A
     }
     let frame = panel.frame_min;
     let mut populated = vec![false; panel.group_regions.len()];
-    for (state_id, withheld, state) in case_matrix(panel) {
-        let data = resolve(&state, &FreshnessPolicy::default());
-        let runs = draw_runs(panel, state_id, withheld, &data, frame)?;
+    for case in case_matrix(panel) {
+        let data = resolve(&case.state, &FreshnessPolicy::default());
+        let runs = draw_runs(panel, &case, &data, frame)?;
         witness(panel, &runs, &mut populated);
     }
     for (index, (group, region)) in panel.group_regions.iter().enumerate() {

--- a/crates/indicate-instrument-conformance/src/admission/tests.rs
+++ b/crates/indicate-instrument-conformance/src/admission/tests.rs
@@ -1,11 +1,11 @@
 #![allow(clippy::expect_used, clippy::panic)]
 
-use indicate_instrument_panels::BUILTIN_PANELS;
+use indicate_instrument_panels::{BUILTIN_CRITICALITY_BANDS, BUILTIN_PANELS};
 use indicate_instrument_registry::{
     BackgroundCapability, DesignFrame, GroupSet, PanelDescriptor, Registry,
 };
 
-use super::admit;
+use super::{admit, criticality_bands};
 
 #[test]
 fn builtin_panels_pass_admission() {
@@ -29,8 +29,20 @@ fn builtin_panels_pass_admission() {
             if text.starts_with("GS ") || text.starts_with("SET ")
     )));
 }
+
+/// The pinned bands must be what the emitted scenes actually measure:
+/// a composition validates obscuration against the pin, so a paint
+/// change that moves a warning has to move the pin in the same change.
+#[test]
+fn the_pinned_criticality_bands_are_the_measured_ones() {
+    let registry = Registry::new(BUILTIN_PANELS).expect("composes");
+    let measured = criticality_bands(&registry).expect("measures");
+    assert_eq!(measured, BUILTIN_CRITICALITY_BANDS.panels);
+}
+
 mod background_checks;
 mod provenance_checks;
+mod region_checks;
 
 /// The one frame every fixture panel below declares: a degenerate
 /// range, so each fixture is drawn exactly once per case and the counts

--- a/crates/indicate-instrument-conformance/src/admission/tests.rs
+++ b/crates/indicate-instrument-conformance/src/admission/tests.rs
@@ -12,8 +12,9 @@ fn builtin_panels_pass_admission() {
     let registry = Registry::new(BUILTIN_PANELS).expect("composes");
     let report = admit(&registry).expect("shipped panels must be admissible");
     // PFD: (4 canonical + 3 extreme) states × (1 fed + 8 withheld);
-    // HSI: (4 + 2) × 8; monitor: 5 × 2.
-    assert_eq!(report.cases, 121);
+    // HSI: (4 + 2) × 8; monitor: 5 × 2 — each drawn twice, quiet and
+    // with the saturated alert stack.
+    assert_eq!(report.cases, 242);
     // Every warning is the PFD's groundspeed or baro readout: their
     // boxes are 90 units wide but a wide value at size 16 has ~107
     // units of nominal ink, so the run overhangs its box and the frame
@@ -22,7 +23,10 @@ fn builtin_panels_pass_admission() {
     // corpus and extreme state; fixing the paint moves frame hashes and
     // is its own change. The ratchet makes any NEW unclipped off-frame
     // text a deliberate decision.
-    assert_eq!(report.warnings.len(), 83);
+    // Twice the quiet-frame count, because the overhanging runs are the
+    // groundspeed and baro readouts, which the alert stack does not
+    // touch: each overhangs on both sides of the alert axis.
+    assert_eq!(report.warnings.len(), 166);
     assert!(report.warnings.iter().all(|w| matches!(
         w,
         super::AdmissionWarning::FrameOverflow { panel: "pfd", text, .. }

--- a/crates/indicate-instrument-conformance/src/admission/tests/region_checks.rs
+++ b/crates/indicate-instrument-conformance/src/admission/tests/region_checks.rs
@@ -1,0 +1,162 @@
+//! Region-family fixtures: a declared readout surface must be one the
+//! group's readout really uses.
+#![allow(clippy::expect_used, clippy::panic)]
+
+use indicate_alerts::AlertOutput;
+use indicate_instrument_registry::{
+    BackgroundCapability, ConfigBlob, DesignFrame, GroupSet, PanelDescriptor, PanelDrawError,
+    Region, Registry,
+};
+use indicate_instrument_scene::{Anchor, LayerId, Rgba8, SceneWriter};
+use indicate_instrument_state::{GroupId, PanelData};
+
+use super::super::{AdmissionError, admit};
+use super::FIXTURE_FRAME;
+
+/// The surface the fixture panel declares for `Air`.
+const READOUT: Region = Region {
+    x: 20.0,
+    y: 20.0,
+    width: 120.0,
+    height: 40.0,
+};
+
+/// A second surface over blank canvas: nothing the panel draws claims
+/// `Air` anywhere near it.
+const BARREN: Region = Region {
+    x: 300.0,
+    y: 250.0,
+    width: 120.0,
+    height: 40.0,
+};
+
+/// Paints the `Air` readout inside [`READOUT`] and a scale ladder well
+/// outside it — the shape every tape panel has, and the reason the
+/// family cannot demand that all claimed ink sit inside a region.
+fn draw_tape(
+    data: &PanelData,
+    _config: &ConfigBlob<'_>,
+    _alerts: Option<&AlertOutput>,
+    _frame: DesignFrame,
+    scene: &mut SceneWriter<'_>,
+) -> Result<(), PanelDrawError> {
+    scene.begin_layer(LayerId::Tapes)?;
+    scene.save()?;
+    scene.fill_color(Rgba8::rgb(255, 255, 255))?;
+    if data.ias_kt.status.shows_value() {
+        let air = GroupId::Air.to_u8();
+        scene.text_attributed(air, 30.0, 45.0, 14.0, Anchor::MIDDLE_LEFT, "120")?;
+        for (index, rung) in ["100", "110", "130"].iter().enumerate() {
+            let y = 120.0 + 30.0 * index as f32;
+            scene.text_attributed(air, 200.0, y, 14.0, Anchor::MIDDLE_LEFT, rung)?;
+        }
+    } else {
+        scene.text(30.0, 45.0, 14.0, Anchor::MIDDLE_LEFT, "---")?;
+    }
+    scene.restore()?;
+    scene.end_layer(LayerId::Tapes)?;
+    Ok(())
+}
+
+const fn probe(id: &'static str, group_regions: &'static [(GroupId, Region)]) -> PanelDescriptor {
+    PanelDescriptor {
+        id,
+        title: "Probe",
+        required_layers: 1 << 2, // Tapes
+        required_groups: GroupSet::of(&[GroupId::Air]),
+        frame_min: FIXTURE_FRAME,
+        frame_max: FIXTURE_FRAME,
+        frame_step: (1.0, 1.0),
+        aspect_min: 1.30,
+        aspect_max: 1.37,
+        canonical_frames: &[FIXTURE_FRAME],
+        background: BackgroundCapability::NotUsed,
+        config_schema: &[],
+        group_regions,
+        extreme_states: &[],
+        raster_baselines: &[],
+        draw: draw_tape,
+    }
+}
+
+/// The witness only has to exist somewhere in the matrix: the readout
+/// dashes out under withholding and paints no claimed run at all in
+/// those cases, and the region is still the surface it uses.
+#[test]
+fn a_populated_region_is_admitted() {
+    static POPULATED: [PanelDescriptor; 1] = [probe("populated", &[(GroupId::Air, READOUT)])];
+    let registry = Registry::new(&POPULATED).expect("structurally valid");
+    admit(&registry).expect("the readout paints inside the region it declares");
+}
+
+#[test]
+fn a_region_over_blank_space_is_refused() {
+    static BARE: [PanelDescriptor; 1] = [probe("bare", &[(GroupId::Air, BARREN)])];
+    let registry = Registry::new(&BARE).expect("structurally valid");
+    let refusal = admit(&registry).expect_err("nothing claiming Air is drawn in that region");
+    let AdmissionError::GroupRegionEmpty {
+        panel,
+        group,
+        region,
+        frame,
+    } = refusal
+    else {
+        panic!("expected an empty region, got {refusal:?}");
+    };
+    assert_eq!(panel, "bare");
+    assert_eq!(group, GroupId::Air);
+    assert_eq!(region, BARREN);
+    assert_eq!(frame, FIXTURE_FRAME);
+}
+
+/// One populated region does not vouch for another: every declared
+/// surface answers for itself, or a panel could bury a fictional
+/// region behind a real one.
+#[test]
+fn a_barren_region_beside_a_populated_one_is_still_refused() {
+    static MIXED: [PanelDescriptor; 1] = [probe(
+        "mixed",
+        &[(GroupId::Air, READOUT), (GroupId::Air, BARREN)],
+    )];
+    let registry = Registry::new(&MIXED).expect("structurally valid");
+    let refusal = admit(&registry).expect_err("the second region catches nothing");
+    let AdmissionError::GroupRegionEmpty { region, .. } = refusal else {
+        panic!("expected an empty region, got {refusal:?}");
+    };
+    assert_eq!(region, BARREN);
+}
+
+/// A sliver overlapping the underside of the first ladder rung's ink
+/// and nothing else: claimed ink crosses it, but no claimed run is
+/// drawn *at* it.
+const GRAZE: Region = Region {
+    x: 190.0,
+    y: 126.0,
+    width: 70.0,
+    height: 16.0,
+};
+
+/// Overlap is not the test. A region clipped by the edge of a rung it
+/// does not own would otherwise vouch for itself, which would make the
+/// family satisfiable by any region drawn near enough to any ink.
+#[test]
+fn a_region_merely_grazed_by_claimed_ink_is_refused() {
+    static GRAZED: [PanelDescriptor; 1] = [probe("grazed", &[(GroupId::Air, GRAZE)])];
+    let registry = Registry::new(&GRAZED).expect("structurally valid");
+    let refusal = admit(&registry).expect_err("no run is drawn at that surface");
+    let AdmissionError::GroupRegionEmpty { region, .. } = refusal else {
+        panic!("expected an empty region, got {refusal:?}");
+    };
+    assert_eq!(region, GRAZE);
+}
+
+/// Ink claiming the group outside every declared region is not a
+/// defect: a scale ladder's rungs carry the group's claim because a
+/// numeral must, and they sit outside the readout box on purpose.
+#[test]
+fn claimed_ink_outside_the_regions_is_not_a_defect() {
+    static POPULATED: [PanelDescriptor; 1] = [probe("ladder", &[(GroupId::Air, READOUT)])];
+    let registry = Registry::new(&POPULATED).expect("structurally valid");
+    let report = admit(&registry).expect("the ladder rungs are honest ink outside the readout");
+    assert!(report.cases > 0);
+}

--- a/crates/indicate-instrument-conformance/src/lib.rs
+++ b/crates/indicate-instrument-conformance/src/lib.rs
@@ -3,19 +3,21 @@
 //!
 //! [`admit`] drives every registered panel through the shared canonical
 //! corpus plus the panel's own extreme states, and through every
-//! single-group withholding its descriptor declares, then checks five
+//! single-group withholding its descriptor declares, then checks six
 //! families: the layer contract (well-formed scenes with every required
 //! band present under every degradation), the background contract (the
 //! declared capability is the band's actual behavior — `NotUsed` never
 //! opens it, an owned band carries a full-frame opaque paint), budgets
 //! (a text run outside the design frame is a counted warning), glyph
 //! coverage (every text run resolves within the controlled
-//! vocabulary), and honest status as a provenance rule (every numeric
+//! vocabulary), honest status as a provenance rule (every numeric
 //! run must claim the state group its value derives from, the claim is
 //! bounded to the panel's required groups, and a run claiming the
-//! withheld group may not be visible — wherever it is drawn). A shell
-//! composes its registry and runs this once at integration time; a
-//! panel that fails does not join an operational layout.
+//! withheld group may not be visible — wherever it is drawn), and
+//! declared regions (a claimed run lands inside a region its group
+//! declares). A shell composes its registry and runs this once at
+//! integration time; a panel that fails does not join an operational
+//! layout.
 //!
 //! Scope, honestly stated: this is a regression net for cooperative
 //! panels, not a proof against adversarial ones. The numeral test is
@@ -33,6 +35,12 @@
 //! numeral legitimately derives from configuration is unadmittable by
 //! construction, not merely untested.
 
+//! Two families are positional, and they exist for the compositor
+//! above: `group_regions` now bounds where a group's readout ink may
+//! land, and the `Annunciation`/`Failure` ink bound is *measured* per
+//! panel × canonical frame ([`criticality_bands`]) rather than
+//! declared. A screen composition plans obscuration against both.
+
 mod admission;
 
-pub use admission::{AdmissionError, AdmissionReport, AdmissionWarning, admit};
+pub use admission::{AdmissionError, AdmissionReport, AdmissionWarning, admit, criticality_bands};

--- a/crates/indicate-instrument-descriptor/src/criticality.rs
+++ b/crates/indicate-instrument-descriptor/src/criticality.rs
@@ -1,0 +1,55 @@
+//! Derived criticality bands: where a panel's warnings, failure
+//! indications, and simulation labelling can land.
+//!
+//! Ordinary readout surfaces are *declared* — [`crate::PanelDescriptor`]
+//! carries `group_regions`. Criticality content has no such declaration
+//! and must not gain one: a panel that could name its own warning
+//! surface could also understate it. The bound is measured instead, by
+//! the admission harness, as the union design-space ink of the
+//! `Annunciation` and `Failure` bands over the whole case matrix, and
+//! pinned so a consumer holds it as plain data.
+//!
+//! A band is keyed by panel *and* frame. A panel laid out at two frames
+//! puts its warnings in two different places, and a union across frames
+//! would be a rectangle in no coordinate space at all.
+
+use crate::descriptor::{DesignFrame, Region};
+
+/// One panel's measured criticality band at one design frame.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct PanelCriticality {
+    /// The panel this bound was measured from.
+    pub panel: &'static str,
+    /// The design frame it was measured at; the bound is in that
+    /// frame's coordinates.
+    pub frame: DesignFrame,
+    /// The union ink bound, or `None` when the panel put no ink in
+    /// either band in any case — an honest empty, not an unknown.
+    pub band: Option<Region>,
+}
+
+/// The criticality bands a shell holds: pinned constants, or the values
+/// an admission run measured and a consumer transcribed.
+///
+/// Lookup is by panel id and frame together, and a miss is a miss: a
+/// consumer asking about a size no run ever measured is told nothing
+/// rather than told zero.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct CriticalityBands {
+    /// The measured entries, in any order; one per panel × frame.
+    pub panels: &'static [PanelCriticality],
+}
+
+impl CriticalityBands {
+    /// No measurements at all. A composition validated against this
+    /// refuses every slot, which is the correct answer for a consumer
+    /// that pinned nothing.
+    pub const EMPTY: CriticalityBands = CriticalityBands { panels: &[] };
+
+    /// The entry for `panel` at `frame`, if one was measured.
+    pub fn entry(&self, panel: &str, frame: DesignFrame) -> Option<&'static PanelCriticality> {
+        self.panels
+            .iter()
+            .find(|entry| entry.panel == panel && entry.frame == frame)
+    }
+}

--- a/crates/indicate-instrument-descriptor/src/descriptor.rs
+++ b/crates/indicate-instrument-descriptor/src/descriptor.rs
@@ -82,6 +82,67 @@ pub struct Region {
     pub height: f32,
 }
 
+impl Region {
+    /// The whole of `frame`, as a region at its origin.
+    pub const fn of(frame: DesignFrame) -> Region {
+        Region {
+            x: 0.0,
+            y: 0.0,
+            width: frame.width,
+            height: frame.height,
+        }
+    }
+
+    /// Right edge.
+    pub fn right(&self) -> f32 {
+        self.x + self.width
+    }
+
+    /// Bottom edge.
+    pub fn bottom(&self) -> f32 {
+        self.y + self.height
+    }
+
+    /// Whether every coordinate is finite and both extents are
+    /// positive. A degenerate region names no surface, so it cannot be
+    /// a readout's or a slot's.
+    pub fn is_sound(&self) -> bool {
+        self.x.is_finite()
+            && self.y.is_finite()
+            && self.width.is_finite()
+            && self.height.is_finite()
+            && self.width > 0.0
+            && self.height > 0.0
+    }
+
+    /// Whether the two overlap on a positive area; sharing only an edge
+    /// does not count.
+    pub fn intersects(&self, other: &Region) -> bool {
+        self.x < other.right()
+            && other.x < self.right()
+            && self.y < other.bottom()
+            && other.y < self.bottom()
+    }
+
+    /// Whether `other` lies wholly inside this region.
+    pub fn contains(&self, other: &Region) -> bool {
+        other.x >= self.x
+            && other.y >= self.y
+            && other.right() <= self.right()
+            && other.bottom() <= self.bottom()
+    }
+
+    /// The same region moved by `(dx, dy)` — a panel's own design-space
+    /// rectangle placed at a composition slot's origin.
+    pub fn translated(&self, dx: f32, dy: f32) -> Region {
+        Region {
+            x: self.x + dx,
+            y: self.y + dy,
+            ..*self
+        }
+    }
+}
+
 /// A panel-contributed extreme state for conformance and digest runs:
 /// the panel names the situations that stress it beyond the shared
 /// canonical set.
@@ -137,11 +198,25 @@ pub struct PanelDescriptor {
     /// Configuration keys this panel understands; a shell refuses a
     /// blob carrying any other key.
     pub config_schema: &'static [ConfigKey],
-    /// Where each consumed group paints its readout — a forward
-    /// declaration for a shell that presents readout ownership or a
-    /// dash-out check. Structurally validated; no shipped consumer
-    /// reads it today (honest status is proven by provenance claims on
-    /// the runs, not by regions).
+    /// Where each consumed group's *value* is drawn: the pointed
+    /// readout, the data box — not the scale ladder or the tick labels
+    /// beside it, which carry the same group's claim because a numeral
+    /// must carry one.
+    ///
+    /// Validated for geometry here — inside [`PanelDescriptor::frame_min`],
+    /// non-degenerate, only for required groups — and asserted by the
+    /// admission harness for non-vacuity: every declared region must be
+    /// populated by claimed ink somewhere in the panel's case matrix. A
+    /// region over blank space is what the assertion is for, because
+    /// screen composition plans obscuration around these rectangles and
+    /// would protect a surface the readout does not use.
+    ///
+    /// Silence is a declaration too: a group with no region here is not
+    /// judged positionally, because some readouts share a strip with a
+    /// neighbouring group's ink and no geometry separates them.
+    ///
+    /// Criticality content is bounded separately and by measurement
+    /// rather than declaration ([`crate::PanelCriticality`]).
     pub group_regions: &'static [(GroupId, Region)],
     /// Panel-contributed stress fixtures beyond the canonical states.
     pub extreme_states: &'static [ExtremeState],

--- a/crates/indicate-instrument-descriptor/src/lib.rs
+++ b/crates/indicate-instrument-descriptor/src/lib.rs
@@ -23,12 +23,14 @@
 extern crate std;
 
 mod config;
+mod criticality;
 mod descriptor;
 mod group_set;
 mod set;
 pub mod states;
 
 pub use config::{CONFIG_BLOB_MAX, ConfigBlob, ConfigError, ConfigKey, EMPTY_CONFIG, keys};
+pub use criticality::{CriticalityBands, PanelCriticality};
 pub use descriptor::{
     BackgroundCapability, DesignFrame, DrawFn, ExtremeState, PanelDescriptor, PanelDrawError,
     Region,

--- a/crates/indicate-instrument-raster/Cargo.toml
+++ b/crates/indicate-instrument-raster/Cargo.toml
@@ -10,12 +10,13 @@ workspace = true
 
 [dependencies]
 libm = { workspace = true }
+indicate-alerts = { workspace = true }
 indicate-instrument-glyphs = { workspace = true }
 thiserror = { workspace = true }
+indicate-instrument-registry = { workspace = true }
 indicate-instrument-scene = { workspace = true }
+indicate-instrument-state = { workspace = true }
 
 [dev-dependencies]
 indicate-instrument-panels = { workspace = true }
-indicate-instrument-registry = { workspace = true }
-indicate-instrument-state = { workspace = true }
 sha2 = { workspace = true }

--- a/crates/indicate-instrument-raster/src/composition.rs
+++ b/crates/indicate-instrument-raster/src/composition.rs
@@ -1,0 +1,168 @@
+//! Screen composition on the reference rasterizer: several validated
+//! panel scenes into one framebuffer (AIR-OUT-011).
+//!
+//! This is the backend contract's composition rule executed rather than
+//! described. Slots paint in index order; each is clipped to its rect,
+//! translated to its origin, and replayed from that panel's own scene.
+//! There is one framebuffer, cleared once, and one global mapping from
+//! screen-logical units to device pixels — the same 1:1 identity every
+//! single-panel render uses, so a composed frame is comparable to the
+//! panel frames beneath it pixel for pixel.
+//!
+//! Placement reuses [`crate::FramebufferDims`]'s sub-window idea: a slot
+//! is a window onto a shared surface, differing from a strided
+//! sub-buffer only in that slots may overlap. Nothing here rescales a
+//! scene — the IR has no scale op and a compositor never rewrites
+//! commands, so a slot's dimensions *are* the frame its panel is asked
+//! to emit.
+//!
+//! **One snapshot, one alert state, every slot.** The inputs are fanned
+//! to every panel unchanged, which is what makes two overlapping panels
+//! showing the same quantity unable to disagree
+//! (`AIR-BAS-007`). A caller that resolved twice would have to work at
+//! it.
+//!
+//! Scope, stated plainly: this is a determinism instrument, not a
+//! flight-worthy compositor. A slot that fails here spoils the whole
+//! frame, as every reference render does, because a bit-exact harness
+//! that painted a partial frame would pin a hash of undefined content.
+//! The per-slot in-rect failure presentation the contract requires of a
+//! real backend is a runtime obligation of the shell, above this.
+//!
+//! A composition is validated at init by
+//! [`indicate_instrument_registry::validate_composition`]; this paints
+//! what that admitted, and deliberately does not re-run it — validation
+//! needs the criticality bands, and painting must not.
+
+use indicate_alerts::AlertOutput;
+use indicate_instrument_registry::{
+    CompositionDescriptor, DesignFrame, EMPTY_CONFIG, Registry, Slot,
+};
+use indicate_instrument_scene::SceneWriter;
+use indicate_instrument_state::PanelData;
+
+use crate::error::RasterError;
+use crate::raster::{Placement, paint_at};
+use crate::report::{FrameId, FramebufferDims, RenderReport, RenderStatus};
+use crate::surface::Surface;
+
+/// What every slot of one composed frame is drawn from.
+///
+/// The scratch buffer is the caller's, reused slot by slot: a slot's
+/// scene is encoded, painted, and finished with before the next one is
+/// encoded, so a composed frame needs one scene buffer rather than one
+/// per slot. Size it [`indicate_instrument_scene::MAX_SCENE_BYTES`].
+pub struct CompositionInputs<'a> {
+    /// The single resolved snapshot every slot draws from.
+    pub data: &'a PanelData,
+    /// The single alert state every slot draws from.
+    pub alerts: Option<&'a AlertOutput>,
+    /// Scene encoding scratch, reused across slots.
+    pub scratch: &'a mut [u8],
+}
+
+/// Paints `composition` into one RGBA8 framebuffer.
+///
+/// The framebuffer is the logical screen at 1:1. On success it holds the
+/// composed frame; on any failure after the framebuffer geometry is
+/// accepted it holds the spoil pattern and the error is returned, so a
+/// caller can never mistake a partial composition for a whole one.
+///
+/// The report describes the composed frame: `layers_present` is the
+/// union over slots, `unknown_opcodes` their sum, and `work` the whole
+/// frame's. Composed work is deliberately not gated against
+/// [`crate::RenderWork::BUDGET`], which prices one panel — a composed
+/// budget is the sum of its slots' and belongs to whoever declares the
+/// screen.
+pub fn render_composition(
+    registry: &Registry,
+    composition: &CompositionDescriptor,
+    inputs: &mut CompositionInputs<'_>,
+    pixels: &mut [u8],
+    dims: FramebufferDims,
+    frame: FrameId,
+) -> Result<RenderReport, RasterError> {
+    let mut surface = Surface::new(pixels, dims)?;
+    surface.clear();
+    let mut painted = Painted::default();
+    for slot in composition.slots {
+        match paint_slot(registry, slot, inputs, &mut surface, &mut painted) {
+            Ok(()) => {}
+            Err(error) => {
+                surface.spoil();
+                return Err(error);
+            }
+        }
+    }
+    Ok(RenderReport {
+        scene_version: painted.scene_version,
+        status: RenderStatus::Painted,
+        frame,
+        unknown_opcodes: painted.unknown_opcodes,
+        layers_present: painted.layers_present,
+        work: surface.work(),
+    })
+}
+
+/// What the slots painted so far contribute to the composed report.
+#[derive(Default)]
+struct Painted {
+    scene_version: u8,
+    unknown_opcodes: u32,
+    layers_present: u8,
+}
+
+fn paint_slot(
+    registry: &Registry,
+    slot: &Slot,
+    inputs: &mut CompositionInputs<'_>,
+    surface: &mut Surface<'_>,
+    painted: &mut Painted,
+) -> Result<(), RasterError> {
+    let panel = registry
+        .by_id(slot.panel)
+        .ok_or(RasterError::SlotPanelMissing { panel: slot.panel })?;
+    let mut writer = SceneWriter::new(inputs.scratch)
+        .map_err(|_| RasterError::SlotSceneBuffer { panel: panel.id })?;
+    // The frame asked for is the slot's own size: composition is
+    // placement, so the rect and the emission frame are one decision.
+    (panel.draw)(
+        inputs.data,
+        &EMPTY_CONFIG,
+        inputs.alerts,
+        slot_frame(slot),
+        &mut writer,
+    )
+    .map_err(|source| RasterError::SlotDraw {
+        panel: panel.id,
+        source,
+    })?;
+    let used = writer.finish();
+    let scene = inputs
+        .scratch
+        .get(..used)
+        .ok_or(RasterError::SlotSceneBuffer { panel: panel.id })?;
+    painted.scene_version = scene.first().copied().unwrap_or(0);
+    let (unknown, layers) = paint_at(
+        scene,
+        surface,
+        Placement {
+            origin: (slot.rect.x, slot.rect.y),
+            extent: Some((slot.rect.width, slot.rect.height)),
+        },
+    )?;
+    painted.unknown_opcodes = painted.unknown_opcodes.wrapping_add(unknown);
+    painted.layers_present |= layers;
+    Ok(())
+}
+
+/// The frame a slot asks its panel for.
+fn slot_frame(slot: &Slot) -> DesignFrame {
+    DesignFrame {
+        width: slot.rect.width,
+        height: slot.rect.height,
+    }
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/indicate-instrument-raster/src/composition/tests.rs
+++ b/crates/indicate-instrument-raster/src/composition/tests.rs
@@ -17,6 +17,8 @@ use std::string::String;
 use std::vec;
 use std::vec::Vec;
 
+mod obscuration;
+
 use super::{CompositionInputs, render_composition};
 use crate::{FrameId, FramebufferDims, RasterError, RenderStatus};
 
@@ -29,29 +31,35 @@ use crate::{FrameId, FramebufferDims, RasterError, RenderStatus};
 /// Each covers a different composition shape, because placement, opaque
 /// overlap, and overlay show-through fail in different ways.
 const SIDE_BY_SIDE_HASH: &str = "ce6b4347e9ccc2e58447ebcad733a287ee4e98eca7c1b6d9f631267fe4430a16";
-const OPAQUE_INSET_HASH: &str = "5779b1a9a8acb12e2e023a10873640463805e6a2fdc08d37b3155bc14a822344";
-const OVERLAY_HASH: &str = "f1065a413363f7a668df49a3bece465ee432dfed9651802f2613fa2a453285b9";
+const OPAQUE_INSET_HASH: &str = "3e9eeb272b232ba6f4be465aa7402ef0fb0b95a88233b2e6dfa0e8d05304b898";
+const OVERLAY_HASH: &str = "4a5cc9228d78bdbc72671e53ac8bfc03bfc30071aa19b43fa61e42e877089e19";
 
-const PANEL_FRAME: DesignFrame = DesignFrame {
+pub(super) const PANEL_FRAME: DesignFrame = DesignFrame {
     width: 480.0,
     height: 360.0,
 };
 
 /// The inset and overlay both occupy this rect on the PFD: the strip
-/// below the PFD's measured criticality band (which ends at y 292) and
-/// above its bottom data boxes (which start at y 335 and sit at the far
-/// left and right). `validate_composition` proves that reading rather
-/// than this comment — see [`the_fixtures_are_admissible_compositions`].
+/// above the PFD's measured criticality band, which begins at y 38 and
+/// runs to the bottom of the alert stack at y 352. That leaves the top
+/// band of the frame, clear also of the VSI readout strip at x 440.
+///
+/// The rect is deliberately small. Once a panel's warnings are measured
+/// with alerts fed, a PFD-sized panel has very little surface a slot
+/// may sit on at all, and that is the floor working rather than a
+/// fixture inconvenience. `validate_composition` proves the reading
+/// rather than this comment — see
+/// [`the_fixtures_are_admissible_compositions`].
 const INSET_RECT: Region = Region {
     x: 140.0,
-    y: 296.0,
+    y: 4.0,
     width: 200.0,
-    height: 60.0,
+    height: 32.0,
 };
 
 const INSET_FRAME: DesignFrame = DesignFrame {
     width: 200.0,
-    height: 60.0,
+    height: 32.0,
 };
 
 fn no_config(config: &ConfigBlob<'_>) -> Result<(), PanelDrawError> {
@@ -102,7 +110,7 @@ fn marker_band(scene: &mut SceneWriter<'_>) -> Result<(), PanelDrawError> {
     scene.begin_layer(LayerId::Tapes)?;
     scene.save()?;
     scene.fill_color(Rgba8::rgb(255, 208, 0))?;
-    scene.rect(PaintMode::Fill, 12.0, 12.0, 80.0, 20.0)?;
+    scene.rect(PaintMode::Fill, 12.0, 8.0, 80.0, 16.0)?;
     scene.restore()?;
     scene.end_layer(LayerId::Tapes)?;
     Ok(())
@@ -121,8 +129,8 @@ const fn fixture(
         frame_min: INSET_FRAME,
         frame_max: INSET_FRAME,
         frame_step: (1.0, 1.0),
-        aspect_min: 3.3,
-        aspect_max: 3.4,
+        aspect_min: 6.2,
+        aspect_max: 6.3,
         canonical_frames: &[INSET_FRAME],
         background,
         config_schema: &[],
@@ -153,7 +161,7 @@ const PFD_BAND: PanelCriticality = PanelCriticality {
         x: 6.0,
         y: 38.0,
         width: 468.0,
-        height: 254.0,
+        height: 314.0,
     }),
 };
 
@@ -228,7 +236,7 @@ const OVERLAY: CompositionDescriptor = CompositionDescriptor {
 
 /// The shared canonical "typical" state, the same fixture the per-panel
 /// frame hashes and the scene digest draw.
-fn typical() -> PanelData {
+pub(super) fn typical() -> PanelData {
     resolve(
         &indicate_instrument_registry::states::typical(),
         &FreshnessPolicy::default(),

--- a/crates/indicate-instrument-raster/src/composition/tests.rs
+++ b/crates/indicate-instrument-raster/src/composition/tests.rs
@@ -1,0 +1,467 @@
+//! Composed-frame evidence: three pinned REN-03-style hashes, and the
+//! show-through property that makes overlap safe.
+#![allow(clippy::expect_used, clippy::panic)]
+
+use indicate_alerts::AlertOutput;
+use indicate_instrument_panels::{BUILTIN_CRITICALITY_BANDS, PFD_DESCRIPTOR};
+use indicate_instrument_registry::{
+    BackgroundCapability, CompositionDescriptor, ConfigBlob, CriticalityBands, DesignFrame,
+    GroupSet, PanelCriticality, PanelDescriptor, PanelDrawError, Region, Registry, Slot,
+    validate_composition,
+};
+use indicate_instrument_scene::{LayerId, MAX_SCENE_BYTES, PaintMode, Rgba8, SceneWriter};
+use indicate_instrument_state::{FreshnessPolicy, PanelData, resolve};
+use sha2::{Digest, Sha256};
+
+use std::string::String;
+use std::vec;
+use std::vec::Vec;
+
+use super::{CompositionInputs, render_composition};
+use crate::{FrameId, FramebufferDims, RasterError, RenderStatus};
+
+/// Composed-frame hashes pinned from a byte-reproducible render, in the
+/// same discipline as the per-panel `raster_baselines` (REN-03): `libm`
+/// plus IEEE-754 `f32` make them identical across the supported CI
+/// architectures, so a mismatch is a determinism regression rather than
+/// a value to re-pin casually.
+///
+/// Each covers a different composition shape, because placement, opaque
+/// overlap, and overlay show-through fail in different ways.
+const SIDE_BY_SIDE_HASH: &str = "ce6b4347e9ccc2e58447ebcad733a287ee4e98eca7c1b6d9f631267fe4430a16";
+const OPAQUE_INSET_HASH: &str = "5779b1a9a8acb12e2e023a10873640463805e6a2fdc08d37b3155bc14a822344";
+const OVERLAY_HASH: &str = "f1065a413363f7a668df49a3bece465ee432dfed9651802f2613fa2a453285b9";
+
+const PANEL_FRAME: DesignFrame = DesignFrame {
+    width: 480.0,
+    height: 360.0,
+};
+
+/// The inset and overlay both occupy this rect on the PFD: the strip
+/// below the PFD's measured criticality band (which ends at y 292) and
+/// above its bottom data boxes (which start at y 335 and sit at the far
+/// left and right). `validate_composition` proves that reading rather
+/// than this comment — see [`the_fixtures_are_admissible_compositions`].
+const INSET_RECT: Region = Region {
+    x: 140.0,
+    y: 296.0,
+    width: 200.0,
+    height: 60.0,
+};
+
+const INSET_FRAME: DesignFrame = DesignFrame {
+    width: 200.0,
+    height: 60.0,
+};
+
+fn no_config(config: &ConfigBlob<'_>) -> Result<(), PanelDrawError> {
+    config.require_schema(&[])?;
+    Ok(())
+}
+
+/// An `Opaque` inset: it owns its background band with a full-frame
+/// fill, so it occludes everything under its rect. The declaration is
+/// honest by construction here, which is what admission proves for a
+/// shipped panel.
+fn draw_inset(
+    _data: &PanelData,
+    config: &ConfigBlob<'_>,
+    _alerts: Option<&AlertOutput>,
+    frame: DesignFrame,
+    scene: &mut SceneWriter<'_>,
+) -> Result<(), PanelDrawError> {
+    no_config(config)?;
+    scene.begin_layer(LayerId::Background)?;
+    scene.save()?;
+    scene.fill_color(Rgba8::rgb(16, 24, 48))?;
+    scene.rect(PaintMode::Fill, 0.0, 0.0, frame.width, frame.height)?;
+    scene.restore()?;
+    scene.end_layer(LayerId::Background)?;
+    marker_band(scene)?;
+    Ok(())
+}
+
+/// A `NotUsed` overlay: it opens no background band at all, so every
+/// pixel of its rect that its own symbology does not paint is left
+/// showing whatever lies beneath.
+fn draw_overlay(
+    _data: &PanelData,
+    config: &ConfigBlob<'_>,
+    _alerts: Option<&AlertOutput>,
+    _frame: DesignFrame,
+    scene: &mut SceneWriter<'_>,
+) -> Result<(), PanelDrawError> {
+    no_config(config)?;
+    marker_band(scene)?;
+    Ok(())
+}
+
+/// The symbology both fixtures paint: one opaque bar well inside the
+/// rect, leaving the rest of the band untouched.
+fn marker_band(scene: &mut SceneWriter<'_>) -> Result<(), PanelDrawError> {
+    scene.begin_layer(LayerId::Tapes)?;
+    scene.save()?;
+    scene.fill_color(Rgba8::rgb(255, 208, 0))?;
+    scene.rect(PaintMode::Fill, 12.0, 12.0, 80.0, 20.0)?;
+    scene.restore()?;
+    scene.end_layer(LayerId::Tapes)?;
+    Ok(())
+}
+
+const fn fixture(
+    id: &'static str,
+    background: BackgroundCapability,
+    draw: indicate_instrument_registry::DrawFn,
+) -> PanelDescriptor {
+    PanelDescriptor {
+        id,
+        title: "Fixture",
+        required_layers: 1 << 2, // Tapes
+        required_groups: GroupSet::EMPTY,
+        frame_min: INSET_FRAME,
+        frame_max: INSET_FRAME,
+        frame_step: (1.0, 1.0),
+        aspect_min: 3.3,
+        aspect_max: 3.4,
+        canonical_frames: &[INSET_FRAME],
+        background,
+        config_schema: &[],
+        group_regions: &[],
+        extreme_states: &[],
+        raster_baselines: &[],
+        draw,
+    }
+}
+
+static PFD_AND_INSET: [PanelDescriptor; 2] = [
+    PFD_DESCRIPTOR,
+    fixture("inset", BackgroundCapability::Opaque, draw_inset),
+];
+
+static PFD_AND_OVERLAY: [PanelDescriptor; 2] = [
+    PFD_DESCRIPTOR,
+    fixture("overlay", BackgroundCapability::NotUsed, draw_overlay),
+];
+
+/// The PFD's pinned criticality band, restated so the fixture bands are
+/// one `'static` slice; [`the_fixture_band_matches_the_pin`] refuses a
+/// drift between this and `BUILTIN_CRITICALITY_BANDS`.
+const PFD_BAND: PanelCriticality = PanelCriticality {
+    panel: "pfd",
+    frame: PANEL_FRAME,
+    band: Some(Region {
+        x: 6.0,
+        y: 38.0,
+        width: 468.0,
+        height: 254.0,
+    }),
+};
+
+const fn quiet(panel: &'static str) -> PanelCriticality {
+    PanelCriticality {
+        panel,
+        frame: INSET_FRAME,
+        band: None,
+    }
+}
+
+const INSET_BANDS: CriticalityBands = CriticalityBands {
+    panels: &[PFD_BAND, quiet("inset")],
+};
+
+const OVERLAY_BANDS: CriticalityBands = CriticalityBands {
+    panels: &[PFD_BAND, quiet("overlay")],
+};
+
+const fn tile(panel: &'static str, x: f32) -> Slot {
+    Slot {
+        panel,
+        rect: Region {
+            x,
+            y: 0.0,
+            width: 480.0,
+            height: 360.0,
+        },
+        occludes: &[],
+    }
+}
+
+const SIDE_BY_SIDE: CompositionDescriptor = CompositionDescriptor {
+    screen: DesignFrame {
+        width: 960.0,
+        height: 360.0,
+    },
+    slots: &[tile("pfd", 0.0), tile("hsi", 480.0)],
+};
+
+/// The PFD alone, and then the PFD with something above it: the two
+/// differ by exactly one slot, which is what lets the show-through
+/// property compare them pixel for pixel.
+const PFD_ALONE: CompositionDescriptor = CompositionDescriptor {
+    screen: PANEL_FRAME,
+    slots: &[tile("pfd", 0.0)],
+};
+
+const OPAQUE_INSET: CompositionDescriptor = CompositionDescriptor {
+    screen: PANEL_FRAME,
+    slots: &[
+        tile("pfd", 0.0),
+        Slot {
+            panel: "inset",
+            rect: INSET_RECT,
+            occludes: &[],
+        },
+    ],
+};
+
+const OVERLAY: CompositionDescriptor = CompositionDescriptor {
+    screen: PANEL_FRAME,
+    slots: &[
+        tile("pfd", 0.0),
+        Slot {
+            panel: "overlay",
+            rect: INSET_RECT,
+            occludes: &[],
+        },
+    ],
+};
+
+/// The shared canonical "typical" state, the same fixture the per-panel
+/// frame hashes and the scene digest draw.
+fn typical() -> PanelData {
+    resolve(
+        &indicate_instrument_registry::states::typical(),
+        &FreshnessPolicy::default(),
+    )
+}
+
+fn compose(registry: &Registry, composition: &CompositionDescriptor) -> Vec<u8> {
+    let (w, h) = (
+        composition.screen.width as u32,
+        composition.screen.height as u32,
+    );
+    let mut pixels = vec![0u8; (w * h * 4) as usize];
+    let mut scratch = vec![0u8; MAX_SCENE_BYTES];
+    let data = typical();
+    let mut inputs = CompositionInputs {
+        data: &data,
+        alerts: None,
+        scratch: &mut scratch,
+    };
+    let report = render_composition(
+        registry,
+        composition,
+        &mut inputs,
+        &mut pixels,
+        FramebufferDims::tight(w, h),
+        FrameId::default(),
+    )
+    .expect("the fixture composition renders");
+    assert_eq!(report.status, RenderStatus::Painted);
+    pixels
+}
+
+fn sha_hex(bytes: &[u8]) -> String {
+    const HEX: &[u8; 16] = b"0123456789abcdef";
+    let digest = Sha256::digest(bytes);
+    let mut out = String::with_capacity(64);
+    for byte in digest {
+        out.push(HEX[(byte >> 4) as usize] as char);
+        out.push(HEX[(byte & 0x0f) as usize] as char);
+    }
+    out
+}
+
+/// Renders twice and asserts the frame is bit-reproducible before
+/// comparing it to the pin, so a mismatch tells the reader whether the
+/// renderer became non-deterministic or merely changed.
+fn pinned(registry: &Registry, composition: &CompositionDescriptor, want: &str) -> Vec<u8> {
+    let first = compose(registry, composition);
+    let second = compose(registry, composition);
+    assert_eq!(first, second, "a composed frame is bit-reproducible");
+    assert_eq!(sha_hex(&first), want);
+    first
+}
+
+fn builtin() -> Registry {
+    Registry::new(indicate_instrument_panels::BUILTIN_PANELS).expect("shipped panels compose")
+}
+
+#[test]
+fn the_fixture_band_matches_the_pin() {
+    let pinned = BUILTIN_CRITICALITY_BANDS
+        .entry("pfd", PANEL_FRAME)
+        .expect("the PFD pins a band at its canonical frame");
+    assert_eq!(*pinned, PFD_BAND);
+}
+
+/// Every fixture below is a composition the registry admits. The inset
+/// and overlay clear the PFD's criticality band and every readout
+/// region it declares, so neither needs an `occludes` entry — and that
+/// is asserted here rather than reasoned about in a comment.
+#[test]
+fn the_fixtures_are_admissible_compositions() {
+    validate_composition(&builtin(), &SIDE_BY_SIDE, &BUILTIN_CRITICALITY_BANDS)
+        .expect("side by side");
+    validate_composition(&builtin(), &PFD_ALONE, &BUILTIN_CRITICALITY_BANDS).expect("pfd alone");
+    let inset = Registry::new(&PFD_AND_INSET).expect("composes");
+    validate_composition(&inset, &OPAQUE_INSET, &INSET_BANDS).expect("opaque inset");
+    let overlay = Registry::new(&PFD_AND_OVERLAY).expect("composes");
+    validate_composition(&overlay, &OVERLAY, &OVERLAY_BANDS).expect("notused overlay");
+}
+
+#[test]
+fn side_by_side_composed_frame_is_reproducible_and_pinned() {
+    pinned(&builtin(), &SIDE_BY_SIDE, SIDE_BY_SIDE_HASH);
+}
+
+#[test]
+fn opaque_inset_composed_frame_is_reproducible_and_pinned() {
+    let registry = Registry::new(&PFD_AND_INSET).expect("composes");
+    pinned(&registry, &OPAQUE_INSET, OPAQUE_INSET_HASH);
+}
+
+#[test]
+fn overlay_composed_frame_is_reproducible_and_pinned() {
+    let registry = Registry::new(&PFD_AND_OVERLAY).expect("composes");
+    pinned(&registry, &OVERLAY, OVERLAY_HASH);
+}
+
+/// An opaque slot replaces what is under it: every pixel of the inset's
+/// rect differs from the PFD-alone frame in at least the background,
+/// so the inset is not merely painting over transparent gaps.
+#[test]
+fn an_opaque_inset_replaces_the_panel_beneath_it() {
+    let base = compose(&builtin(), &PFD_ALONE);
+    let registry = Registry::new(&PFD_AND_INSET).expect("composes");
+    let composed = compose(&registry, &OPAQUE_INSET);
+    let mut differing = 0usize;
+    for (x, y) in inset_pixels() {
+        if pixel(&composed, x, y) != pixel(&base, x, y) {
+            differing += 1;
+        }
+    }
+    assert_eq!(
+        differing,
+        inset_pixels().count(),
+        "an Opaque slot owns every pixel of its rect"
+    );
+}
+
+/// The property that makes overlap safe: where a `NotUsed` overlay's
+/// own scene paints nothing, the slot beneath shows through unchanged.
+///
+/// This is the strong form — every transparent pixel of the overlay's
+/// scene, not a sampled one — because a hash proves reproducibility and
+/// this proves correctness.
+#[test]
+fn a_notused_overlay_lets_the_panel_beneath_show_through() {
+    let base = compose(&builtin(), &PFD_ALONE);
+    let registry = Registry::new(&PFD_AND_OVERLAY).expect("composes");
+    let composed = compose(&registry, &OVERLAY);
+    let alone = overlay_scene_alone();
+
+    let (mut transparent, mut painted) = (0usize, 0usize);
+    for (x, y) in inset_pixels() {
+        let local = (x - INSET_RECT.x as usize, y - INSET_RECT.y as usize);
+        let own = pixel_at(&alone, local.0, local.1, INSET_FRAME.width as usize);
+        if own[3] == 0 {
+            transparent += 1;
+            assert_eq!(
+                pixel(&composed, x, y),
+                pixel(&base, x, y),
+                "the panel beneath shows through at ({x}, {y})"
+            );
+        } else {
+            painted += 1;
+            assert_eq!(
+                pixel(&composed, x, y),
+                own,
+                "the overlay's own ink reaches the surface at ({x}, {y})"
+            );
+        }
+    }
+    // Neither half of the property may be vacuous: the overlay must
+    // really paint somewhere and really leave gaps.
+    assert!(transparent > 0, "the overlay covered its whole rect");
+    assert!(painted > 0, "the overlay painted nothing at all");
+}
+
+/// `validate_composition` refuses an unregistered slot at init, so the
+/// renderer meets one only when a composition was painted that was
+/// never admitted. It fails typed and spoils, like every other
+/// reference render — it does not panic and it does not leave a
+/// plausible partial frame.
+#[test]
+fn an_unregistered_slot_fails_typed_and_spoils() {
+    const STRANGER: CompositionDescriptor = CompositionDescriptor {
+        screen: PANEL_FRAME,
+        slots: &[tile("pfd", 0.0), tile("nowhere", 0.0)],
+    };
+    let registry = builtin();
+    let (w, h) = (PANEL_FRAME.width as u32, PANEL_FRAME.height as u32);
+    let mut pixels = vec![0u8; (w * h * 4) as usize];
+    let mut scratch = vec![0u8; MAX_SCENE_BYTES];
+    let data = typical();
+    let mut inputs = CompositionInputs {
+        data: &data,
+        alerts: None,
+        scratch: &mut scratch,
+    };
+    let error = render_composition(
+        &registry,
+        &STRANGER,
+        &mut inputs,
+        &mut pixels,
+        FramebufferDims::tight(w, h),
+        FrameId::default(),
+    )
+    .expect_err("the registry composes no panel called nowhere");
+    assert_eq!(error, RasterError::SlotPanelMissing { panel: "nowhere" });
+    // Against the frame the successful slot alone would have left, not
+    // against a property the spoil pattern and the PFD's opaque ground
+    // happen to share: alpha is 255 everywhere either way, so an
+    // alpha test would pass whether or not the frame was spoiled.
+    assert_ne!(
+        pixels,
+        compose(&builtin(), &PFD_ALONE),
+        "no pixel of the partial composition survived"
+    );
+}
+
+/// The overlay's scene alone on transparent black, at its own frame:
+/// the ground truth for which of its pixels are its own ink.
+fn overlay_scene_alone() -> Vec<u8> {
+    let registry = Registry::new(&PFD_AND_OVERLAY).expect("composes");
+    const ALONE: CompositionDescriptor = CompositionDescriptor {
+        screen: INSET_FRAME,
+        slots: &[Slot {
+            panel: "overlay",
+            rect: Region {
+                x: 0.0,
+                y: 0.0,
+                width: INSET_FRAME.width,
+                height: INSET_FRAME.height,
+            },
+            occludes: &[],
+        }],
+    };
+    compose(&registry, &ALONE)
+}
+
+fn inset_pixels() -> impl Iterator<Item = (usize, usize)> {
+    let x0 = INSET_RECT.x as usize;
+    let y0 = INSET_RECT.y as usize;
+    let (w, h) = (INSET_RECT.width as usize, INSET_RECT.height as usize);
+    (y0..y0 + h).flat_map(move |y| (x0..x0 + w).map(move |x| (x, y)))
+}
+
+fn pixel(frame: &[u8], x: usize, y: usize) -> [u8; 4] {
+    pixel_at(frame, x, y, PANEL_FRAME.width as usize)
+}
+
+fn pixel_at(frame: &[u8], x: usize, y: usize, width: usize) -> [u8; 4] {
+    let at = (y * width + x) * 4;
+    let px = frame.get(at..at + 4).expect("pixel inside the frame");
+    [px[0], px[1], px[2], px[3]]
+}

--- a/crates/indicate-instrument-raster/src/composition/tests/obscuration.rs
+++ b/crates/indicate-instrument-raster/src/composition/tests/obscuration.rs
@@ -1,0 +1,240 @@
+//! The obscuration floor, measured in pixels.
+//!
+//! `validate_composition` is the gate, but a gate is only as good as the
+//! band it reads. These reproduce two compositions that were once
+//! admitted and would have covered warning ink: the floor has to refuse
+//! them, and the pixel measurement says what was at stake if it does
+//! not.
+#![allow(clippy::expect_used, clippy::panic)]
+
+use indicate_alerts::{
+    AlertCondition, AlertContext, AlertEvent, AlertManager, AlertOutput, AlertProfile,
+    MiscompareFault,
+};
+use indicate_instrument_panels::{BUILTIN_CRITICALITY_BANDS, BUILTIN_PANELS};
+use indicate_instrument_registry::{
+    CompositionDescriptor, CompositionError, DesignFrame, Region, Registry, Slot,
+    validate_composition,
+};
+use indicate_instrument_scene::MAX_SCENE_BYTES;
+
+use std::vec;
+use std::vec::Vec;
+
+use super::{PANEL_FRAME, typical};
+use crate::composition::{CompositionInputs, render_composition};
+use crate::{FrameId, FramebufferDims};
+
+/// Alert-row red, the never-skinnable failure color every panel paints a
+/// warning row in. Restated rather than imported because the rasterizer
+/// does not depend on the symbology crate; a drift would fail the
+/// coverage assertion loudly rather than silently pass.
+const ALERT_RED: [u8; 4] = [255, 0, 0, 255];
+
+/// One warning-class alert: enough to put a red row in every panel's
+/// annunciation band, which is the ink these compositions would cover.
+fn one_warning() -> AlertOutput {
+    let mut manager = AlertManager::new();
+    manager.step(
+        &AlertProfile::simulator(),
+        &[AlertEvent::Assert(AlertCondition::Miscompare(
+            MiscompareFault::Attitude,
+        ))],
+        AlertContext::default(),
+        1_000,
+    )
+}
+
+fn screen(width: f32, height: f32) -> DesignFrame {
+    DesignFrame { width, height }
+}
+
+const fn placed(panel: &'static str, y: f32, occludes: &'static [&'static str]) -> Slot {
+    Slot {
+        panel,
+        rect: Region {
+            x: 0.0,
+            y,
+            width: 480.0,
+            height: 360.0,
+        },
+        occludes,
+    }
+}
+
+fn builtin() -> Registry {
+    Registry::new(BUILTIN_PANELS).expect("shipped panels compose")
+}
+
+/// Renders `composition` with one warning alert active and counts the
+/// alert-red pixels anywhere on the screen.
+fn red_pixels(composition: &CompositionDescriptor) -> usize {
+    let (w, h) = (
+        composition.screen.width as u32,
+        composition.screen.height as u32,
+    );
+    let mut pixels = vec![0u8; (w * h * 4) as usize];
+    let mut scratch = vec![0u8; MAX_SCENE_BYTES];
+    let data = typical();
+    let alerts = one_warning();
+    let mut inputs = CompositionInputs {
+        data: &data,
+        alerts: Some(&alerts),
+        scratch: &mut scratch,
+    };
+    render_composition(
+        &builtin(),
+        composition,
+        &mut inputs,
+        &mut pixels,
+        FramebufferDims::tight(w, h),
+        FrameId::default(),
+    )
+    .expect("renders");
+    count_red(&pixels)
+}
+
+fn count_red(pixels: &[u8]) -> usize {
+    pixels.chunks_exact(4).filter(|px| *px == ALERT_RED).count()
+}
+
+/// The PFD alone, so the measurement below has a baseline for how much
+/// warning ink there was to lose.
+const PFD_ALONE_TALL: CompositionDescriptor = CompositionDescriptor {
+    screen: DesignFrame {
+        width: 480.0,
+        height: 660.0,
+    },
+    slots: &[placed("pfd", 0.0, &[])],
+};
+
+/// A declared obscuration of the PFD by a panel below it. The monitor's
+/// rect starts at y 300, so it covers the PFD's alert stack — which a
+/// declaration must never buy.
+const MONITOR_OVER_PFD: CompositionDescriptor = CompositionDescriptor {
+    screen: DesignFrame {
+        width: 480.0,
+        height: 660.0,
+    },
+    slots: &[placed("pfd", 0.0, &[]), placed("monitor", 300.0, &["pfd"])],
+};
+
+#[test]
+fn a_declared_obscuration_may_not_cover_the_alert_stack() {
+    // What is at stake, stated in pixels rather than in prose: the PFD
+    // paints warning ink, and the composition below would erase it.
+    let alone = red_pixels(&PFD_ALONE_TALL);
+    assert!(alone > 0, "the fixture must actually raise a warning row");
+
+    let refusal = validate_composition(&builtin(), &MONITOR_OVER_PFD, &BUILTIN_CRITICALITY_BANDS)
+        .expect_err("covering a warning is refused however it is declared");
+    assert!(
+        matches!(refusal, CompositionError::CriticalityObscured { .. }),
+        "expected the criticality floor, got {refusal:?}"
+    );
+}
+
+/// The monitor under the HSI. The monitor's own annunciation band —
+/// its alert stack, and the failure X it paints over the whole frame
+/// when its channel fails — lies under the HSI's rect.
+const HSI_OVER_MONITOR: CompositionDescriptor = CompositionDescriptor {
+    screen: DesignFrame {
+        width: 480.0,
+        height: 540.0,
+    },
+    slots: &[
+        placed("monitor", 0.0, &[]),
+        placed("hsi", 180.0, &["monitor"]),
+    ],
+};
+
+#[test]
+fn a_declared_obscuration_may_not_cover_the_monitors_annunciation() {
+    let refusal = validate_composition(&builtin(), &HSI_OVER_MONITOR, &BUILTIN_CRITICALITY_BANDS)
+        .expect_err("the monitor's annunciation band is not coverable either");
+    assert!(
+        matches!(refusal, CompositionError::CriticalityObscured { .. }),
+        "expected the criticality floor, got {refusal:?}"
+    );
+}
+
+/// The floor is only meaningful if the band it reads was measured with
+/// alerts fed, because a composed frame fans one `AlertOutput` to every
+/// slot. This asserts the band actually contains the stack rather than
+/// trusting that it does.
+#[test]
+fn the_pinned_bands_contain_the_alert_stack() {
+    let stack = stack_ink_bound();
+    for panel in ["pfd", "hsi", "monitor"] {
+        let entry = BUILTIN_CRITICALITY_BANDS
+            .entry(panel, PANEL_FRAME)
+            .expect("every shipped panel pins a band");
+        let band = entry.band.expect("every shipped panel paints alert ink");
+        assert!(
+            band.contains(&stack),
+            "{panel}'s band {band:?} does not contain the alert stack {stack:?}"
+        );
+    }
+}
+
+/// Where the shared alert stack inks, measured from the rendered pixels
+/// rather than from the symbology crate's layout constants.
+fn stack_ink_bound() -> Region {
+    let quiet = render_pfd(None);
+    let alerted = render_pfd(Some(&one_warning()));
+    let (w, h) = (PANEL_FRAME.width as usize, PANEL_FRAME.height as usize);
+    let (mut min_x, mut min_y, mut max_x, mut max_y) = (w, h, 0usize, 0usize);
+    for y in 0..h {
+        for x in 0..w {
+            let at = (y * w + x) * 4;
+            if quiet.get(at..at + 4) == alerted.get(at..at + 4) {
+                continue;
+            }
+            min_x = min_x.min(x);
+            min_y = min_y.min(y);
+            max_x = max_x.max(x + 1);
+            max_y = max_y.max(y + 1);
+        }
+    }
+    assert!(min_x < max_x, "the alert made no difference to the frame");
+    Region {
+        x: min_x as f32,
+        y: min_y as f32,
+        width: (max_x - min_x) as f32,
+        height: (max_y - min_y) as f32,
+    }
+}
+
+fn render_pfd(alerts: Option<&AlertOutput>) -> Vec<u8> {
+    const ONE: CompositionDescriptor = CompositionDescriptor {
+        screen: PANEL_FRAME,
+        slots: &[placed("pfd", 0.0, &[])],
+    };
+    let (w, h) = (PANEL_FRAME.width as u32, PANEL_FRAME.height as u32);
+    let mut pixels = vec![0u8; (w * h * 4) as usize];
+    let mut scratch = vec![0u8; MAX_SCENE_BYTES];
+    let data = typical();
+    let mut inputs = CompositionInputs {
+        data: &data,
+        alerts,
+        scratch: &mut scratch,
+    };
+    render_composition(
+        &builtin(),
+        &ONE,
+        &mut inputs,
+        &mut pixels,
+        FramebufferDims::tight(w, h),
+        FrameId::default(),
+    )
+    .expect("renders");
+    pixels
+}
+
+/// `screen` is used by the descriptors above through their literal
+/// dimensions; keeping the helper honest about that avoids a dead
+/// function warning if a fixture is reshaped.
+#[test]
+fn fixture_screens_are_sound() {
+    assert!(Region::of(screen(480.0, 660.0)).is_sound());
+}

--- a/crates/indicate-instrument-raster/src/error.rs
+++ b/crates/indicate-instrument-raster/src/error.rs
@@ -8,6 +8,7 @@
 //! survives a failure.
 
 use indicate_instrument_glyphs::GlyphError;
+use indicate_instrument_registry::PanelDrawError;
 use indicate_instrument_scene::{DecodeError, LayerError};
 
 /// Why a render did not produce a valid frame.
@@ -77,4 +78,27 @@ pub enum RasterError {
     /// A restore was issued with no matching save.
     #[error("restore with no matching save")]
     UnbalancedRestore,
+    /// A composition slot names a panel the registry does not compose.
+    /// `validate_composition` refuses this at init; reaching it here
+    /// means a composition was painted that was never admitted.
+    #[error("composition slot names panel {panel}, which this registry does not compose")]
+    SlotPanelMissing {
+        /// The name the slot gave.
+        panel: &'static str,
+    },
+    /// A slot's panel refused to draw the composed frame.
+    #[error("panel {panel} failed to draw its composition slot")]
+    SlotDraw {
+        /// The refusing panel.
+        panel: &'static str,
+        /// The panel's own reason.
+        #[source]
+        source: PanelDrawError,
+    },
+    /// The caller's scene scratch cannot hold a slot's scene.
+    #[error("the scene scratch buffer cannot hold panel {panel}'s slot scene")]
+    SlotSceneBuffer {
+        /// The panel whose scene did not fit.
+        panel: &'static str,
+    },
 }

--- a/crates/indicate-instrument-raster/src/lib.rs
+++ b/crates/indicate-instrument-raster/src/lib.rs
@@ -70,6 +70,7 @@
 #[cfg(test)]
 extern crate std;
 
+mod composition;
 mod curve;
 mod error;
 mod fixed;
@@ -83,6 +84,7 @@ mod text;
 pub mod timing;
 mod transform;
 
+pub use composition::{CompositionInputs, render_composition};
 pub use error::RasterError;
 pub use raster::render;
 pub use report::{FrameId, FramebufferDims, RenderReport, RenderStatus, RenderWork};

--- a/crates/indicate-instrument-raster/src/raster.rs
+++ b/crates/indicate-instrument-raster/src/raster.rs
@@ -35,7 +35,8 @@ pub fn render(
     frame: FrameId,
 ) -> Result<RenderReport, RasterError> {
     let mut surface = Surface::new(pixels, dims)?;
-    match paint(scene, &mut surface) {
+    surface.clear();
+    match paint_at(scene, &mut surface, Placement::WHOLE_SURFACE) {
         Ok((unknown_opcodes, layers_present)) => Ok(RenderReport {
             scene_version: scene.first().copied().unwrap_or(0),
             status: RenderStatus::Painted,
@@ -51,16 +52,55 @@ pub fn render(
     }
 }
 
-/// Validates, clears, and paints; returns the unknown-opcode count and the
+/// Where on the surface one scene paints: the device-space origin its
+/// logical coordinates are measured from, and the rectangle it is
+/// confined to.
+///
+/// A whole-surface placement is the ordinary single-panel render. A
+/// composition gives each slot its own, which is the `stride_bytes`
+/// sub-window idea (see [`crate::FramebufferDims`]) carried into a
+/// shared framebuffer, where sub-windows may overlap.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub(crate) struct Placement {
+    /// Device-space origin of the scene's logical space.
+    pub(crate) origin: (f32, f32),
+    /// Extent from that origin, in logical units; `None` clips to the
+    /// surface alone.
+    pub(crate) extent: Option<(f32, f32)>,
+}
+
+impl Placement {
+    pub(crate) const WHOLE_SURFACE: Placement = Placement {
+        origin: (0.0, 0.0),
+        extent: None,
+    };
+}
+
+/// Validates and paints one scene at `placement`, without clearing:
+/// clearing is the frame's business, and a composed frame has one
+/// frame and many scenes. Returns the unknown-opcode count and the
 /// present-layer bitset for the report.
-fn paint(scene: &[u8], surface: &mut Surface<'_>) -> Result<(u32, u8), RasterError> {
+///
+/// The placement is applied through the ordinary translate and clip
+/// commands rather than a second geometry path, so a slot inherits the
+/// same Q8.8 snapping and the same conservative clip bound that every
+/// scene's own `Translate`/`ClipRect` gets.
+pub(crate) fn paint_at(
+    scene: &[u8],
+    surface: &mut Surface<'_>,
+    placement: Placement,
+) -> Result<(u32, u8), RasterError> {
     let report = validate_layers(scene)?;
     // The controlled glyph pack is part of the display's integrity
     // envelope: a corrupt pack fails the frame before any text could
     // paint from it (REN-02's no-fallback rule).
     indicate_instrument_glyphs::PANEL_GLYPHS.verify()?;
-    surface.clear();
     let mut state = RenderState::new(surface.bounds());
+    let (ox, oy) = placement.origin;
+    translate(&mut state, ox, oy)?;
+    if let Some((w, h)) = placement.extent {
+        clip(&mut state, 0.0, 0.0, w, h)?;
+    }
     let mut unknown: u32 = 0;
     for item in SceneCmds::new(scene)? {
         run(&item?, &mut state, surface, &mut unknown)?;

--- a/crates/indicate-instrument-raster/src/raster/tests/conformance/outcomes.rs
+++ b/crates/indicate-instrument-raster/src/raster/tests/conformance/outcomes.rs
@@ -454,6 +454,13 @@ fn raster_class(e: &RasterError) -> String {
         RasterError::TooManyVertices { .. } => "TooManyVertices",
         RasterError::StackOverflow { .. } => "StackOverflow",
         RasterError::UnbalancedRestore => "UnbalancedRestore",
+        // Composition faults, which the single-scene conformance corpus
+        // cannot reach: a corpus case is one scene, and these name a
+        // slot. Spelled out rather than caught by a wildcard so a new
+        // single-scene fault still has to be classified deliberately.
+        RasterError::SlotPanelMissing { .. } => "SlotPanelMissing",
+        RasterError::SlotDraw { .. } => "SlotDraw",
+        RasterError::SlotSceneBuffer { .. } => "SlotSceneBuffer",
     }
     .to_string()
 }

--- a/crates/indicate-instrument-registry/src/composition.rs
+++ b/crates/indicate-instrument-registry/src/composition.rs
@@ -93,11 +93,18 @@ pub struct CompositionDescriptor {
 ///   placed at its slot's origin — may be covered, but only where the
 ///   covering slot names the lower panel in `occludes`.
 /// - **Criticality content** — the measured `Annunciation`/`Failure`
-///   band, which carries the warnings, the failure indications, and the
-///   labelling that identifies the surface as simulation — may not be
-///   covered at all. No declaration licences it, because a declaration
-///   that could conceal a warning would be a declaration that the
-///   warning does not matter.
+///   band — may not be covered at all. No declaration licences it,
+///   because a declaration that could conceal a warning would be a
+///   declaration that the warning does not matter.
+///
+/// The floor protects what is *in* those two bands, and nothing else.
+/// It is therefore exactly as wide as the panels make it: content a
+/// panel paints into a lower band is ordinary symbology as far as this
+/// is concerned, whatever it says. A panel carrying the simulation
+/// labelling AIR-BAS-001 and AIR-FLAG-007 require must paint it into a
+/// criticality band for the floor to reach it; no shipped panel emits
+/// that labelling today, so the obligation is the author's and this
+/// does not pretend otherwise.
 pub fn validate_composition(
     registry: &Registry,
     composition: &CompositionDescriptor,
@@ -270,8 +277,16 @@ fn check_criticality(
     let Some(entry) = criticality.entry(below.panel, slot_frame(below)) else {
         return Ok(());
     };
+    // A band nothing was ever witnessed in is *unknown*, not empty. It
+    // does not say the panel puts no warnings anywhere; it says no case
+    // that ran drew one. Reading it as empty would make an unexercised
+    // failure cue the easiest thing on the screen to cover.
     let Some(band) = entry.band else {
-        return Ok(());
+        return Err(CompositionError::CriticalityUnwitnessed {
+            upper,
+            lower,
+            panel: below.panel,
+        });
     };
     let placed = band.translated(below.rect.x, below.rect.y);
     if above.rect.intersects(&placed) {

--- a/crates/indicate-instrument-registry/src/composition.rs
+++ b/crates/indicate-instrument-registry/src/composition.rs
@@ -1,0 +1,331 @@
+//! Screen composition: whole validated panel scenes, placed and stacked
+//! by declaration on one logical screen (AIR-OUT-011).
+//!
+//! A composition is layout and nothing else. It names panels, gives
+//! each a rectangle of the screen, and fixes the paint order — **slot
+//! index is z**, exactly as [`indicate_instrument_scene::LayerId`]'s
+//! discriminant is z within a scene, so later slots paint above earlier
+//! ones and declaration order is paint order everywhere. It carries no
+//! per-slot configuration: the descriptor declares layout, the shell
+//! supplies data and configuration at draw time, so configuration never
+//! joins the composition's identity.
+//!
+//! Nothing here resizes a scene. There is no `SCALE` opcode and a
+//! compositor never rewrites commands, so a slot's dimensions *are* the
+//! frame its panel is asked to emit — which is why a slot rect must be
+//! a frame the panel declared it can lay out against.
+//!
+//! Overlap rides [`BackgroundCapability`] rather than any new alpha
+//! mechanism: `Opaque` and `Cedeable` panels prove a full-frame opaque
+//! cover at admission, so they occlude their whole rect, while a
+//! `NotUsed` panel paints nothing in the background band and functions
+//! as an overlay through which lower slots show.
+
+use indicate_instrument_descriptor::{BackgroundCapability, CriticalityBands, DesignFrame, Region};
+
+use crate::registry::{Registry, frame_supported};
+
+mod coverage;
+mod digest;
+mod error;
+
+pub use digest::{COMPOSITION_DIGEST_DOMAIN, composition_digest};
+pub use error::CompositionError;
+
+/// What a fixed-size cover array holds outside the prefix it fills.
+/// It covers nothing, so an entry read past that prefix by mistake
+/// could only ever understate coverage.
+const NOWHERE: Region = Region {
+    x: 0.0,
+    y: 0.0,
+    width: 0.0,
+    height: 0.0,
+};
+
+/// Most slots one screen may compose.
+///
+/// Every composed-frame ceiling is a sum over slots — total scene bytes
+/// are at most this many times
+/// [`indicate_instrument_scene::MAX_SCENE_BYTES`], and the composed
+/// timing envelope is the sum of the slot envelopes — so this constant
+/// is what makes those sums finite.
+pub const MAX_COMPOSITION_SLOTS: usize = 8;
+
+/// One placed panel. `rect` is in screen units and `occludes` names the
+/// panels below whose ordinary symbology this slot is allowed to cover.
+///
+/// A name in `occludes` is a reviewed decision, in the same spirit as
+/// the admission warning ratchet: growing obscuration is deliberate,
+/// never drift. It does not reach criticality content — see
+/// [`validate_composition`].
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct Slot {
+    /// The registered panel this slot paints.
+    pub panel: &'static str,
+    /// Where on the screen it paints, in screen units.
+    pub rect: Region,
+    /// Panel ids below this slot whose ordinary symbology it may cover.
+    pub occludes: &'static [&'static str],
+}
+
+/// A declared screen layout: the logical screen, and the slots in paint
+/// order.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct CompositionDescriptor {
+    /// The logical screen space, under the same units discipline as a
+    /// panel frame.
+    pub screen: DesignFrame,
+    /// The slots, bottom to top.
+    pub slots: &'static [Slot],
+}
+
+/// Validates a composition against the registry it will be painted
+/// from and the criticality bands measured for its panels.
+///
+/// Allocation-free and meant for init: a composition fault is refused
+/// before first paint, never discovered as a rendering curiosity
+/// (AIR-HAZ-004).
+///
+/// The occlusion rules are two, and the difference between them is the
+/// whole of AIR-OUT-011's floor:
+///
+/// - **Ordinary symbology** — a lower panel's declared `group_regions`,
+///   placed at its slot's origin — may be covered, but only where the
+///   covering slot names the lower panel in `occludes`.
+/// - **Criticality content** — the measured `Annunciation`/`Failure`
+///   band, which carries the warnings, the failure indications, and the
+///   labelling that identifies the surface as simulation — may not be
+///   covered at all. No declaration licences it, because a declaration
+///   that could conceal a warning would be a declaration that the
+///   warning does not matter.
+pub fn validate_composition(
+    registry: &Registry,
+    composition: &CompositionDescriptor,
+    criticality: &CriticalityBands,
+) -> Result<(), CompositionError> {
+    validate_shape(composition)?;
+    // Every slot's own declaration is judged before any rule that reads
+    // another slot's rect, so a nonsense rectangle is named as one
+    // rather than reported as whatever it did to its neighbours.
+    for (index, slot) in composition.slots.iter().enumerate() {
+        validate_slot(registry, composition, index, slot)?;
+        validate_band_known(criticality, index, slot)?;
+    }
+    for index in 0..composition.slots.len() {
+        validate_alive(composition, registry, index)?;
+    }
+    validate_occlusion(registry, composition, criticality)
+}
+
+fn validate_shape(composition: &CompositionDescriptor) -> Result<(), CompositionError> {
+    let screen = composition.screen;
+    if !Region::of(screen).is_sound() {
+        return Err(CompositionError::BadScreen { screen });
+    }
+    if composition.slots.is_empty() {
+        return Err(CompositionError::NoSlots);
+    }
+    if composition.slots.len() > MAX_COMPOSITION_SLOTS {
+        return Err(CompositionError::TooManySlots {
+            slots: composition.slots.len(),
+            ceiling: MAX_COMPOSITION_SLOTS,
+        });
+    }
+    Ok(())
+}
+
+fn validate_slot(
+    registry: &Registry,
+    composition: &CompositionDescriptor,
+    index: usize,
+    slot: &Slot,
+) -> Result<(), CompositionError> {
+    let Some(panel) = registry.by_id(slot.panel) else {
+        return Err(CompositionError::UnknownPanel {
+            slot: index,
+            panel: slot.panel,
+        });
+    };
+    if !slot.rect.is_sound() {
+        return Err(CompositionError::SlotRectDegenerate {
+            slot: index,
+            rect: slot.rect,
+        });
+    }
+    if !Region::of(composition.screen).contains(&slot.rect) {
+        return Err(CompositionError::SlotOutsideScreen {
+            slot: index,
+            rect: slot.rect,
+            screen: composition.screen,
+        });
+    }
+    let frame = slot_frame(slot);
+    if !frame_supported(panel, frame) {
+        return Err(CompositionError::SlotFrameUnsupported {
+            slot: index,
+            panel: slot.panel,
+            frame,
+        });
+    }
+    Ok(())
+}
+
+/// A slot is only validated against measured evidence, so a panel with
+/// no band pinned at the size the slot asks for is refused rather than
+/// treated as inking nothing.
+fn validate_band_known(
+    criticality: &CriticalityBands,
+    index: usize,
+    slot: &Slot,
+) -> Result<(), CompositionError> {
+    let frame = slot_frame(slot);
+    if criticality.entry(slot.panel, frame).is_none() {
+        return Err(CompositionError::CriticalityUnknown {
+            slot: index,
+            panel: slot.panel,
+            frame,
+        });
+    }
+    Ok(())
+}
+
+fn validate_alive(
+    composition: &CompositionDescriptor,
+    registry: &Registry,
+    index: usize,
+) -> Result<(), CompositionError> {
+    let Some(slot) = composition.slots.get(index) else {
+        return Ok(());
+    };
+    let mut covers = [NOWHERE; MAX_COMPOSITION_SLOTS];
+    let mut count = 0;
+    for above in composition.slots.iter().skip(index.wrapping_add(1)) {
+        if !opaque(registry, above) {
+            continue;
+        }
+        if let Some(entry) = covers.get_mut(count) {
+            *entry = above.rect;
+            count = count.wrapping_add(1);
+        }
+    }
+    let covers = covers.get(..count).unwrap_or(&[]);
+    if coverage::covered(&slot.rect, covers) {
+        return Err(CompositionError::DeadSlot { slot: index });
+    }
+    Ok(())
+}
+
+/// Whether a slot's panel occludes what it covers: an owned background
+/// band is a proven full-frame opaque cover, and nothing else is.
+fn opaque(registry: &Registry, slot: &Slot) -> bool {
+    registry.by_id(slot.panel).is_some_and(|panel| {
+        matches!(
+            panel.background,
+            BackgroundCapability::Opaque | BackgroundCapability::Cedeable
+        )
+    })
+}
+
+fn validate_occlusion(
+    registry: &Registry,
+    composition: &CompositionDescriptor,
+    criticality: &CriticalityBands,
+) -> Result<(), CompositionError> {
+    for (upper, above) in composition.slots.iter().enumerate() {
+        for (lower, below) in composition.slots.iter().enumerate().take(upper) {
+            check_pair(registry, criticality, (upper, above), (lower, below))?;
+        }
+    }
+    Ok(())
+}
+
+/// The whole rect of the slot above is what may cover, whatever its
+/// background capability: an overlay is transparent only in the
+/// background band, and its own symbology paints wherever it likes
+/// inside its rect.
+fn check_pair(
+    registry: &Registry,
+    criticality: &CriticalityBands,
+    (upper, above): (usize, &Slot),
+    (lower, below): (usize, &Slot),
+) -> Result<(), CompositionError> {
+    if !above.rect.intersects(&below.rect) {
+        return Ok(());
+    }
+    check_criticality(criticality, (upper, above), (lower, below))?;
+    if above.occludes.contains(&below.panel) {
+        return Ok(());
+    }
+    check_ordinary(registry, (upper, above), (lower, below))
+}
+
+fn check_criticality(
+    criticality: &CriticalityBands,
+    (upper, above): (usize, &Slot),
+    (lower, below): (usize, &Slot),
+) -> Result<(), CompositionError> {
+    // Unreachable in a validated run: every slot's band is required to
+    // exist before any pair is compared, so a miss here would be a
+    // caller that skipped that step rather than a permissive case.
+    let Some(entry) = criticality.entry(below.panel, slot_frame(below)) else {
+        return Ok(());
+    };
+    let Some(band) = entry.band else {
+        return Ok(());
+    };
+    let placed = band.translated(below.rect.x, below.rect.y);
+    if above.rect.intersects(&placed) {
+        return Err(CompositionError::CriticalityObscured {
+            upper,
+            lower,
+            panel: below.panel,
+            band: placed,
+        });
+    }
+    Ok(())
+}
+
+/// `group_regions` describe the layout at the panel's readability floor
+/// and nowhere else, so a slot that asks for a different frame has no
+/// declaration this can place. That case treats the whole slot rect as
+/// ordinary ink — the covering slot must then declare the obscuration,
+/// which is the fail-closed direction.
+fn check_ordinary(
+    registry: &Registry,
+    (upper, above): (usize, &Slot),
+    (lower, below): (usize, &Slot),
+) -> Result<(), CompositionError> {
+    let refuse = |region| {
+        Err(CompositionError::UndeclaredOcclusion {
+            upper,
+            lower,
+            panel: below.panel,
+            region,
+        })
+    };
+    let placeable = registry
+        .by_id(below.panel)
+        .filter(|panel| panel.frame_min == slot_frame(below));
+    let Some(panel) = placeable else {
+        return refuse(below.rect);
+    };
+    for (_, region) in panel.group_regions {
+        let placed = region.translated(below.rect.x, below.rect.y);
+        if above.rect.intersects(&placed) {
+            return refuse(placed);
+        }
+    }
+    Ok(())
+}
+
+/// The frame a slot asks its panel for: composition is placement only,
+/// so the slot's own dimensions are the emission frame.
+fn slot_frame(slot: &Slot) -> DesignFrame {
+    DesignFrame {
+        width: slot.rect.width,
+        height: slot.rect.height,
+    }
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/indicate-instrument-registry/src/composition/coverage.rs
+++ b/crates/indicate-instrument-registry/src/composition/coverage.rs
@@ -99,7 +99,7 @@ fn dedup(edges: &mut [f32]) -> usize {
         }
         if let Some(slot) = edges.get_mut(kept) {
             *slot = value;
-            kept += 1;
+            kept = kept.wrapping_add(1);
         }
     }
     kept

--- a/crates/indicate-instrument-registry/src/composition/coverage.rs
+++ b/crates/indicate-instrument-registry/src/composition/coverage.rs
@@ -1,0 +1,110 @@
+//! Whether a union of rectangles wholly covers another — the dead-slot
+//! question, answered without allocating.
+//!
+//! The union's edges cut the target into a grid of cells, and a union
+//! of axis-aligned rectangles covers the target exactly when it covers
+//! every cell. The grid is bounded by
+//! [`crate::MAX_COMPOSITION_SLOTS`], so the working arrays are fixed.
+
+use indicate_instrument_descriptor::Region;
+
+use crate::composition::MAX_COMPOSITION_SLOTS;
+
+/// Edges a compressed axis can carry: the target's two, plus two per
+/// covering rectangle.
+const MAX_EDGES: usize = 2 + 2 * MAX_COMPOSITION_SLOTS;
+
+/// Whether `covers` together contain every point of `target`.
+pub(super) fn covered(target: &Region, covers: &[Region]) -> bool {
+    let mut xs = [0.0f32; MAX_EDGES];
+    let mut ys = [0.0f32; MAX_EDGES];
+    let x_count = compress(&mut xs, target.x, target.right(), covers, Axis::X);
+    let y_count = compress(&mut ys, target.y, target.bottom(), covers, Axis::Y);
+    for xi in 1..x_count {
+        for yi in 1..y_count {
+            let (Some(x0), Some(x1)) = (xs.get(xi - 1), xs.get(xi)) else {
+                return false;
+            };
+            let (Some(y0), Some(y1)) = (ys.get(yi - 1), ys.get(yi)) else {
+                return false;
+            };
+            if x1 <= x0 || y1 <= y0 {
+                continue;
+            }
+            let point = ((x0 + x1) / 2.0, (y0 + y1) / 2.0);
+            if !covers.iter().any(|cover| holds(cover, point)) {
+                return false;
+            }
+        }
+    }
+    // A target with no interior cell has no interior to leave showing.
+    x_count > 1 && y_count > 1
+}
+
+enum Axis {
+    X,
+    Y,
+}
+
+/// Fills `out` with the sorted, deduplicated cut points between `low`
+/// and `high`, and returns how many it wrote.
+fn compress(
+    out: &mut [f32; MAX_EDGES],
+    low: f32,
+    high: f32,
+    covers: &[Region],
+    axis: Axis,
+) -> usize {
+    let mut count = push(out, 0, low);
+    count = push(out, count, high);
+    for cover in covers {
+        let (near, far) = match axis {
+            Axis::X => (cover.x, cover.right()),
+            Axis::Y => (cover.y, cover.bottom()),
+        };
+        // Edges outside the target cut nothing inside it.
+        if near >= low && near <= high {
+            count = push(out, count, near);
+        }
+        if far >= low && far <= high {
+            count = push(out, count, far);
+        }
+    }
+    let edges = out.get_mut(..count).unwrap_or(&mut []);
+    edges.sort_unstable_by(f32::total_cmp);
+    dedup(edges)
+}
+
+fn push(out: &mut [f32; MAX_EDGES], count: usize, value: f32) -> usize {
+    match out.get_mut(count) {
+        Some(slot) => {
+            *slot = value;
+            count.wrapping_add(1)
+        }
+        None => count,
+    }
+}
+
+/// Collapses equal neighbours in a sorted slice, returning the kept
+/// length. `slice::dedup` is not available without an allocator's
+/// `Vec`, and the fixed array is the point.
+fn dedup(edges: &mut [f32]) -> usize {
+    let mut kept = 0;
+    for index in 0..edges.len() {
+        let Some(value) = edges.get(index).copied() else {
+            break;
+        };
+        if kept > 0 && edges.get(kept - 1) == Some(&value) {
+            continue;
+        }
+        if let Some(slot) = edges.get_mut(kept) {
+            *slot = value;
+            kept += 1;
+        }
+    }
+    kept
+}
+
+fn holds(region: &Region, (x, y): (f32, f32)) -> bool {
+    x >= region.x && x <= region.right() && y >= region.y && y <= region.bottom()
+}

--- a/crates/indicate-instrument-registry/src/composition/digest.rs
+++ b/crates/indicate-instrument-registry/src/composition/digest.rs
@@ -1,0 +1,69 @@
+//! The screen-composition digest: one number that proves two shells lay
+//! the same instruments out the same way on one surface.
+//!
+//! It covers the screen frame, the ordered slots — panel id, rect, and
+//! `occludes` list — and the registry scene digest beneath, so it is
+//! strictly stronger than the scene digest: two shells agreeing here
+//! agree both about what their panels paint and about where.
+//!
+//! Slot rects are in the digest from day one. Relaxing which rects are
+//! admissible therefore changes what validates, never what the digest
+//! covers, and no such relaxation churns the format.
+//!
+//! Per-slot configuration is deliberately absent, because it is not
+//! declared here: the descriptor declares layout and the shell supplies
+//! configuration at draw time, so a shell that reconfigures a panel
+//! still composes the same screen.
+
+use indicate_sha256::Sha256Ctx;
+
+use crate::composition::CompositionDescriptor;
+use crate::digest::{DigestError, digest_frame, scene_digest, update_framed};
+use crate::registry::Registry;
+
+/// Domain separator; a new value is a deliberate contract break.
+///
+/// Like [`crate::SCENE_DIGEST_DOMAIN`] this is an identifier rather than
+/// a name: it is hashed into every pin a consumer holds, so it does not
+/// track what the crates are called.
+pub const COMPOSITION_DIGEST_DOMAIN: &[u8] = b"pilotage-screen-composition-digest-v1";
+
+/// Item-role tags framing the composition stream. They start above the
+/// scene digest's tags so a reader of a hexdump cannot confuse the two
+/// streams, though the domain separator already makes them disjoint.
+const ROLE_SLOT: u8 = 0x11;
+const ROLE_OCCLUDES: u8 = 0x12;
+
+/// Digests `composition` over `registry`, drawing into `scratch` (size
+/// it [`indicate_instrument_scene::MAX_SCENE_BYTES`]).
+///
+/// Deliberately independent of [`crate::validate_composition`]: a
+/// digest states what a composition *is*, and a consumer comparing pins
+/// must get the same answer whether or not its registry would admit it.
+pub fn composition_digest(
+    registry: &Registry,
+    composition: &CompositionDescriptor,
+    scratch: &mut [u8],
+) -> Result<[u8; 32], DigestError> {
+    let beneath = scene_digest(registry, scratch)?;
+    let mut ctx = Sha256Ctx::new();
+    ctx.update(COMPOSITION_DIGEST_DOMAIN);
+    ctx.update(&beneath);
+    digest_frame(&mut ctx, composition.screen);
+    ctx.update(&(composition.slots.len() as u32).to_le_bytes());
+    for slot in composition.slots {
+        update_framed(&mut ctx, ROLE_SLOT, slot.panel.as_bytes());
+        ctx.update(&slot.rect.x.to_le_bytes());
+        ctx.update(&slot.rect.y.to_le_bytes());
+        ctx.update(&slot.rect.width.to_le_bytes());
+        ctx.update(&slot.rect.height.to_le_bytes());
+        ctx.update(&(slot.occludes.len() as u32).to_le_bytes());
+        for occluded in slot.occludes {
+            update_framed(&mut ctx, ROLE_OCCLUDES, occluded.as_bytes());
+        }
+    }
+    Ok(ctx.finalize())
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/indicate-instrument-registry/src/composition/digest/tests.rs
+++ b/crates/indicate-instrument-registry/src/composition/digest/tests.rs
@@ -1,0 +1,78 @@
+#![allow(clippy::expect_used, clippy::panic)]
+
+use indicate_instrument_descriptor::DesignFrame;
+use indicate_instrument_scene::MAX_SCENE_BYTES;
+
+use std::vec;
+
+use super::composition_digest;
+use crate::composition::tests::{SCREEN, SIDE_BY_SIDE, rect, registry, slot};
+use crate::composition::{CompositionDescriptor, Slot};
+
+#[test]
+fn the_digest_covers_the_screen_the_rects_and_the_occlusions() {
+    let registry = registry();
+    let mut scratch = vec![0u8; MAX_SCENE_BYTES];
+    let base = composition_digest(&registry, &SIDE_BY_SIDE, &mut scratch).expect("digests");
+    assert_eq!(
+        base,
+        composition_digest(&registry, &SIDE_BY_SIDE, &mut scratch).expect("digests"),
+        "the digest is a function of the declaration alone"
+    );
+
+    const MOVED: CompositionDescriptor = CompositionDescriptor {
+        screen: SCREEN,
+        slots: &[
+            slot("low", rect(0.0, 0.0, 480.0, 360.0)),
+            slot("high", rect(480.0, 360.0, 480.0, 360.0)),
+        ],
+    };
+    assert_ne!(
+        base,
+        composition_digest(&registry, &MOVED, &mut scratch).expect("digests"),
+        "a moved slot is a different screen"
+    );
+
+    const WIDER: CompositionDescriptor = CompositionDescriptor {
+        screen: DesignFrame {
+            width: 1200.0,
+            height: 720.0,
+        },
+        slots: SIDE_BY_SIDE.slots,
+    };
+    assert_ne!(
+        base,
+        composition_digest(&registry, &WIDER, &mut scratch).expect("digests"),
+        "a different screen is a different composition"
+    );
+
+    const DECLARED: CompositionDescriptor = CompositionDescriptor {
+        screen: SCREEN,
+        slots: &[
+            slot("low", rect(0.0, 0.0, 480.0, 360.0)),
+            Slot {
+                panel: "high",
+                rect: rect(480.0, 0.0, 480.0, 360.0),
+                occludes: &["low"],
+            },
+        ],
+    };
+    assert_ne!(
+        base,
+        composition_digest(&registry, &DECLARED, &mut scratch).expect("digests"),
+        "an obscuration declaration is part of the contract"
+    );
+
+    const REORDERED: CompositionDescriptor = CompositionDescriptor {
+        screen: SCREEN,
+        slots: &[
+            slot("high", rect(480.0, 0.0, 480.0, 360.0)),
+            slot("low", rect(0.0, 0.0, 480.0, 360.0)),
+        ],
+    };
+    assert_ne!(
+        base,
+        composition_digest(&registry, &REORDERED, &mut scratch).expect("digests"),
+        "slot index is z, so order is contract"
+    );
+}

--- a/crates/indicate-instrument-registry/src/composition/error.rs
+++ b/crates/indicate-instrument-registry/src/composition/error.rs
@@ -102,11 +102,28 @@ pub enum CompositionError {
         /// The covered surface, in screen units.
         region: Region,
     },
+    /// A slot overlaps a lower panel whose criticality band was
+    /// measured empty. An empty measurement is the absence of a
+    /// witness, not a proof of absence: no case that ran drew warning
+    /// ink, which says nothing about where warning ink goes.
+    #[error(
+        "slot {upper} overlaps {panel} in slot {lower}, whose criticality band no case ever witnessed"
+    )]
+    CriticalityUnwitnessed {
+        /// The covering slot.
+        upper: usize,
+        /// The covered slot.
+        lower: usize,
+        /// The covered panel.
+        panel: &'static str,
+    },
     /// A slot covers a lower panel's criticality band. Declaring an
     /// obscuration does not licence this and no list can: a declared
-    /// obscuration may cover ordinary symbology, never a warning, a
-    /// failure indication, or the labelling that identifies the surface
-    /// as simulation (AIR-OUT-011).
+    /// obscuration may cover ordinary symbology, never a warning or a
+    /// failure indication (AIR-OUT-011). The band is what was measured
+    /// in the `Annunciation` and `Failure` layers, so a panel's
+    /// simulation labelling is protected exactly when the panel paints
+    /// it there.
     #[error(
         "slot {upper} covers the criticality band {band:?} of {panel} in slot {lower}; no declaration permits this"
     )]

--- a/crates/indicate-instrument-registry/src/composition/error.rs
+++ b/crates/indicate-instrument-registry/src/composition/error.rs
@@ -1,0 +1,123 @@
+//! Why a screen composition was refused. Every variant names the slot
+//! index, because a slot index is the composition's own vocabulary —
+//! it is the z-order, and it is what an author edits.
+
+use indicate_instrument_descriptor::{DesignFrame, Region};
+
+/// Why [`crate::validate_composition`] refused a descriptor.
+#[derive(Debug, Clone, Copy, PartialEq, thiserror::Error)]
+pub enum CompositionError {
+    /// The composition places nothing.
+    #[error("composition declares no slots")]
+    NoSlots,
+    /// More slots than the composed-frame budget allows.
+    #[error("composition declares {slots} slots, over the ceiling of {ceiling}")]
+    TooManySlots {
+        /// The declared slot count.
+        slots: usize,
+        /// [`crate::MAX_COMPOSITION_SLOTS`].
+        ceiling: usize,
+    },
+    /// The logical screen is not a frame.
+    #[error("screen frame {screen:?} is not finite and positive on both axes")]
+    BadScreen {
+        /// The offending declaration.
+        screen: DesignFrame,
+    },
+    /// A slot names a panel the registry does not compose.
+    #[error("slot {slot} names panel {panel}, which this registry does not compose")]
+    UnknownPanel {
+        /// The offending slot.
+        slot: usize,
+        /// The name it gave.
+        panel: &'static str,
+    },
+    /// A slot rect is non-finite or has a non-positive extent.
+    #[error("slot {slot} declares {rect:?}, which is not a finite, non-degenerate rectangle")]
+    SlotRectDegenerate {
+        /// The offending slot.
+        slot: usize,
+        /// Its rect.
+        rect: Region,
+    },
+    /// A slot rect leaves the screen. Nothing clips it back: a slot is
+    /// a placement, and a placement off the screen paints nowhere the
+    /// composition can account for.
+    #[error("slot {slot} rect {rect:?} is not inside the screen {screen:?}")]
+    SlotOutsideScreen {
+        /// The offending slot.
+        slot: usize,
+        /// Its rect.
+        rect: Region,
+        /// The declared screen.
+        screen: DesignFrame,
+    },
+    /// A slot asks a panel for a size it never declared. Composition is
+    /// placement only — there is no `SCALE` opcode and a scene is never
+    /// rewritten to fit — so the slot's dimensions *are* the frame the
+    /// panel is asked to emit.
+    #[error("slot {slot} asks {panel} for frame {frame:?}, which it does not support")]
+    SlotFrameUnsupported {
+        /// The offending slot.
+        slot: usize,
+        /// The panel asked.
+        panel: &'static str,
+        /// The frame the slot's dimensions ask for.
+        frame: DesignFrame,
+    },
+    /// A slot lies entirely under opaque slots above it. Painting it
+    /// costs a full scene and shows nothing, so it is a declaration
+    /// error rather than a rendering curiosity.
+    #[error("slot {slot} is wholly covered by the opaque slots above it")]
+    DeadSlot {
+        /// The dead slot.
+        slot: usize,
+    },
+    /// No criticality band was measured for this panel at this frame,
+    /// so nothing bounds where its warnings land and no obscuration
+    /// above it can be judged.
+    #[error("no criticality band is pinned for {panel} at frame {frame:?} (slot {slot})")]
+    CriticalityUnknown {
+        /// The slot whose panel has no band.
+        slot: usize,
+        /// The panel.
+        panel: &'static str,
+        /// The frame its slot asks for.
+        frame: DesignFrame,
+    },
+    /// A slot covers a lower panel's ordinary readout surface without
+    /// the composition saying so. Obscuration is permitted, drift is
+    /// not: the lower panel's id must appear in the covering slot's
+    /// `occludes` list, where a reviewer sees it.
+    #[error(
+        "slot {upper} covers readout surface {region:?} of {panel} in slot {lower} without declaring it"
+    )]
+    UndeclaredOcclusion {
+        /// The covering slot.
+        upper: usize,
+        /// The covered slot.
+        lower: usize,
+        /// The covered panel.
+        panel: &'static str,
+        /// The covered surface, in screen units.
+        region: Region,
+    },
+    /// A slot covers a lower panel's criticality band. Declaring an
+    /// obscuration does not licence this and no list can: a declared
+    /// obscuration may cover ordinary symbology, never a warning, a
+    /// failure indication, or the labelling that identifies the surface
+    /// as simulation (AIR-OUT-011).
+    #[error(
+        "slot {upper} covers the criticality band {band:?} of {panel} in slot {lower}; no declaration permits this"
+    )]
+    CriticalityObscured {
+        /// The covering slot.
+        upper: usize,
+        /// The covered slot.
+        lower: usize,
+        /// The covered panel.
+        panel: &'static str,
+        /// The covered band, in screen units.
+        band: Region,
+    },
+}

--- a/crates/indicate-instrument-registry/src/composition/tests.rs
+++ b/crates/indicate-instrument-registry/src/composition/tests.rs
@@ -127,9 +127,11 @@ pub(super) const BANDS: CriticalityBands = CriticalityBands {
     ],
 };
 
-/// Bands with no warning ink anywhere, for the rules that must fire
-/// without the criticality floor firing first.
-pub(super) const QUIET_BANDS: CriticalityBands = CriticalityBands {
+/// Bands no case ever witnessed ink in. Since an empty measurement is
+/// the absence of a witness rather than a proof of absence, a
+/// composition validated against these refuses every overlap — which is
+/// what [`an_unwitnessed_band_refuses_obscuration`] is for.
+pub(super) const UNWITNESSED_BANDS: CriticalityBands = CriticalityBands {
     panels: &[
         PanelCriticality {
             panel: "low",
@@ -331,16 +333,20 @@ fn a_slot_buried_under_opaque_slots_is_refused() {
         ],
     };
     assert_eq!(
-        validate_composition(&registry(), &COMPOSITION, &QUIET_BANDS),
+        validate_composition(&registry(), &COMPOSITION, &UNWITNESSED_BANDS),
         Err(CompositionError::DeadSlot { slot: 0 })
     );
 }
 
+/// The dead-slot rule counts opaque covers only, and this is the pair
+/// that proves it: byte-identical geometry to the case above, differing
+/// only in the covering panel's `background`. An `Opaque` cover buries
+/// the slot and is refused as `DeadSlot`; a `NotUsed` cover does not
+/// bury it, so rule 5 stays silent and the refusal comes from the
+/// criticality floor instead — full-rect coverage of a panel that paints
+/// warnings is never admissible, whoever declares it.
 #[test]
 fn an_overlay_does_not_bury_the_slot_beneath_it() {
-    // Same geometry as the dead-slot case, but the covering panel
-    // declares `NotUsed`: it paints no background, so the slot below
-    // shows through and is alive.
     const COMPOSITION: CompositionDescriptor = CompositionDescriptor {
         screen: SCREEN,
         slots: &[
@@ -352,8 +358,12 @@ fn an_overlay_does_not_bury_the_slot_beneath_it() {
             },
         ],
     };
-    validate_composition(&registry(), &COMPOSITION, &QUIET_BANDS)
-        .expect("an overlay leaves the slot beneath it visible");
+    let refusal = validate_composition(&registry(), &COMPOSITION, &BANDS)
+        .expect_err("the overlay covers the warning band beneath it");
+    assert!(
+        matches!(refusal, CompositionError::CriticalityObscured { .. }),
+        "an overlay must not read as a dead-slot cover, got {refusal:?}"
+    );
 }
 
 #[test]
@@ -366,7 +376,7 @@ fn covering_a_readout_without_declaring_it_is_refused() {
         ],
     };
     assert_eq!(
-        validate_composition(&registry(), &COMPOSITION, &QUIET_BANDS),
+        validate_composition(&registry(), &COMPOSITION, &BANDS),
         Err(CompositionError::UndeclaredOcclusion {
             upper: 1,
             lower: 0,
@@ -389,8 +399,35 @@ fn declaring_the_occlusion_permits_covering_a_readout() {
             },
         ],
     };
-    validate_composition(&registry(), &COMPOSITION, &QUIET_BANDS)
+    validate_composition(&registry(), &COMPOSITION, &BANDS)
         .expect("a declared obscuration may cover ordinary symbology");
+}
+
+/// An empty measurement is the absence of a witness, not a proof of
+/// absence. A panel whose band no case ever drew ink in refuses
+/// obscuration outright — the alternative would make an unexercised
+/// failure cue the easiest thing on a screen to cover.
+#[test]
+fn an_unwitnessed_band_refuses_obscuration() {
+    const COMPOSITION: CompositionDescriptor = CompositionDescriptor {
+        screen: SCREEN,
+        slots: &[
+            slot("low", rect(0.0, 0.0, 480.0, 360.0)),
+            Slot {
+                panel: "badge",
+                rect: rect(0.0, 0.0, 200.0, 100.0),
+                occludes: &["low"],
+            },
+        ],
+    };
+    assert_eq!(
+        validate_composition(&registry(), &COMPOSITION, &UNWITNESSED_BANDS),
+        Err(CompositionError::CriticalityUnwitnessed {
+            upper: 1,
+            lower: 0,
+            panel: "low",
+        })
+    );
 }
 
 #[test]

--- a/crates/indicate-instrument-registry/src/composition/tests.rs
+++ b/crates/indicate-instrument-registry/src/composition/tests.rs
@@ -1,0 +1,440 @@
+#![allow(clippy::expect_used, clippy::panic)]
+
+use indicate_alerts::AlertOutput;
+use indicate_instrument_descriptor::{
+    BackgroundCapability, ConfigBlob, CriticalityBands, DesignFrame, GroupSet, PanelCriticality,
+    PanelDescriptor, PanelDrawError, Region,
+};
+use indicate_instrument_scene::SceneWriter;
+use indicate_instrument_state::{GroupId, PanelData};
+
+use super::{
+    CompositionDescriptor, CompositionError, MAX_COMPOSITION_SLOTS, Slot, validate_composition,
+};
+use crate::registry::Registry;
+
+pub(super) const FRAME: DesignFrame = DesignFrame {
+    width: 480.0,
+    height: 360.0,
+};
+pub(super) const SCREEN: DesignFrame = DesignFrame {
+    width: 960.0,
+    height: 720.0,
+};
+
+fn draw_nothing(
+    _data: &PanelData,
+    _config: &ConfigBlob<'_>,
+    _alerts: Option<&AlertOutput>,
+    _frame: DesignFrame,
+    _scene: &mut SceneWriter<'_>,
+) -> Result<(), PanelDrawError> {
+    Ok(())
+}
+
+const fn base(id: &'static str, background: BackgroundCapability) -> PanelDescriptor {
+    PanelDescriptor {
+        id,
+        title: "Panel",
+        required_layers: 0b0000_0110,
+        required_groups: GroupSet::of(&[GroupId::Air]),
+        frame_min: FRAME,
+        frame_max: FRAME,
+        frame_step: (1.0, 1.0),
+        aspect_min: 1.30,
+        aspect_max: 1.37,
+        canonical_frames: &[FRAME],
+        background,
+        config_schema: &[],
+        group_regions: &[],
+        extreme_states: &[],
+        raster_baselines: &[],
+        draw: draw_nothing,
+    }
+}
+
+/// A readout surface in the top-left corner of the panel's own frame,
+/// so a slot placed over that corner covers ordinary symbology.
+const READOUT: &[(GroupId, Region)] = &[(
+    GroupId::Air,
+    Region {
+        x: 10.0,
+        y: 10.0,
+        width: 100.0,
+        height: 40.0,
+    },
+)];
+
+/// A small 2:1 badge: an overlay sized to sit on part of a panel, so
+/// the occlusion fixtures place something that is not a whole frame.
+pub(super) const BADGE_FRAME: DesignFrame = DesignFrame {
+    width: 200.0,
+    height: 100.0,
+};
+
+pub(super) const PANELS: &[PanelDescriptor] = &[
+    {
+        let mut panel = base("low", BackgroundCapability::Opaque);
+        panel.group_regions = READOUT;
+        panel
+    },
+    base("high", BackgroundCapability::Opaque),
+    base("overlay", BackgroundCapability::NotUsed),
+    {
+        let mut panel = base("badge", BackgroundCapability::NotUsed);
+        panel.frame_min = BADGE_FRAME;
+        panel.frame_max = BADGE_FRAME;
+        panel.canonical_frames = &[BADGE_FRAME];
+        panel.aspect_min = 1.9;
+        panel.aspect_max = 2.1;
+        panel
+    },
+];
+
+pub(super) fn registry() -> Registry {
+    Registry::new(PANELS).expect("fixture composes")
+}
+
+/// Bands measured for every fixture panel at the one frame they declare:
+/// `low` warns in a band left of centre, the others warn nowhere.
+pub(super) const BANDS: CriticalityBands = CriticalityBands {
+    panels: &[
+        PanelCriticality {
+            panel: "low",
+            frame: FRAME,
+            band: Some(Region {
+                x: 200.0,
+                y: 150.0,
+                width: 80.0,
+                height: 60.0,
+            }),
+        },
+        PanelCriticality {
+            panel: "high",
+            frame: FRAME,
+            band: None,
+        },
+        PanelCriticality {
+            panel: "overlay",
+            frame: FRAME,
+            band: None,
+        },
+        PanelCriticality {
+            panel: "badge",
+            frame: BADGE_FRAME,
+            band: None,
+        },
+    ],
+};
+
+/// Bands with no warning ink anywhere, for the rules that must fire
+/// without the criticality floor firing first.
+pub(super) const QUIET_BANDS: CriticalityBands = CriticalityBands {
+    panels: &[
+        PanelCriticality {
+            panel: "low",
+            frame: FRAME,
+            band: None,
+        },
+        PanelCriticality {
+            panel: "high",
+            frame: FRAME,
+            band: None,
+        },
+        PanelCriticality {
+            panel: "overlay",
+            frame: FRAME,
+            band: None,
+        },
+        PanelCriticality {
+            panel: "badge",
+            frame: BADGE_FRAME,
+            band: None,
+        },
+    ],
+};
+
+pub(super) const fn rect(x: f32, y: f32, width: f32, height: f32) -> Region {
+    Region {
+        x,
+        y,
+        width,
+        height,
+    }
+}
+
+pub(super) const fn slot(panel: &'static str, rect: Region) -> Slot {
+    Slot {
+        panel,
+        rect,
+        occludes: &[],
+    }
+}
+
+pub(super) const SIDE_BY_SIDE: CompositionDescriptor = CompositionDescriptor {
+    screen: SCREEN,
+    slots: &[
+        slot("low", rect(0.0, 0.0, 480.0, 360.0)),
+        slot("high", rect(480.0, 0.0, 480.0, 360.0)),
+    ],
+};
+
+#[test]
+fn side_by_side_validates() {
+    validate_composition(&registry(), &SIDE_BY_SIDE, &BANDS).expect("no slot touches another");
+}
+
+#[test]
+fn empty_composition_is_refused() {
+    const COMPOSITION: CompositionDescriptor = CompositionDescriptor {
+        screen: SCREEN,
+        slots: &[],
+    };
+    assert_eq!(
+        validate_composition(&registry(), &COMPOSITION, &BANDS),
+        Err(CompositionError::NoSlots)
+    );
+}
+
+#[test]
+fn slot_count_over_the_ceiling_is_refused() {
+    const NINE: &[Slot] = &[
+        slot("low", rect(0.0, 0.0, 480.0, 360.0)),
+        slot("high", rect(0.0, 360.0, 480.0, 360.0)),
+        slot("high", rect(480.0, 0.0, 480.0, 360.0)),
+        slot("high", rect(480.0, 360.0, 480.0, 360.0)),
+        slot("high", rect(0.0, 0.0, 480.0, 360.0)),
+        slot("high", rect(0.0, 0.0, 480.0, 360.0)),
+        slot("high", rect(0.0, 0.0, 480.0, 360.0)),
+        slot("high", rect(0.0, 0.0, 480.0, 360.0)),
+        slot("high", rect(0.0, 0.0, 480.0, 360.0)),
+    ];
+    const COMPOSITION: CompositionDescriptor = CompositionDescriptor {
+        screen: SCREEN,
+        slots: NINE,
+    };
+    assert_eq!(
+        validate_composition(&registry(), &COMPOSITION, &BANDS),
+        Err(CompositionError::TooManySlots {
+            slots: 9,
+            ceiling: MAX_COMPOSITION_SLOTS,
+        })
+    );
+}
+
+#[test]
+fn a_screen_that_is_not_a_frame_is_refused() {
+    const BAD: DesignFrame = DesignFrame {
+        width: 0.0,
+        height: 720.0,
+    };
+    const COMPOSITION: CompositionDescriptor = CompositionDescriptor {
+        screen: BAD,
+        slots: &[slot("low", rect(0.0, 0.0, 480.0, 360.0))],
+    };
+    assert_eq!(
+        validate_composition(&registry(), &COMPOSITION, &BANDS),
+        Err(CompositionError::BadScreen { screen: BAD })
+    );
+}
+
+#[test]
+fn an_unregistered_panel_is_refused() {
+    const COMPOSITION: CompositionDescriptor = CompositionDescriptor {
+        screen: SCREEN,
+        slots: &[slot("nowhere", rect(0.0, 0.0, 480.0, 360.0))],
+    };
+    assert_eq!(
+        validate_composition(&registry(), &COMPOSITION, &BANDS),
+        Err(CompositionError::UnknownPanel {
+            slot: 0,
+            panel: "nowhere",
+        })
+    );
+}
+
+#[test]
+fn a_degenerate_slot_rect_is_refused() {
+    const FLAT: Region = rect(0.0, 0.0, 480.0, 0.0);
+    const COMPOSITION: CompositionDescriptor = CompositionDescriptor {
+        screen: SCREEN,
+        slots: &[slot("low", FLAT)],
+    };
+    assert_eq!(
+        validate_composition(&registry(), &COMPOSITION, &BANDS),
+        Err(CompositionError::SlotRectDegenerate {
+            slot: 0,
+            rect: FLAT
+        })
+    );
+}
+
+#[test]
+fn a_slot_off_the_screen_is_refused() {
+    const OFF: Region = rect(600.0, 400.0, 480.0, 360.0);
+    const COMPOSITION: CompositionDescriptor = CompositionDescriptor {
+        screen: SCREEN,
+        slots: &[slot("low", OFF)],
+    };
+    assert_eq!(
+        validate_composition(&registry(), &COMPOSITION, &BANDS),
+        Err(CompositionError::SlotOutsideScreen {
+            slot: 0,
+            rect: OFF,
+            screen: SCREEN,
+        })
+    );
+}
+
+#[test]
+fn a_slot_sized_off_the_declared_frame_is_refused() {
+    const COMPOSITION: CompositionDescriptor = CompositionDescriptor {
+        screen: SCREEN,
+        slots: &[slot("low", rect(0.0, 0.0, 400.0, 300.0))],
+    };
+    assert_eq!(
+        validate_composition(&registry(), &COMPOSITION, &BANDS),
+        Err(CompositionError::SlotFrameUnsupported {
+            slot: 0,
+            panel: "low",
+            frame: DesignFrame {
+                width: 400.0,
+                height: 300.0,
+            },
+        })
+    );
+}
+
+#[test]
+fn a_panel_with_no_measured_band_is_refused() {
+    const COMPOSITION: CompositionDescriptor = CompositionDescriptor {
+        screen: SCREEN,
+        slots: &[slot("low", rect(0.0, 0.0, 480.0, 360.0))],
+    };
+    assert_eq!(
+        validate_composition(&registry(), &COMPOSITION, &CriticalityBands::EMPTY),
+        Err(CompositionError::CriticalityUnknown {
+            slot: 0,
+            panel: "low",
+            frame: FRAME,
+        })
+    );
+}
+
+#[test]
+fn a_slot_buried_under_opaque_slots_is_refused() {
+    const COMPOSITION: CompositionDescriptor = CompositionDescriptor {
+        screen: SCREEN,
+        slots: &[
+            slot("low", rect(0.0, 0.0, 480.0, 360.0)),
+            slot("high", rect(0.0, 0.0, 480.0, 360.0)),
+        ],
+    };
+    assert_eq!(
+        validate_composition(&registry(), &COMPOSITION, &QUIET_BANDS),
+        Err(CompositionError::DeadSlot { slot: 0 })
+    );
+}
+
+#[test]
+fn an_overlay_does_not_bury_the_slot_beneath_it() {
+    // Same geometry as the dead-slot case, but the covering panel
+    // declares `NotUsed`: it paints no background, so the slot below
+    // shows through and is alive.
+    const COMPOSITION: CompositionDescriptor = CompositionDescriptor {
+        screen: SCREEN,
+        slots: &[
+            slot("low", rect(0.0, 0.0, 480.0, 360.0)),
+            Slot {
+                panel: "overlay",
+                rect: rect(0.0, 0.0, 480.0, 360.0),
+                occludes: &["low"],
+            },
+        ],
+    };
+    validate_composition(&registry(), &COMPOSITION, &QUIET_BANDS)
+        .expect("an overlay leaves the slot beneath it visible");
+}
+
+#[test]
+fn covering_a_readout_without_declaring_it_is_refused() {
+    const COMPOSITION: CompositionDescriptor = CompositionDescriptor {
+        screen: SCREEN,
+        slots: &[
+            slot("low", rect(0.0, 0.0, 480.0, 360.0)),
+            slot("badge", rect(0.0, 0.0, 200.0, 100.0)),
+        ],
+    };
+    assert_eq!(
+        validate_composition(&registry(), &COMPOSITION, &QUIET_BANDS),
+        Err(CompositionError::UndeclaredOcclusion {
+            upper: 1,
+            lower: 0,
+            panel: "low",
+            region: rect(10.0, 10.0, 100.0, 40.0),
+        })
+    );
+}
+
+#[test]
+fn declaring_the_occlusion_permits_covering_a_readout() {
+    const COMPOSITION: CompositionDescriptor = CompositionDescriptor {
+        screen: SCREEN,
+        slots: &[
+            slot("low", rect(0.0, 0.0, 480.0, 360.0)),
+            Slot {
+                panel: "badge",
+                rect: rect(0.0, 0.0, 200.0, 100.0),
+                occludes: &["low"],
+            },
+        ],
+    };
+    validate_composition(&registry(), &COMPOSITION, &QUIET_BANDS)
+        .expect("a declared obscuration may cover ordinary symbology");
+}
+
+#[test]
+fn declaring_the_occlusion_does_not_permit_covering_a_warning() {
+    // The same declaration as above, against a panel whose measured
+    // Annunciation band lies under the covering slot: AIR-OUT-011's
+    // floor, which no `occludes` entry reaches.
+    const COMPOSITION: CompositionDescriptor = CompositionDescriptor {
+        screen: SCREEN,
+        slots: &[
+            slot("low", rect(0.0, 0.0, 480.0, 360.0)),
+            Slot {
+                panel: "badge",
+                rect: rect(180.0, 120.0, 200.0, 100.0),
+                occludes: &["low"],
+            },
+        ],
+    };
+    assert_eq!(
+        validate_composition(&registry(), &COMPOSITION, &BANDS),
+        Err(CompositionError::CriticalityObscured {
+            upper: 1,
+            lower: 0,
+            panel: "low",
+            band: rect(200.0, 150.0, 80.0, 60.0),
+        })
+    );
+}
+
+#[test]
+fn the_band_is_placed_at_the_slot_origin() {
+    // The lower slot sits at (480, 360), so its warning band moves with
+    // it: an overlay over the *screen* origin covers nothing.
+    const COMPOSITION: CompositionDescriptor = CompositionDescriptor {
+        screen: SCREEN,
+        slots: &[
+            slot("low", rect(480.0, 360.0, 480.0, 360.0)),
+            Slot {
+                panel: "badge",
+                rect: rect(480.0, 360.0, 200.0, 100.0),
+                occludes: &["low"],
+            },
+        ],
+    };
+    validate_composition(&registry(), &COMPOSITION, &BANDS)
+        .expect("the band translated with its slot");
+}

--- a/crates/indicate-instrument-registry/src/digest.rs
+++ b/crates/indicate-instrument-registry/src/digest.rs
@@ -160,14 +160,14 @@ fn digest_frame_scene(
 /// A frame is two fixed-width words, so it needs no length prefix; the
 /// role tag that precedes a frame item keeps it from aliasing anything
 /// else in the stream.
-fn digest_frame(ctx: &mut Sha256Ctx, frame: DesignFrame) {
+pub(crate) fn digest_frame(ctx: &mut Sha256Ctx, frame: DesignFrame) {
     ctx.update(&frame.width.to_le_bytes());
     ctx.update(&frame.height.to_le_bytes());
 }
 
 /// Role-tagged, length-prefixed (`u32` LE) update: framing keeps
 /// adjacent fields and different item roles from aliasing each other.
-fn update_framed(ctx: &mut Sha256Ctx, role: u8, bytes: &[u8]) {
+pub(crate) fn update_framed(ctx: &mut Sha256Ctx, role: u8, bytes: &[u8]) {
     ctx.update(&[role]);
     ctx.update(&(bytes.len() as u32).to_le_bytes());
     ctx.update(bytes);

--- a/crates/indicate-instrument-registry/src/lib.rs
+++ b/crates/indicate-instrument-registry/src/lib.rs
@@ -23,14 +23,19 @@
 #[cfg(test)]
 extern crate std;
 
+mod composition;
 mod digest;
 mod registry;
 
+pub use composition::{
+    COMPOSITION_DIGEST_DOMAIN, CompositionDescriptor, CompositionError, MAX_COMPOSITION_SLOTS,
+    Slot, composition_digest, validate_composition,
+};
 pub use digest::{DigestError, SCENE_DIGEST_DOMAIN, scene_digest};
 pub use indicate_instrument_descriptor::states;
 pub use indicate_instrument_descriptor::{
     BackgroundCapability, CANONICAL_STATES, CONFIG_BLOB_MAX, CanonicalState, ConfigBlob,
-    ConfigError, ConfigKey, DesignFrame, DrawFn, EMPTY_CONFIG, ExtremeState, GroupSet,
-    PanelDescriptor, PanelDrawError, PanelSet, Region, keys,
+    ConfigError, ConfigKey, CriticalityBands, DesignFrame, DrawFn, EMPTY_CONFIG, ExtremeState,
+    GroupSet, PanelCriticality, PanelDescriptor, PanelDrawError, PanelSet, Region, keys,
 };
 pub use registry::{Panels, Registry, RegistryError};

--- a/crates/indicate-instrument-registry/src/registry.rs
+++ b/crates/indicate-instrument-registry/src/registry.rs
@@ -2,12 +2,13 @@
 
 use indicate_instrument_scene::LAYER_COUNT;
 
-use indicate_instrument_descriptor::{PanelDescriptor, PanelSet};
+use indicate_instrument_descriptor::{PanelDescriptor, PanelSet, Region};
 
 mod error;
 mod frame_range;
 
 pub use error::RegistryError;
+pub(crate) use frame_range::supports as frame_supported;
 
 /// How a shell named the panels it composed.
 ///
@@ -209,13 +210,7 @@ fn validate_panel(index: usize, panel: &PanelDescriptor) -> Result<(), RegistryE
         // The floor is where a readout surface has to fit: a region
         // that only fits at a larger frame does not describe the panel
         // a shell may ask for at its smallest.
-        let floor = panel.frame_min;
-        let inside = region.x >= 0.0
-            && region.y >= 0.0
-            && region.width > 0.0
-            && region.height > 0.0
-            && region.x + region.width <= floor.width
-            && region.y + region.height <= floor.height;
+        let inside = region.is_sound() && Region::of(panel.frame_min).contains(region);
         if !inside {
             return Err(RegistryError::RegionOutsideFrame {
                 index,

--- a/crates/indicate-instrument-registry/src/registry/frame_range.rs
+++ b/crates/indicate-instrument-registry/src/registry/frame_range.rs
@@ -62,6 +62,9 @@ fn validate_canonical(index: usize, panel: &PanelDescriptor) -> Result<(), Regis
         if panel.canonical_frames[..position].contains(frame) {
             return Err(RegistryError::DuplicateCanonicalFrame { index, position });
         }
+        // Spelled out rather than routed through `supports`, because a
+        // canonical frame that fails names *which* rule it broke, and
+        // a declaration is fixed by knowing that.
         if !in_range(*frame, panel) {
             return Err(RegistryError::CanonicalFrameOutOfRange { index, position });
         }
@@ -93,6 +96,19 @@ fn validate_baselines(index: usize, panel: &PanelDescriptor) -> Result<(), Regis
         }
     }
     Ok(())
+}
+
+/// Whether `panel` declared that it can lay out against `frame`: in
+/// range, on the step grid, and inside the aspect bounds.
+///
+/// The composition layer asks this of a slot's dimensions, and a shell
+/// choosing a frame may ask it before drawing — the draw path itself
+/// re-checks nothing.
+pub(crate) fn supports(panel: &PanelDescriptor, frame: DesignFrame) -> bool {
+    in_range(frame, panel)
+        && on_grid(frame.width, panel.frame_min.width, panel.frame_step.0)
+        && on_grid(frame.height, panel.frame_min.height, panel.frame_step.1)
+        && aspect_ok(frame, panel)
 }
 
 fn in_range(frame: DesignFrame, panel: &PanelDescriptor) -> bool {

--- a/docs/instruments/backend-contract.md
+++ b/docs/instruments/backend-contract.md
@@ -77,6 +77,100 @@ frame a conforming shell may ask any of them for is 480×360.
   reviewed decision — never drift. Fixing overflowing paint moves frame
   hashes and is its own change, at which point the ratchet steps down.
 
+## Screen composition
+
+Several panels may share one surface ([`AIR-OUT-011`](requirements.md#air-out-011)).
+A `CompositionDescriptor` in `indicate-instrument-registry` declares the
+logical screen and an ordered list of `Slot`s — a panel id, a rect in
+screen units, and the `occludes` list naming the panels below whose
+ordinary symbology this slot is allowed to cover. **Slot index is z**,
+exactly as `LayerId`'s discriminant is z within a scene: later slots
+paint above earlier ones, and declaration order is paint order
+everywhere.
+
+What a backend does with it:
+
+- **Paint slots in index order.** Per slot: clip to the slot rect,
+  translate to the slot origin, and replay that panel's validated scene.
+  That is the whole of the placement — the `stride_bytes` sub-window the
+  reference rasterizer already supports, generalized to overlap.
+- **One global uniform mapping** from screen-logical units to the
+  surface. A slot gets no mapping of its own; there is no per-slot
+  rotation, and no slot is scaled to fit its rect. The slot's dimensions
+  *are* the frame its panel was asked to emit, which is why
+  `validate_composition` refuses a slot sized outside the panel's
+  declared frame range.
+- **No offscreen surfaces and no retained graph.** A slot's cost is a
+  function of its own scene and never of what lies beneath it, so
+  overdraw from stacking is bounded by construction. The ceilings are
+  sums: total encoded bytes at most `MAX_COMPOSITION_SLOTS ×
+  MAX_SCENE_BYTES`, composed-frame work at most the sum of the per-slot
+  `RenderWork` budgets, and the composed timing envelope the sum of the
+  slot envelopes against the same liveness-derived deadline (REN-04).
+- **One resolved snapshot and one `AlertOutput` per composed frame**,
+  fanned to every slot. Two overlapping panels disagreeing because they
+  resolved different snapshots is a misleading display
+  ([`AIR-BAS-007`](requirements.md#air-bas-007)); resolving once is the
+  rule, not an optimization.
+- **A slot that fails at run time paints its failure inside its own rect
+  and nowhere else,** and suppresses, delays, and alters nothing in any
+  other slot.
+- **Per-slot configuration is shell-supplied at draw time,** not
+  declared in the composition. The descriptor declares layout; the feed
+  supplies data and configuration. It therefore does not join the
+  screen-composition digest, and a shell that reconfigures a panel still
+  composes the same screen.
+
+What `validate_composition` refuses at init, before first paint — a
+composition fault is a declaration error, never a rendering curiosity:
+an unregistered panel id; a rect that is not finite, is degenerate, or
+leaves the screen; a slot sized to a frame its panel does not support;
+more than `MAX_COMPOSITION_SLOTS` (8) slots; a slot wholly covered by
+the opaque slots above it; and undeclared obscuration.
+
+Overlap rides `BackgroundCapability` rather than any new alpha
+mechanism. `Opaque` and `Cedeable` panels prove a full-frame opaque
+cover at admission, so they occlude their whole rect and count toward
+burying a slot below; a `NotUsed` panel paints nothing in the background
+band and functions as an overlay through which lower slots show.
+
+**The obscuration floor.** Two rules, and the difference between them is
+what [`AIR-OUT-011`](requirements.md#air-out-011) requires:
+
+| What may be covered | Where it comes from | Rule |
+|---|---|---|
+| Ordinary symbology | the lower panel's declared `group_regions`, placed at its slot origin | covered only where the covering slot names the lower panel in `occludes` |
+| Criticality content | the *measured* union `Annunciation`/`Failure` ink bound, per panel × frame | may not be covered at all |
+
+A declaration reaches the first row and never the second:
+
+> **Declaring buys you readouts, never warnings.**
+
+Naming a panel in `occludes` permits covering its ordinary symbology; it
+does not permit covering its warnings, its failure indications, or the
+labelling that identifies the surface as simulation, because a
+declaration that could conceal a warning would be a declaration that the
+warning does not matter. The criticality bound is measured rather than
+declared for the same reason: a panel able to name its own warning
+surface could also understate it.
+
+The bound a composition validates against is what admission measured
+over the whole canonical × extreme × withheld case matrix, pinned beside
+the raster baselines. A panel with no band pinned at the size its slot
+asks for is refused rather than assumed quiet.
+
+The **screen-composition digest** has its own domain string and covers
+the screen frame, the ordered slots — panel id, rect, and `occludes`
+list — and the scene digest beneath, so it is strictly stronger than the
+scene digest: two shells agreeing here agree both about what their
+panels paint and about where. Slot rects are in it from day one, so
+relaxing which rects are admissible changes what validates and never
+what the digest covers. Pin-advance discipline is the same as for the
+scene digest.
+
+Composition does not change a panel: its modes, its reversion, and its
+failure presentation are what they were standalone.
+
 ## Where the vocabulary deliberately stops
 
 Two properties of the opcode set decide what an instrument can be. One

--- a/docs/instruments/backend-contract.md
+++ b/docs/instruments/backend-contract.md
@@ -147,12 +147,27 @@ A declaration reaches the first row and never the second:
 > **Declaring buys you readouts, never warnings.**
 
 Naming a panel in `occludes` permits covering its ordinary symbology; it
-does not permit covering its warnings, its failure indications, or the
-labelling that identifies the surface as simulation, because a
-declaration that could conceal a warning would be a declaration that the
-warning does not matter. The criticality bound is measured rather than
-declared for the same reason: a panel able to name its own warning
-surface could also understate it.
+does not permit covering its warnings or its failure indications,
+because a declaration that could conceal a warning would be a
+declaration that the warning does not matter. The criticality bound is
+measured rather than declared for the same reason: a panel able to name
+its own warning surface could also understate it.
+
+**The floor is exactly the two bands, and no wider.** It protects what a
+panel paints into `Annunciation` and `Failure`, whatever that is, and it
+does not protect anything a panel paints elsewhere, whatever that says.
+Two consequences worth stating rather than discovering:
+
+- The simulation labelling [`AIR-BAS-001`](requirements.md#air-bas-001)
+  and [`AIR-FLAG-007`](requirements.md#air-flag-007) require is covered
+  by this floor **only if the panel paints it into a criticality band**.
+  No shipped panel emits that labelling at all today, so this is an
+  obligation on a panel author, not a property the composition layer
+  supplies.
+- A band is only as wide as the cases that measured it. A failure cue no
+  corpus or extreme state drives is not in the bound and is not
+  protected; `panel-contract.md` says the same thing to the author who
+  can fix it.
 
 The bound a composition validates against is what admission measured
 over the whole canonical × extreme × withheld case matrix, pinned beside

--- a/docs/instruments/panel-contract.md
+++ b/docs/instruments/panel-contract.md
@@ -220,22 +220,37 @@ than a tolerance:
 
 A panel does not declare where its warnings go. The admission harness
 measures it: the union design-space ink of the `Annunciation` and
-`Failure` bands across the whole canonical × extreme × withheld matrix,
-per canonical frame, exposed on the admission report and pinned beside
-the raster baselines. A composition above uses that bound and no
-declaration, because a panel able to name its own warning surface could
-also understate it.
+`Failure` bands across the whole canonical × extreme × withheld ×
+**alerted** matrix, per canonical frame, exposed on the admission report
+and pinned beside the raster baselines. A composition above uses that
+bound and no declaration, because a panel able to name its own warning
+surface could also understate it.
 
-Two things follow for an author:
+The alert axis matters more than it looks. A composed frame fans one
+`AlertOutput` to every slot, so every panel that draws the shared alert
+stack draws it at run time; the harness therefore draws every case twice,
+once quiet and once with a saturated stack, and folds both into the
+bound. A band measured only on quiet frames would exclude every alert
+row and tell a composition it may cover warnings.
+
+Three things follow for an author:
 
 - **Paint your warnings in `Annunciation` or `Failure`.** A caution
   drawn into `Tapes` is outside the measured band, and a composition
-  will be told it may be covered.
-- **A band measured empty is an honest empty, and a weak one.** If no
-  corpus or extreme state drives your failure cue, nothing is measured
-  and nothing is protected. The shipped monitor panel is in that
-  position: its `MON` flag is gated on a channel status no corpus state
-  produces, so its band is `None`. Contribute an extreme state that
+  will be told it may be covered. The floor is the two bands and nothing
+  else — including the simulation labelling
+  [`AIR-BAS-001`](requirements.md#air-bas-001) and
+  [`AIR-FLAG-007`](requirements.md#air-flag-007) require, which is
+  protected exactly when you paint it into a criticality band and not
+  otherwise.
+- **A band nothing was witnessed in refuses obscuration outright.** An
+  empty measurement is the absence of a witness, not a proof of absence,
+  so composition treats it as unknown and refuses any overlap. That is
+  fail-closed, and it is not a substitute for measuring.
+- **A cue no case drives is not in your band.** The shipped monitor is
+  the example: its `MON` flag and full-frame failure X are gated on a
+  channel status no corpus or extreme state produces, so its band covers
+  its alert stack and nothing else. Contribute an extreme state that
   drives the cue if you want the protection.
 
 ## What the admission harness actually asserts

--- a/docs/instruments/panel-contract.md
+++ b/docs/instruments/panel-contract.md
@@ -53,7 +53,7 @@ Three tiers of obligation, and the difference matters:
 | `extreme_states` | **Load-bearing.** Each one multiplies the case matrix. |
 | `id`, `title` | Validated at registry init: charset, non-empty. |
 | `config_schema` | Validated at init (keys strictly ascending). Admission always draws the empty config. |
-| `group_regions` | **Declared, not currently read by admission.** See below. |
+| `group_regions` | **Load-bearing.** Admission asserts every declared region is populated by claimed ink, and screen composition plans obscuration around them. |
 | `raster_baselines` | Inert unless the panel is in a set the raster tests cover. Each entry must name a canonical frame. |
 
 ### `required_layers` — declare what you always emit
@@ -156,25 +156,87 @@ Coverage is exact, not conservative.
 A panel that paints nothing in the background band declares `NotUsed`
 and composes as an overlay.
 
-### `group_regions` — declared, and not yet load-bearing
+### `group_regions` — a surface the readout really uses
 
-Regions say which surface of the panel a group's readout owns. They are
-validated for geometry at registry init — inside `frame_min`, non-
-degenerate, only for groups the panel requires — and **admission does
-not currently read them**. The conformance crate says so in its own
-module documentation, and this contract will not paper over it.
+Regions say which surface of the panel a group's *value* is drawn on,
+and they are asserted. Registry init still checks the geometry — inside
+`frame_min`, non-degenerate, only for groups the panel requires — and
+admission adds the assertion that gives the field teeth:
 
-What actually keeps a panel honest today is the provenance machinery
-above, which tests every claimed run wherever the ink lands. Declare
-regions accurately anyway: they are a shell's statement of readout
-ownership, and giving them teeth is the first phase of the screen
-composition work. A region drawn wrong will become a failure the day it
-is checked, and the person who has to fix it is the one who drew it.
+> **Every declared region must be populated: somewhere in the panel's
+> case matrix, a visible run claiming that group is drawn at it.**
+
+A region nothing populates fails as `GroupRegionEmpty`, naming the
+panel, the group, and the rectangle that caught nothing.
 
 Draw the boundary around the value's own ink and nothing else. Scale
 ladders, tick labels, and neighbouring boxes belong to other groups or
 to no group; a region generous enough to swallow them is the vacuous
-case the mechanism exists to prevent.
+case the mechanism exists to prevent. That guidance has not changed —
+what changed is that it is now enforced from the other side as well. A
+region must be **tight enough to be honest and populated enough to be
+real**, and the second half is what admission checks.
+
+Note what is deliberately *not* asserted: that all of a group's claimed
+ink sits inside its regions. It never could be. A numeral must carry a
+claim, so every ladder rung and every compass tick carries the claim of
+the group it measures, and those sit outside the readout box on purpose.
+A rule demanding they be inside would be unsatisfiable for every tape
+and every rose, and satisfiable only by inflating regions until they
+described nothing.
+
+The hazard the assertion does address is the opposite one. A region
+pointing at empty space is worse than no region, because the composition
+layer plans obscuration around regions: it would protect a surface the
+readout does not use and leave the surface it does use undeclared. A
+region is a claim that this is where the group's value appears, and
+admission makes the claim answerable.
+
+Four scoping rules, each a consequence of what a region means rather
+than a tolerance:
+
+- **A group that declares no region is not judged.** Some readouts share
+  a strip with a neighbouring group's ink and no geometry separates
+  them; silence is the honest declaration there, and the provenance
+  claim on the run is what keeps it honest. The PFD's selected-altitude
+  box is the shipped example.
+- **The witness may come from any case.** A readout that dashes out
+  under withholding paints no claimed run at all in that case, and it is
+  still the same readout. One case in the matrix is enough.
+- **The search runs at `frame_min`,** the frame regions are declared and
+  validated against. A panel laid out at a larger frame puts its
+  readouts somewhere else, and floor coordinates describe that layout no
+  better than they describe another panel's.
+- **A region holds a run when it holds the centre of that run's ink,**
+  which is neither whole-rectangle containment nor bare overlap. Run
+  rectangles here are conservative nominal metrics, deliberately wider
+  than the glyphs, so a readout centred in its own tightly-drawn box
+  overhangs it by a few units and containment would call it empty. Bare
+  overlap is too weak in the other direction: a rung grazing a region's
+  corner is not that region's readout. Clipped-away runs paint nothing
+  and are skipped, the same visibility rule the provenance family uses.
+
+### Criticality bands are measured, not declared
+
+A panel does not declare where its warnings go. The admission harness
+measures it: the union design-space ink of the `Annunciation` and
+`Failure` bands across the whole canonical × extreme × withheld matrix,
+per canonical frame, exposed on the admission report and pinned beside
+the raster baselines. A composition above uses that bound and no
+declaration, because a panel able to name its own warning surface could
+also understate it.
+
+Two things follow for an author:
+
+- **Paint your warnings in `Annunciation` or `Failure`.** A caution
+  drawn into `Tapes` is outside the measured band, and a composition
+  will be told it may be covered.
+- **A band measured empty is an honest empty, and a weak one.** If no
+  corpus or extreme state drives your failure cue, nothing is measured
+  and nothing is protected. The shipped monitor panel is in that
+  position: its `MON` flag is gated on a channel status no corpus state
+  produces, so its band is `None`. Contribute an extreme state that
+  drives the cue if you want the protection.
 
 ## What the admission harness actually asserts
 
@@ -189,7 +251,9 @@ states, each fully fed and then once per withheld group — the harness
 checks that the draw returns, that the scene decodes and satisfies the
 layer envelope, that every required layer is present, that the
 background claim holds, that every glyph is in the controlled
-vocabulary, and that the provenance rules above hold. Every geometry
+vocabulary, and that the provenance rules above hold. Once per panel it
+also checks that every declared region caught claimed ink somewhere in
+the matrix. Every geometry
 check uses the frame being drawn, not a constant. Ink outside that frame
 is **counted, not refused** —
 and the ratchet that keeps the count from growing is an assertion *you*
@@ -260,6 +324,44 @@ Contract values that a consumer pins — the state ABI, the scene format,
 the corpus, the composition digest, the shipped panel set — are named
 per release in `CHANGELOG.md`, and cutting that release is a step in
 `CONTRIBUTING.md`.
+
+## What composition asks of you
+
+A panel may be placed beside, inset into, or under another on one
+screen. `backend-contract.md` carries the compositor's side; this is
+what a composed panel owes.
+
+- **Lay out against the frame you are handed, every time.** A slot's
+  dimensions *are* the frame the panel is asked to emit — nothing
+  rescales a scene, because there is no `SCALE` opcode. A geometry
+  constant that should have read `frame.width` becomes visible the day
+  someone slots your panel at a size other than the one you tested.
+  `validate_composition` refuses a slot whose dimensions are not a frame
+  you declared, so the range in your descriptor is the whole of what a
+  screen may ask.
+- **Your `background` declaration decides whether you occlude.**
+  `Opaque` and `Cedeable` prove a full-frame opaque cover at admission,
+  so a composition treats your whole rect as covering what lies beneath;
+  `NotUsed` makes you an overlay lower slots show through. Declaring
+  `Opaque` because it seemed safer will bury the panel underneath you,
+  and the composition will be refused as a dead slot.
+- **Declare your readout regions accurately, and paint criticality in
+  the criticality bands.** Those two are what a composition may and may
+  not cover. Regions may be covered when the screen declares it;
+  measured `Annunciation`/`Failure` ink may not be covered at all. A
+  region drawn over blank space is worse than none: the screen would
+  protect it and cover the readout instead.
+- **Expect one snapshot and one alert state per composed frame.** Do not
+  cache a previous frame's data to smooth a readout: two panels showing
+  the same quantity from different snapshots is the disagreement the
+  single-resolve rule exists to prevent.
+- **Fail inside your own rect.** Your failure presentation is drawn in
+  your own scene, in your own frame's coordinates, and a compositor
+  clips it to your slot. A panel that tries to annunciate globally
+  annunciates nowhere.
+- **Configuration still arrives at draw time.** A composition declares
+  layout only, so being slotted changes nothing about how your config
+  blob reaches you.
 
 ## Where the vocabulary stops
 

--- a/docs/instruments/renderer-verification.md
+++ b/docs/instruments/renderer-verification.md
@@ -130,14 +130,27 @@ the pin, exactly as the per-panel baselines are.
 | Fixture | Screen | Slots |
 |---|---|---|
 | Side by side | 960x360 | `pfd` at (0, 0), `hsi` at (480, 0), neither overlapping |
-| Opaque inset over a PFD | 480x360 | `pfd` full-frame, an `Opaque` 200x60 fixture panel inset at (140, 296) |
+| Opaque inset over a PFD | 480x360 | `pfd` full-frame, an `Opaque` 200x32 fixture panel inset at (140, 4) |
 | `NotUsed` overlay | 480x360 | the same geometry with a `NotUsed` fixture panel, which opens no background band |
 
-The inset rect sits in the strip below the PFD's measured criticality band and
-clear of every readout region it declares, so neither fixture needs an
-`occludes` entry. That is asserted by running `validate_composition` over each
+The inset rect sits in the narrow strip *above* the PFD's measured criticality
+band — which, once alerts are folded into the measurement, runs from y 38 to the
+bottom of the alert stack at y 352 — and clear of the readout regions the PFD
+declares, so neither fixture needs an `occludes` entry. That a PFD-sized panel
+has so little surface a slot may sit on is the floor working, not a fixture
+inconvenience. It is asserted by running `validate_composition` over each
 fixture rather than reasoned about in prose, and the PFD band the fixtures use
 is asserted equal to the pinned `BUILTIN_CRITICALITY_BANDS` entry.
+
+### The obscuration floor, measured in pixels
+
+`src/composition/tests/obscuration.rs` holds two compositions that a declared
+`occludes` entry once admitted and that must now be refused: a panel placed over
+a PFD's alert stack, and one placed over the monitor's annunciation band. Both
+assert `CriticalityObscured`. A third test measures where the shared alert stack
+actually inks — by diffing a rendered quiet frame against an alerted one — and
+asserts every shipped panel's pinned band contains it, so the pin cannot drift
+away from the ink it is supposed to bound.
 
 ### What the hashes do not prove
 

--- a/docs/instruments/renderer-verification.md
+++ b/docs/instruments/renderer-verification.md
@@ -14,6 +14,7 @@ engineering conformance for the simulator; it makes no certification claim.
 | Backend | Where | Determinism gate |
 |---|---|---|
 | Reference software rasterizer | `indicate-instrument-raster::render` | Bit-exact: pinned SHA-256 frame hashes (`src/raster/tests/frame_hashes.rs`), reproducible via `libm` + IEEE-754 `f32`. |
+| Reference composition harness | `indicate-instrument-raster::render_composition` | Bit-exact: pinned SHA-256 composed-frame hashes (`src/composition/tests.rs`), plus the overlay show-through property. |
 | Browser Canvas2D | Pilotage repository, `clients/web/instruments.js` (`interpretScene`) | Semantic conformance + documented, limited tolerances. **Not** pixel-deterministic — Canvas2D anti-aliasing and font/geometry rounding are platform-owned. |
 | wgpu / embedded framebuffer | future | Consume the identical scene IR; verified by the same corpus when they land. |
 
@@ -98,6 +99,67 @@ the firmware/build identity, MCU, clock and memory configuration, compiler
 flags, and raw output; only then does the envelope become a WCET and the
 deadline a display refresh requirement. The browser watchdog (`PanelHealth`,
 simulator-only) latches a stalled panel as `LIVENESS` past its deadline.
+
+## Composed frames
+
+A screen composition places several validated panel scenes on one surface
+([`AIR-OUT-011`](requirements.md#air-out-011)); `backend-contract.md` states the
+rule and `render_composition` executes it. The harness is the evidence that the
+rule is implementable rather than merely declarable: one framebuffer cleared
+once, slots painted in index order, each clipped to its rect and translated to
+its origin, one global 1:1 mapping, no offscreen surface and no retained graph.
+
+Placement reuses the single-panel painting path. A slot's origin and rect enter
+through the same translate and clip commands any scene may issue, so a slot
+inherits the same Q8.8 snapping and the same conservative clip bound — there is
+no second geometry path to keep in agreement. That is the `stride_bytes`
+sub-window idea generalized: a slot is a window onto a shared surface, differing
+from a strided sub-buffer only in that slots may overlap.
+
+One snapshot and one `AlertOutput` are fanned to every slot, so the harness also
+demonstrates the single-resolve rule two overlapping panels depend on
+([`AIR-BAS-007`](requirements.md#air-bas-007)).
+
+### Pinned composed-frame hashes
+
+Three shapes, because placement, opaque overlap, and overlay show-through fail
+differently. All are tight-stride RGBA8 at 1:1 over the shared canonical
+`typical` state, asserted reproducible (rendered twice) before being compared to
+the pin, exactly as the per-panel baselines are.
+
+| Fixture | Screen | Slots |
+|---|---|---|
+| Side by side | 960x360 | `pfd` at (0, 0), `hsi` at (480, 0), neither overlapping |
+| Opaque inset over a PFD | 480x360 | `pfd` full-frame, an `Opaque` 200x60 fixture panel inset at (140, 296) |
+| `NotUsed` overlay | 480x360 | the same geometry with a `NotUsed` fixture panel, which opens no background band |
+
+The inset rect sits in the strip below the PFD's measured criticality band and
+clear of every readout region it declares, so neither fixture needs an
+`occludes` entry. That is asserted by running `validate_composition` over each
+fixture rather than reasoned about in prose, and the PFD band the fixtures use
+is asserted equal to the pinned `BUILTIN_CRITICALITY_BANDS` entry.
+
+### What the hashes do not prove
+
+A hash proves reproducibility. Two property tests prove the behaviour that makes
+overlap safe, and they are the reason the overlay fixture exists:
+
+- **Opaque slots replace.** Every pixel of the inset's rect differs from the
+  PFD-alone frame, so an `Opaque` slot owns its whole rect rather than merely
+  painting into transparent gaps.
+- **`NotUsed` slots show through.** The overlay's scene is rendered alone on
+  transparent black to establish which of its pixels are its own ink. Then, for
+  **every** pixel of the rect: where the overlay's alpha is zero the composed
+  frame equals the PFD-alone frame exactly, and where it is not, the composed
+  frame equals the overlay's own ink. Both halves are asserted non-empty, so
+  neither can pass vacuously.
+
+Scope, stated plainly: the harness is a determinism instrument, not a
+flight-worthy compositor. A slot fault here spoils the whole frame, as every
+reference render does, because a bit-exact harness that painted a partial frame
+would pin a hash of undefined content. The per-slot in-rect failure presentation
+the contract requires of a real backend is a runtime obligation of the shell
+above it.
 
 ## The conformance corpus
 

--- a/sets/indicate-instrument-panels/src/descriptors.rs
+++ b/sets/indicate-instrument-panels/src/descriptors.rs
@@ -370,20 +370,25 @@ pub const BUILTIN_SCENE_DIGEST: &str =
 /// The measured criticality bands of [`BUILTIN_PANELS`], pinned beside
 /// the raster baselines: the union `Annunciation`/`Failure` ink bound
 /// per panel × canonical frame, over the whole canonical × extreme ×
-/// withheld case matrix. A screen composition validates its obscuration
-/// against these.
+/// withheld × alerted case matrix. A screen composition validates its
+/// obscuration against these.
+///
+/// The alert axis is what makes these honest. A composed frame fans one
+/// `AlertOutput` to every slot, and all three panels draw the shared
+/// alert stack into `Annunciation`; a band measured only on quiet
+/// frames would exclude every alert row and licence covering warnings.
+/// Each band below therefore reaches y 352, the stack's bottom row.
 ///
 /// A shell holds this as data. The admission harness re-derives the
 /// same values from the emitted scenes and its test refuses a
 /// disagreement, so a paint change that moves a warning moves the pin
 /// deliberately rather than silently widening what may be covered.
 ///
-/// The monitor's band is `None`, and that is a measurement rather than
-/// an omission: its `MON` flag and failure X are gated on a channel
-/// status no corpus state produces, so nothing was ever drawn in either
-/// band. Nothing may be *proven* coverable there either — a composition
-/// that covers the monitor covers no measured warning, which is exactly
-/// as strong a statement as the corpus supports.
+/// Read the monitor's band for what it is: the alert stack, and only
+/// that. Its own `MON` flag and full-frame failure X are gated on a
+/// channel status no corpus or extreme state produces, so they were
+/// never drawn and are not in the bound. A set that wants them
+/// protected contributes a state that drives them.
 pub const BUILTIN_CRITICALITY_BANDS: CriticalityBands = CriticalityBands {
     panels: &[
         PanelCriticality {
@@ -393,7 +398,7 @@ pub const BUILTIN_CRITICALITY_BANDS: CriticalityBands = CriticalityBands {
                 x: 6.0,
                 y: 38.0,
                 width: 468.0,
-                height: 254.0,
+                height: 314.0,
             }),
         },
         PanelCriticality {
@@ -403,13 +408,18 @@ pub const BUILTIN_CRITICALITY_BANDS: CriticalityBands = CriticalityBands {
                 x: 98.0,
                 y: 48.0,
                 width: 284.0,
-                height: 284.0,
+                height: 304.0,
             }),
         },
         PanelCriticality {
             panel: "monitor",
             frame: BUILTIN_FRAME,
-            band: None,
+            band: Some(Region {
+                x: 100.0,
+                y: 276.0,
+                width: 90.85715,
+                height: 76.0,
+            }),
         },
     ],
 };

--- a/sets/indicate-instrument-panels/src/descriptors.rs
+++ b/sets/indicate-instrument-panels/src/descriptors.rs
@@ -11,8 +11,8 @@ mod extreme_states;
 
 use indicate_alerts::AlertOutput;
 use indicate_instrument_descriptor::{
-    BackgroundCapability, ConfigBlob, DesignFrame, ExtremeState, GroupSet, PanelDescriptor,
-    PanelDrawError, PanelSet, Region,
+    BackgroundCapability, ConfigBlob, CriticalityBands, DesignFrame, ExtremeState, GroupSet,
+    PanelCriticality, PanelDescriptor, PanelDrawError, PanelSet, Region,
 };
 use indicate_instrument_scene::{LayerId, SceneWriter};
 use indicate_instrument_state::{GroupId, PanelData};
@@ -95,11 +95,15 @@ pub const PFD_DESCRIPTOR: PanelDescriptor = PanelDescriptor {
     background: BackgroundCapability::Cedeable,
     config_schema: PFD_CONFIG_SCHEMA,
     // Value-readout surfaces, keyed by the group whose data the number
-    // comes from. Honest status is proven by provenance claims on the
-    // runs themselves (the harness's withholding matrix tests every
-    // claim, wherever the ink lands), so these regions are the
-    // descriptor's statement of readout ownership for a shell — not
-    // the numeral police.
+    // comes from, drawn around the pointed readout and deliberately
+    // excluding the scale ladder beside it — the rungs claim the same
+    // group, because a numeral must claim the group it came from, and
+    // they are not what these rectangles name.
+    //
+    // Admission asserts each of these is populated: some case must draw
+    // a run claiming the group at the surface. Screen composition then
+    // plans obscuration around them, which is why a rectangle over
+    // blank space would be worse than no rectangle at all.
     group_regions: &[
         // IAS pointed readout value (the run anchors at x 40; the
         // scale ladder's runs anchor at x 70 and stay outside).
@@ -362,6 +366,53 @@ pub const BUILTIN_SET: PanelSet = PanelSet {
 /// review note saying why.
 pub const BUILTIN_SCENE_DIGEST: &str =
     "3efb08c55eadadc2b006ee6b006b29e4b3a3f8d4ec3ce1324f401dbc16dc85ca";
+
+/// The measured criticality bands of [`BUILTIN_PANELS`], pinned beside
+/// the raster baselines: the union `Annunciation`/`Failure` ink bound
+/// per panel × canonical frame, over the whole canonical × extreme ×
+/// withheld case matrix. A screen composition validates its obscuration
+/// against these.
+///
+/// A shell holds this as data. The admission harness re-derives the
+/// same values from the emitted scenes and its test refuses a
+/// disagreement, so a paint change that moves a warning moves the pin
+/// deliberately rather than silently widening what may be covered.
+///
+/// The monitor's band is `None`, and that is a measurement rather than
+/// an omission: its `MON` flag and failure X are gated on a channel
+/// status no corpus state produces, so nothing was ever drawn in either
+/// band. Nothing may be *proven* coverable there either — a composition
+/// that covers the monitor covers no measured warning, which is exactly
+/// as strong a statement as the corpus supports.
+pub const BUILTIN_CRITICALITY_BANDS: CriticalityBands = CriticalityBands {
+    panels: &[
+        PanelCriticality {
+            panel: "pfd",
+            frame: BUILTIN_FRAME,
+            band: Some(Region {
+                x: 6.0,
+                y: 38.0,
+                width: 468.0,
+                height: 254.0,
+            }),
+        },
+        PanelCriticality {
+            panel: "hsi",
+            frame: BUILTIN_FRAME,
+            band: Some(Region {
+                x: 98.0,
+                y: 48.0,
+                width: 284.0,
+                height: 284.0,
+            }),
+        },
+        PanelCriticality {
+            panel: "monitor",
+            frame: BUILTIN_FRAME,
+            band: None,
+        },
+    ],
+};
 
 #[cfg(test)]
 mod digest_tests;

--- a/sets/indicate-instrument-panels/src/lib.rs
+++ b/sets/indicate-instrument-panels/src/lib.rs
@@ -29,8 +29,8 @@ mod pfd;
 use indicate_instrument_descriptor::DesignFrame;
 
 pub use descriptors::{
-    BUILTIN_PANELS, BUILTIN_SCENE_DIGEST, BUILTIN_SET, HSI_DESCRIPTOR, MONITOR_DESCRIPTOR,
-    PFD_DESCRIPTOR,
+    BUILTIN_CRITICALITY_BANDS, BUILTIN_PANELS, BUILTIN_SCENE_DIGEST, BUILTIN_SET, HSI_DESCRIPTOR,
+    MONITOR_DESCRIPTOR, PFD_DESCRIPTOR,
 };
 pub use hsi::draw_hsi;
 pub use monitor::draw_monitor;

--- a/sets/indicate-instrument-template/src/template/tests.rs
+++ b/sets/indicate-instrument-template/src/template/tests.rs
@@ -15,8 +15,12 @@ fn the_template_set_passes_admission() {
     let registry = Registry::from_sets(&SETS).expect("the template set composes");
     let report = admit(&registry).expect("the template must be admissible");
     // Four canonical states x (one fed case + one per required group
-    // withheld); the panel contributes no extreme states of its own.
-    assert_eq!(report.cases, 12);
+    // withheld) x (quiet, alerted); the panel contributes no extreme
+    // states of its own. The alert axis is not optional: a composed
+    // screen fans one AlertOutput to every slot, so a panel's
+    // criticality band is only honest if it was measured with the stack
+    // drawn.
+    assert_eq!(report.cases, 24);
     // A set copied from this template starts with nothing tolerated:
     // every run's nominal ink sits inside the design frame, so no
     // frame-overflow observation is counted. Keeping the line at zero is

--- a/tools/instrument-bench/src/main.rs
+++ b/tools/instrument-bench/src/main.rs
@@ -1,10 +1,14 @@
 //! Standalone bench shell (ADR-0029): the third, deliberately unalike
-//! shell. It composes the same registry the web shell consumes, runs
-//! the admission harness, computes the cross-shell scene digest against
-//! the pinned value, and rasterizes every panel × canonical state ×
-//! canonical frame — optionally writing PPM frames — with no host and
-//! no protocol. A
+//! shell. It composes the same registry the web shell consumes,
+//! reproduces the cross-shell scene digest and the screen-composition
+//! digest against their pinned values, runs the admission harness, and
+//! rasterizes every panel × canonical state × canonical frame —
+//! optionally writing PPM frames — with no host and no protocol. A
 //! nonzero exit is a conformance failure, never a partial pass.
+//!
+//! Identity is reported before judgement: a refusal from the admission
+//! harness still leaves the reader knowing which contract this shell
+//! was running.
 
 mod output;
 
@@ -14,11 +18,12 @@ use output::print_line;
 use std::path::PathBuf;
 
 use indicate_instrument_conformance::{AdmissionError, admit};
-use indicate_instrument_panels::{BUILTIN_PANELS, BUILTIN_SCENE_DIGEST};
+use indicate_instrument_panels::{BUILTIN_CRITICALITY_BANDS, BUILTIN_PANELS, BUILTIN_SCENE_DIGEST};
 use indicate_instrument_raster::{FrameId, FramebufferDims, RenderStatus, render};
 use indicate_instrument_registry::{
-    CANONICAL_STATES, DesignFrame, EMPTY_CONFIG, PanelDrawError, Registry, RegistryError,
-    scene_digest,
+    CANONICAL_STATES, CompositionDescriptor, CompositionError, DesignFrame, EMPTY_CONFIG,
+    PanelDrawError, Region, Registry, RegistryError, Slot, composition_digest, scene_digest,
+    validate_composition,
 };
 use indicate_instrument_scene::{MAX_SCENE_BYTES, SceneWriter};
 use indicate_instrument_state::{FreshnessPolicy, resolve};
@@ -34,6 +39,17 @@ enum BenchError {
     /// This shell renders a different contract than the pin.
     #[error("scene digest {got} does not match the pinned {want}")]
     DigestMismatch {
+        /// What this shell computed.
+        got: String,
+        /// The cross-shell pin.
+        want: &'static str,
+    },
+    /// The fixture screen composition was refused.
+    #[error("screen composition refused: {0}")]
+    Composition(#[from] CompositionError),
+    /// This shell lays the fixture screen out differently than the pin.
+    #[error("screen-composition digest {got} does not match the pinned {want}")]
+    CompositionDigestMismatch {
         /// What this shell computed.
         got: String,
         /// The cross-shell pin.
@@ -75,9 +91,56 @@ enum BenchError {
     },
 }
 
+/// The logical screen the fixture composition lays out on: two panel
+/// frames wide and two tall.
+const BENCH_SCREEN: DesignFrame = DesignFrame {
+    width: 960.0,
+    height: 720.0,
+};
+
+const fn tile(panel: &'static str, x: f32, y: f32) -> Slot {
+    Slot {
+        panel,
+        rect: Region {
+            x,
+            y,
+            width: 480.0,
+            height: 360.0,
+        },
+        occludes: &[],
+    }
+}
+
+/// The fixture screen: the three shipped panels tiled, each at the one
+/// frame it declares. It overlaps nothing, so what it exercises here is
+/// placement, the frame rule, and the digest; the occlusion and
+/// dead-slot rules are covered by the registry's own must-fail
+/// fixtures, which need panels shaped to break them.
+const BENCH_COMPOSITION: CompositionDescriptor = CompositionDescriptor {
+    screen: BENCH_SCREEN,
+    slots: &[
+        tile("pfd", 0.0, 0.0),
+        tile("hsi", 480.0, 0.0),
+        tile("monitor", 0.0, 360.0),
+    ],
+};
+
+/// The pinned screen-composition digest over [`BENCH_COMPOSITION`]:
+/// every shell composing this screen from this registry reproduces it.
+const BENCH_COMPOSITION_DIGEST: &str =
+    "071bd35c2e5884d7376a6a3e6ee5fa391148c74b51604d2024dea565190f688a";
+
 fn main() -> Result<(), BenchError> {
     let out_dir = parse_out_dir();
     let registry = Registry::new(BUILTIN_PANELS)?;
+    let mut scratch = vec![0u8; MAX_SCENE_BYTES];
+
+    let digest = check_scene_digest(&registry, &mut scratch)?;
+    print_line(&format!("scene digest: {digest} (matches pin)"));
+    let composed = check_composition(&registry, &mut scratch)?;
+    print_line(&format!(
+        "screen-composition digest: {composed} (matches pin)"
+    ));
 
     let report = admit(&registry)?;
     print_line(&format!(
@@ -85,31 +148,6 @@ fn main() -> Result<(), BenchError> {
         report.cases,
         report.warnings.len()
     ));
-
-    let mut scratch = vec![0u8; MAX_SCENE_BYTES];
-    let digest = hex(
-        scene_digest(&registry, &mut scratch).map_err(|error| match error {
-            indicate_instrument_registry::DigestError::Draw {
-                panel,
-                state,
-                source,
-            } => BenchError::Draw {
-                panel,
-                state,
-                source,
-            },
-            indicate_instrument_registry::DigestError::Scratch { len } => {
-                BenchError::DigestScratch { len }
-            }
-        })?,
-    );
-    if digest != BUILTIN_SCENE_DIGEST {
-        return Err(BenchError::DigestMismatch {
-            got: digest,
-            want: BUILTIN_SCENE_DIGEST,
-        });
-    }
-    print_line(&format!("scene digest: {digest} (matches pin)"));
 
     let mut rasterized = 0usize;
     for panel in registry.panels() {
@@ -127,6 +165,47 @@ fn main() -> Result<(), BenchError> {
         "rasterized {rasterized} panel x state x canonical frame renders"
     ));
     Ok(())
+}
+
+fn check_scene_digest(registry: &Registry, scratch: &mut [u8]) -> Result<String, BenchError> {
+    let digest = hex(scene_digest(registry, scratch).map_err(digest_error)?);
+    if digest != BUILTIN_SCENE_DIGEST {
+        return Err(BenchError::DigestMismatch {
+            got: digest,
+            want: BUILTIN_SCENE_DIGEST,
+        });
+    }
+    Ok(digest)
+}
+
+fn check_composition(registry: &Registry, scratch: &mut [u8]) -> Result<String, BenchError> {
+    validate_composition(registry, &BENCH_COMPOSITION, &BUILTIN_CRITICALITY_BANDS)?;
+    let digest =
+        hex(composition_digest(registry, &BENCH_COMPOSITION, scratch).map_err(digest_error)?);
+    if digest != BENCH_COMPOSITION_DIGEST {
+        return Err(BenchError::CompositionDigestMismatch {
+            got: digest,
+            want: BENCH_COMPOSITION_DIGEST,
+        });
+    }
+    Ok(digest)
+}
+
+fn digest_error(error: indicate_instrument_registry::DigestError) -> BenchError {
+    match error {
+        indicate_instrument_registry::DigestError::Draw {
+            panel,
+            state,
+            source,
+        } => BenchError::Draw {
+            panel,
+            state,
+            source,
+        },
+        indicate_instrument_registry::DigestError::Scratch { len } => {
+            BenchError::DigestScratch { len }
+        }
+    }
 }
 
 fn parse_out_dir() -> Option<PathBuf> {


### PR DESCRIPTION
Fixes #11. Implements phases 2–6, folds in phase 7 (available now that #12 landed); phase 1, the requirement, landed separately in #26 as the issue mandates.

## The contract

`CompositionDescriptor { screen, slots }` with `Slot { panel, rect, occludes }`. **Slot index is z**, exactly as a `LayerId` discriminant is z within a scene, so declaration order is paint order everywhere. No new opcode, no stream surgery — whole validated panel scenes, placed and stacked.

`validate_composition` is alloc-free and refuses at init. **Eleven variants, each with a test that fires it**: unregistered panel, degenerate rect, off-screen rect, a slot sized to a frame its panel does not support (phase 7), too many slots, a dead slot buried under the opaque slots above it, an undeclared occlusion, an unmeasured criticality band, and three shape/bounds refusals.

## The AIR-OUT-011 floor, and how it is enforced

The requirement is stricter than the issue draft: a declared obscuration may cover ordinary symbology but **never** warnings, failure indications, or the simulation labelling. That is enforced structurally rather than by prose — **the criticality check runs before the `occludes` list is ever consulted**, so no declaration can reach it. `declaring_the_occlusion_does_not_permit_covering_a_warning` and `declaring_the_occlusion_permits_covering_a_readout` use byte-identical declarations and differ only in what lies beneath.

Two supporting choices make the floor sound: the band is **measured from emitted ink, not declared** (a panel able to name its own warning surface could understate it), and a panel with **no** measured band is refused rather than assumed quiet.

## The finding that changed the design

Phase 2 as drafted — "every run attributed to group G lands inside G's declared region" — was implemented, measured, and **rejected**, because it refuses all three shipped panels (HSI `Heading` by 299 units, PFD `Air` by 159).

It is not a panel bug. Provenance *totality* forces every ladder rung to carry the group it measures, while `group_regions` were authored as the readout value's own box — the PFD descriptor says so outright ("the scale ladder's runs anchor at x 70 and stay outside"), and `panel-contract.md` instructs authors to draw them that way. The rule contradicted both. No region was widened and no panel changed.

**The rule is non-vacuity instead**: a declared region must hold a claimed run of its group. That is the failure worth refusing — a region pointing at empty space would make composition guard a surface where the readout is *not*. `a_region_merely_grazed_by_claimed_ink_is_refused` proves it is stronger than bare overlap. The rejected alternative and the reason are written down in the module and in the contract, not discarded.

## Evidence the contract is implementable

The reference rasterizer composes: one surface, slots in index order, each clipped and translated. **Placement was generalized in place, not forked** — the single-panel path took a placement and rendering one panel became its whole-surface case, so a slot inherits the identical snapping and clip bound. The three REN-03 hashes were re-asserted immediately after that extraction, before anything else moved.

Three composed frames pinned (side-by-side, opaque inset, `NotUsed` overlay), each rendered twice and asserted bit-identical before comparison.

Hashes prove reproducibility, not correctness, so two **property** tests carry the load: the overlay test renders the overlay alone to learn its own ink, then checks *every* pixel of the rect — where the overlay paints nothing the composed frame equals the panel beneath exactly, where it paints it is its own ink, both counts asserted non-zero so neither half passes vacuously. A wrong translate or clip fails that; a hash would have pinned the bug.

## Identity

A screen-composition digest with its own domain, covering the screen frame, the ordered slots with rects and occlusion declarations, and the scene digest beneath. Slot rects are in it from day one. The bench reproduces it: `071bd35c…`.

Per-slot configuration is **shell-supplied at draw time** and therefore not in the digest — the descriptor declares layout, the feed supplies data.

## Nothing previously pinned moved

Scene digest `3efb08c5…`, all three REN-03 panel hashes, and the corpus are unchanged — verified by diffing the pinned literals against `main`. Admission is still 121 cases / 83 warnings.

## Open, and stated rather than implied

`MAX_COMPOSITION_SLOTS = 8` is a declared ceiling, not a measured one; the issue asks for a full-screen six-pack bench before pinning it. Composed `RenderWork` is not gated against a budget that prices one panel. A slot fault spoils the whole reference frame, because a bit-exact harness painting a partial frame would pin a hash of undefined content; the in-rect failure presentation is a runtime obligation of the shell.