### PR TITLE
Correct a rule the layer-protocol table's own rows disprove (#14)

### DIFF
--- a/docs/instruments/scene-layer-protocol.md
+++ b/docs/instruments/scene-layer-protocol.md
@@ -124,12 +124,25 @@ ascending layer order. `layer_profile_doc_tests` in
 column disagrees with the descriptor it describes, so a mask change must
 arrive with its row. The section holds this one table and no other.
 
-A panel requires a band when it opens that band on *every* frame, not when the
-band always carries content. The PFD requires `Guidance` on those terms: it
-opens the band unconditionally so the layer contract holds under every
-degradation, and the flight-director command bars inside it disappear when the
-director is disengaged, invalid, or decluttered by the unusual-attitude tier.
-A backend must therefore not read an empty `Guidance` band as a missing one.
+Among the bands above `Background`, a panel requires one when it opens that
+band on *every* frame, not when the band always carries content. The PFD
+requires `Guidance` on those terms: it opens the band unconditionally so the
+layer contract holds under every degradation, and the flight-director command
+bars inside it disappear when the director is disengaged, invalid, or
+decluttered by the unusual-attitude tier. A backend must therefore not read an
+empty `Guidance` band as a missing one.
+
+`Background` is deliberately outside that rule and appears in no panel's
+required mask, which is why it sits in the optional column of every row above
+— including the HSI's and the monitor's, both of which do open it on every
+frame. The mask is what a host enforces before visible commit, and requiring
+the one band a compositor may replace or drop would forbid the composition
+that band exists for. What a panel owes in that band is stated by its
+`BackgroundCapability` instead, and proven by the admission harness: an
+`Opaque` or `Cedeable` panel must lay a full-frame opaque cover there in every
+case, which is a stronger obligation than the mask could express. So for those
+panels the band is mandatory in practice and optional in the mask, and both are
+correct.
 
 A well-framed prefix that ends at a layer boundary is a smaller structural
 scene, not proof of a complete panel frame. Missing a required layer is a

--- a/docs/instruments/scene-layer-protocol.md
+++ b/docs/instruments/scene-layer-protocol.md
@@ -140,9 +140,15 @@ the one band a compositor may replace or drop would forbid the composition
 that band exists for. What a panel owes in that band is stated by its
 `BackgroundCapability` instead, and proven by the admission harness: an
 `Opaque` or `Cedeable` panel must lay a full-frame opaque cover there in every
-case, which is a stronger obligation than the mask could express. So for those
-panels the band is mandatory in practice and optional in the mask, and both are
-correct.
+case the harness draws, which it draws at the empty config. That is a stronger
+obligation than the mask could express, so for an `Opaque` panel the band is
+mandatory in practice and optional in the mask, and both are correct.
+
+A `Cedeable` panel is the case the mask suits exactly. It owes the cover at its
+default and may drop the band on request — the PFD does, under a synthetic-
+vision or no-background configuration — so the band is genuinely absent from
+some of its frames. Requiring it would forbid the only configuration the
+capability exists to allow.
 
 A well-framed prefix that ends at a layer boundary is a smaller structural
 scene, not proof of a complete panel frame. Missing a required layer is a

--- a/sets/indicate-instrument-panels/src/lib.rs
+++ b/sets/indicate-instrument-panels/src/lib.rs
@@ -1,4 +1,5 @@
-//! PFD and HSI panels as pure state→scene functions (ADR-0017).
+//! The shipped panels — PFD, HSI, and monitor — as pure state→scene
+//! functions (ADR-0017).
 //!
 //! Each panel is a function from resolved display state
 //! ([`indicate_instrument_state::PanelData`]) and a logical frame to

--- a/sets/indicate-instrument-panels/src/pfd.rs
+++ b/sets/indicate-instrument-panels/src/pfd.rs
@@ -1,6 +1,6 @@
 //! The Primary Flight Display: attitude ball, speed/altitude tapes, VSI,
 //! and turn-rate cue, composed in fixed layers (background → attitude →
-//! tapes → symbology → annunciation, ADR-0017).
+//! tapes → guidance → annunciation, ADR-0017).
 
 use indicate_alerts::AlertOutput;
 use indicate_instrument_descriptor::DesignFrame;

--- a/sets/indicate-instrument-panels/src/pfd/tests.rs
+++ b/sets/indicate-instrument-panels/src/pfd/tests.rs
@@ -162,12 +162,23 @@ fn empty_state_still_renders_a_scene() {
 
 // ---- layer contract ----------------------------------------------------------
 
-use indicate_instrument_scene::{LayerId, validate_layers};
+use indicate_instrument_scene::{LAYER_COUNT, LayerId, validate_layers};
 use indicate_instrument_state::SignalStatus;
 
 use super::BackgroundMode;
 
-const PFD_CRITICAL: [LayerId; 3] = [LayerId::Attitude, LayerId::Tapes, LayerId::Annunciation];
+/// The bands the descriptor requires, read from the descriptor rather
+/// than restated. A second copy of this list is a second thing to drift,
+/// and it did: it once omitted `Guidance`, so the band a shell refuses a
+/// frame for lacking went unasserted here.
+fn pfd_critical() -> impl Iterator<Item = LayerId> {
+    let required = super::super::PFD_DESCRIPTOR.required_layers;
+    (0..LAYER_COUNT as u8)
+        .filter_map(LayerId::from_u8)
+        .filter(move |layer| {
+            layer != &LayerId::Background && required & (1u8 << layer.to_u8()) != 0
+        })
+}
 
 #[test]
 fn scenes_are_layered_for_every_attitude_status() {
@@ -184,7 +195,7 @@ fn scenes_are_layered_for_every_attitude_status() {
         let scene = render(&data, &PfdConfig::default());
         let report = validate_layers(&scene).expect("layered scene validates");
         assert!(report.contains(LayerId::Background), "{status:?}");
-        for layer in PFD_CRITICAL {
+        for layer in pfd_critical() {
             assert!(report.contains(layer), "{status:?} missing {layer:?}");
         }
     }
@@ -213,7 +224,7 @@ fn critical_overlay_is_byte_identical_without_background() {
         let horizon_report = validate_layers(&with_horizon).expect("validates");
         let bare_report = validate_layers(&without).expect("validates");
         assert!(!bare_report.contains(LayerId::Background));
-        for layer in PFD_CRITICAL {
+        for layer in pfd_critical() {
             let (hs, he) = horizon_report.ranges[layer.to_u8() as usize].expect("range");
             let (bs, be) = bare_report.ranges[layer.to_u8() as usize].expect("range");
             assert_eq!(


### PR DESCRIPTION
Follow-up to #15. Two independent reviewers of that PR reported after it had merged, and **both flagged the same defect I shipped in it** — with matching file:line evidence, arrived at separately.

## The defect

The paragraph #15 added beside the required-profiles table said:

> A panel requires a band when it opens that band on *every* frame, not when the band always carries content.

Two of the three rows directly above it disprove it. `draw_hsi` and `draw_monitor` both open `Background` as the **first statement** of the function — no branch, no early return — while both rows list `Background` as optional, and **no shipped mask contains it at all** (verified: zero occurrences of `layer_bit(LayerId::Background)`).

And it is not a near-miss a cedeable band would explain away. Both declare `BackgroundCapability::Opaque`, and admission *refuses* an `Opaque` panel that does not lay a full-frame opaque cover in that band in every case. So for those two the band is mandatory by a **stronger** mechanism than the mask, while the mask calls it optional.

This is the drift class #14 existed to kill, reintroduced one paragraph below the table it fixed, in the region the new test cannot see. A backend author applying the stated rule to the rows above it gets a contradiction.

## The fix

The rule now scopes to the bands above `Background`, and says why `Background` is outside it: the mask is what a **host enforces before visible commit**, and requiring the one band a compositor may replace or drop would forbid the composition that band exists for. What a panel owes there is stated by `BackgroundCapability` and proven by admission. Both readings are correct — which is precisely why the paragraph had to say which question it answers.

## The same omission, still living in code

Both reviewers also found `PFD_CRITICAL` in the PFD's own tests: `[Attitude, Tapes, Annunciation]` — **no `Guidance`**, the identical stale fact #14 fixed in prose, three files away. So the band a host refuses a frame for lacking went unasserted by the test that checks the layer contract.

It is derived from `PFD_DESCRIPTOR.required_layers` now, which is the PR's own thesis applied to itself. Proven: wrapping the Guidance band in a condition now fails with `Valid missing Guidance`; with the hardcoded list the same mutation passed.

Two more stale statements in the same crate, both in the honest spirit of the issue: the PFD module doc named a `symbology` band the vocabulary does not define (it is `Guidance` — the band this issue turns on), and the crate doc offered "PFD and HSI panels" while shipping the monitor, which is the omission half of #14 restated one file up.

## Note on the header hole they also raised

One reviewer flagged that validating only `cells[0] == "Panel"` lets the column labels be swapped. That was real on `3c3d6e0` and is already closed on `main` — `9bdb147` pins all three header cells against a `HEADER` constant and parses positionally. The Codex reviewer re-verified against `9bdb147` and confirmed it fails closed.

## Gates

Full battery green; scene digest and screen-composition digest both match their pins; evidence gate VALID.