### PR TITLE
Cut 0.2.0: the changelog said a release was due and none was tagged

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,12 +24,30 @@ from a rewritten one. Entries are newest first, and the tag's message
 repeats the same five values so `git show <tag>` answers the question
 without a checkout. `CONTRIBUTING.md` has the release steps.
 
-## [Unreleased]
+## [0.2.0] — 2026-08-07
 
-Screen composition ([`AIR-OUT-011`](docs/instruments/requirements.md)).
-None of the five values above moved, so this is not a release — but a
-consumer gains a sixth pinnable value and two new refusals, and both are
-worth knowing before the next one is cut.
+The design frame becomes an emission input. `DrawFn` gains a
+`DesignFrame` parameter, and `PanelDescriptor` declares the range of
+frames a shell may ask for — `frame_min`, `frame_max`, `frame_step`,
+aspect bounds, and the `canonical_frames` the evidence is pinned at —
+in place of the single `design_frame` constant. `raster_baseline`
+becomes `raster_baselines`, one per canonical frame.
+
+| Value | This release |
+|---|---|
+| State ABI | 6 |
+| Scene format | 1 |
+| Corpus | 4 |
+| Composition digest | `3efb08c55eadadc2b006ee6b006b29e4b3a3f8d4ec3ce1324f401dbc16dc85ca` |
+| Panel set | `pfd`, `hsi`, `monitor` |
+
+Panel set changed since the previous release: no.
+
+
+### Screen composition ([`AIR-OUT-011`](docs/instruments/requirements.md))
+
+None of the five values above moved for this part, but a consumer gains
+a sixth pinnable value and several new refusals.
 
 - **New pinnable value: the screen-composition digest.** Its own domain
   string (`pilotage-screen-composition-digest-v1`), covering the screen
@@ -52,8 +70,10 @@ worth knowing before the next one is cut.
   the rule as authored; no region and no panel changed.
 - **New pinned data: `BUILTIN_CRITICALITY_BANDS`.** The measured
   `Annunciation`/`Failure` ink bound per panel × canonical frame, which
-  a composition validates obscuration against. The monitor's is `None`,
-  which is a measurement rather than an omission.
+  a composition validates obscuration against, measured with the alert
+  stack drawn. A band no case witnessed refuses obscuration rather than
+  permitting it: an empty measurement is the absence of a witness, not a
+  proof of absence.
 - **The criticality band now folds in the alert stack, and this is a
   safety fix.** Admission drew every case with no alerts, so the
   measured `Annunciation`/`Failure` bound excluded the shared alert
@@ -80,25 +100,13 @@ worth knowing before the next one is cut.
   rasterizer.
 - The scene digest, the corpus, the screen-composition digest, and every
   REN-03 per-panel frame hash are unchanged.
+- **Admission gained an alerts axis**, so every case is drawn twice —
+  quiet, and with a saturated alert stack. Case counts double (the
+  shipped panels go from 121 to 242, and the counted overflow warnings
+  from 83 to 166) because the two overhanging readouts sit on both sides
+  of the axis. Without it the measured criticality bands did not contain
+  the alert stack, and a declared obscuration could cover a warning.
 
-## [0.2.0] — 2026-08-07
-
-The design frame becomes an emission input. `DrawFn` gains a
-`DesignFrame` parameter, and `PanelDescriptor` declares the range of
-frames a shell may ask for — `frame_min`, `frame_max`, `frame_step`,
-aspect bounds, and the `canonical_frames` the evidence is pinned at —
-in place of the single `design_frame` constant. `raster_baseline`
-becomes `raster_baselines`, one per canonical frame.
-
-| Value | This release |
-|---|---|
-| State ABI | 6 |
-| Scene format | 1 |
-| Corpus | 4 |
-| Composition digest | `3efb08c55eadadc2b006ee6b006b29e4b3a3f8d4ec3ce1324f401dbc16dc85ca` |
-| Panel set | `pfd`, `hsi`, `monitor` |
-
-Panel set changed since the previous release: no.
 
 ### Notes for anyone re-pinning
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,7 +43,6 @@ becomes `raster_baselines`, one per canonical frame.
 
 Panel set changed since the previous release: no.
 
-
 ### Screen composition ([`AIR-OUT-011`](docs/instruments/requirements.md))
 
 None of the five values above moved for this part, but a consumer gains
@@ -71,9 +70,7 @@ a sixth pinnable value and several new refusals.
 - **New pinned data: `BUILTIN_CRITICALITY_BANDS`.** The measured
   `Annunciation`/`Failure` ink bound per panel × canonical frame, which
   a composition validates obscuration against, measured with the alert
-  stack drawn. A band no case witnessed refuses obscuration rather than
-  permitting it: an empty measurement is the absence of a witness, not a
-  proof of absence.
+  stack drawn.
 - **The criticality band now folds in the alert stack, and this is a
   safety fix.** Admission drew every case with no alerts, so the
   measured `Annunciation`/`Failure` bound excluded the shared alert
@@ -93,20 +90,14 @@ a sixth pinnable value and several new refusals.
   composition into one framebuffer, and pins REN-03-style hashes for a
   side-by-side screen, an opaque inset over a PFD, and a `NotUsed`
   overlay. The inset and overlay fixtures moved above the PFD's band
-  once alerts were folded in, so two of the three hashes are new. The overlay's show-through is asserted as a property, not
-  only as a hash. `indicate-instrument-raster` gains normal
+  once alerts were folded in, so two of the three hashes are new. The
+  overlay's show-through is asserted as a property, not only as a hash.
+  `indicate-instrument-raster` gains normal
   dependencies on the registry, the state crate, and the alert model;
   the arrow points that way and no crate gained a dependency on the
   rasterizer.
-- The scene digest, the corpus, the screen-composition digest, and every
-  REN-03 per-panel frame hash are unchanged.
-- **Admission gained an alerts axis**, so every case is drawn twice —
-  quiet, and with a saturated alert stack. Case counts double (the
-  shipped panels go from 121 to 242, and the counted overflow warnings
-  from 83 to 166) because the two overhanging readouts sit on both sides
-  of the axis. Without it the measured criticality bands did not contain
-  the alert stack, and a declared obscuration could cover a warning.
-
+- The scene digest, the corpus, and every REN-03 per-panel frame hash
+  are unchanged by the composition work.
 
 ### Notes for anyone re-pinning
 


### PR DESCRIPTION
Housekeeping that closes a self-inconsistency, not a new feature.

## Why

The composition digest moved when the design frame became an emission input (#12). That is one of the five values whose movement cuts a release, `CHANGELOG.md` has carried a written `0.2.0` entry ever since — and `git tag -l` shows only `v0.1.0`. So the repository was asserting a discipline it had not followed, which is exactly the drift these entries exist to prevent.

## What changed

- The screen-composition work (#11) sat under `[Unreleased]` while shipping in the **same revision** as the 0.2.0 entry above it. Tagging would have made the tag disagree with the tree the moment it was applied, so it folds into 0.2.0, where it actually ships.
- One statement in it had gone stale: it said the monitor's criticality band is `None`, "a measurement rather than an omission". The safety fix in #11 made it genuinely measured, and an unwitnessed band now *refuses* obscuration rather than permitting it.
- The alerts axis and its cost are recorded, because a consumer re-pinning across this release will see admission go from 121 cases to 242 and counted warnings from 83 to 166, and should know that is an added axis rather than a regression.

`check-release-markers.sh` still validates the 0.2.0 entry against the tree: `OK (0.2.0; ABI 6, scene 1, corpus 4, panels: pfd, hsi, monitor)`.

## After merge

I will tag `v0.2.0` on the merge commit with the five values in its message, per the release steps in `CONTRIBUTING.md` — the step that is deliberately manual because a release tags its own merge commit, which does not exist while this PR is open.