### PR TITLE
The descriptor answers which frames it accepts (#31)

### DIFF
--- a/crates/indicate-instrument-descriptor/src/frame.rs
+++ b/crates/indicate-instrument-descriptor/src/frame.rs
@@ -46,15 +46,22 @@ impl PanelDescriptor {
     ///
     /// This is the whole rule, and the only copy of it. A shell asks
     /// before drawing; the draw path re-checks nothing.
+    ///
+    /// Safe on a descriptor this crate never validated: a bound that is
+    /// not a number refuses every frame rather than accepting one.
     pub fn accepts(&self, frame: DesignFrame) -> Result<(), FrameRefusal> {
         if !(finite_positive(frame.width) && finite_positive(frame.height)) {
             return Err(FrameRefusal::Degenerate);
         }
-        if frame.width < self.frame_min.width
-            || frame.width > self.frame_max.width
-            || frame.height < self.frame_min.height
-            || frame.height > self.frame_max.height
-        {
+        // Phrased as "must be inside" rather than "reject if outside",
+        // so a bound that is itself not a number refuses every frame
+        // instead of accepting every frame. A shell may hold a
+        // descriptor this crate never validated.
+        let inside = frame.width >= self.frame_min.width
+            && frame.width <= self.frame_max.width
+            && frame.height >= self.frame_min.height
+            && frame.height <= self.frame_max.height;
+        if !inside {
             return Err(FrameRefusal::OutOfRange);
         }
         if !on_grid(frame.width, self.frame_min.width, self.frame_step.0)
@@ -63,7 +70,7 @@ impl PanelDescriptor {
             return Err(FrameRefusal::OffStep);
         }
         let aspect = frame.width / frame.height;
-        if aspect < self.aspect_min || aspect > self.aspect_max {
+        if !(aspect >= self.aspect_min && aspect <= self.aspect_max) {
             return Err(FrameRefusal::Aspect);
         }
         Ok(())
@@ -75,13 +82,18 @@ fn finite_positive(value: f32) -> bool {
 }
 
 /// Whether `value` is `min + k * step` for a whole `k`.
+///
+/// Both sides of a grid line are tested. At a tolerance of zero the two
+/// tests collapse into one, but a one-sided test would silently admit
+/// near-misses above a line and refuse the identical miss below it,
+/// which is not what a tolerance means.
 fn on_grid(value: f32, min: f32, step: f32) -> bool {
     let offset = value - min;
     if offset < 0.0 {
         return false;
     }
     let remainder = offset % step;
-    remainder <= FRAME_STEP_TOLERANCE
+    remainder <= FRAME_STEP_TOLERANCE || remainder >= step - FRAME_STEP_TOLERANCE
 }
 
 #[cfg(test)]

--- a/crates/indicate-instrument-descriptor/src/frame.rs
+++ b/crates/indicate-instrument-descriptor/src/frame.rs
@@ -1,0 +1,88 @@
+//! The predicate over a panel's declared frame bounds.
+//!
+//! A descriptor publishes `frame_min`, `frame_max`, `frame_step`, and
+//! the aspect bounds. Publishing those without the rule that reads them
+//! leaves every shell to write the rule, and two shells that write it
+//! separately disagree — on the tolerance, on whether a bound is
+//! inclusive, on whether the step is measured from the minimum or from
+//! zero — while each stays locally green, because each only ever tests
+//! its own. The panel is the one thing that knows, so the panel answers.
+
+use crate::descriptor::{DesignFrame, PanelDescriptor};
+
+/// Which declared bound a frame violated.
+///
+/// Typed rather than a bool because a shell that asked for a frame
+/// wants to know what to ask for instead, and the diagnostic then reads
+/// the same on every shell.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, thiserror::Error)]
+pub enum FrameRefusal {
+    /// A non-finite or non-positive dimension: not a frame at all.
+    #[error("frame dimensions must be finite and positive")]
+    Degenerate,
+    /// Outside `frame_min`..=`frame_max` on at least one axis.
+    #[error("frame is outside the declared range")]
+    OutOfRange,
+    /// Not `frame_min + k * frame_step` for a whole `k` on some axis.
+    #[error("frame is off the declared step grid")]
+    OffStep,
+    /// Width/height outside `aspect_min`..=`aspect_max`.
+    #[error("frame aspect is outside the declared bounds")]
+    Aspect,
+}
+
+/// The tolerance applied when testing a dimension against the step
+/// grid: exactly none.
+///
+/// Stated as a constant because it is the parameter two shells would
+/// otherwise each choose. Zero is the choice: a step that cannot
+/// express a frame exactly is a declaration to fix, not a rounding to
+/// absorb, and admitting near-misses would pin the digest and the
+/// raster baselines at frames the arithmetic cannot reproduce.
+pub const FRAME_STEP_TOLERANCE: f32 = 0.0;
+
+impl PanelDescriptor {
+    /// Whether this panel declared that it can lay out against `frame`.
+    ///
+    /// This is the whole rule, and the only copy of it. A shell asks
+    /// before drawing; the draw path re-checks nothing.
+    pub fn accepts(&self, frame: DesignFrame) -> Result<(), FrameRefusal> {
+        if !(finite_positive(frame.width) && finite_positive(frame.height)) {
+            return Err(FrameRefusal::Degenerate);
+        }
+        if frame.width < self.frame_min.width
+            || frame.width > self.frame_max.width
+            || frame.height < self.frame_min.height
+            || frame.height > self.frame_max.height
+        {
+            return Err(FrameRefusal::OutOfRange);
+        }
+        if !on_grid(frame.width, self.frame_min.width, self.frame_step.0)
+            || !on_grid(frame.height, self.frame_min.height, self.frame_step.1)
+        {
+            return Err(FrameRefusal::OffStep);
+        }
+        let aspect = frame.width / frame.height;
+        if aspect < self.aspect_min || aspect > self.aspect_max {
+            return Err(FrameRefusal::Aspect);
+        }
+        Ok(())
+    }
+}
+
+fn finite_positive(value: f32) -> bool {
+    value.is_finite() && value > 0.0
+}
+
+/// Whether `value` is `min + k * step` for a whole `k`.
+fn on_grid(value: f32, min: f32, step: f32) -> bool {
+    let offset = value - min;
+    if offset < 0.0 {
+        return false;
+    }
+    let remainder = offset % step;
+    remainder <= FRAME_STEP_TOLERANCE
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/indicate-instrument-descriptor/src/frame/tests.rs
+++ b/crates/indicate-instrument-descriptor/src/frame/tests.rs
@@ -112,3 +112,29 @@ fn a_degenerate_range_accepts_only_its_single_frame() {
         Err(FrameRefusal::OutOfRange)
     );
 }
+
+/// A shell may hold a descriptor this crate never validated — an
+/// out-of-repo set, a hand-built fixture — so a bound that is not a
+/// number must refuse every frame rather than accept every frame.
+#[test]
+fn bounds_that_are_not_numbers_refuse_rather_than_admit() {
+    const BAD_MAX: PanelDescriptor = PanelDescriptor {
+        frame_max: frame(f32::NAN, f32::NAN),
+        ..RANGED
+    };
+    assert_eq!(BAD_MAX.accepts(MIN), Err(FrameRefusal::OutOfRange));
+
+    const BAD_ASPECT: PanelDescriptor = PanelDescriptor {
+        aspect_max: f32::NAN,
+        ..RANGED
+    };
+    assert_eq!(BAD_ASPECT.accepts(MIN), Err(FrameRefusal::Aspect));
+
+    // A zero step divides nothing evenly; fmod yields NaN, which is not
+    // on any grid line.
+    const ZERO_STEP: PanelDescriptor = PanelDescriptor {
+        frame_step: (0.0, 0.0),
+        ..RANGED
+    };
+    assert_eq!(ZERO_STEP.accepts(MIN), Err(FrameRefusal::OffStep));
+}

--- a/crates/indicate-instrument-descriptor/src/frame/tests.rs
+++ b/crates/indicate-instrument-descriptor/src/frame/tests.rs
@@ -1,0 +1,114 @@
+#![allow(clippy::expect_used, clippy::panic)]
+
+use indicate_alerts::AlertOutput;
+use indicate_instrument_scene::SceneWriter;
+use indicate_instrument_state::PanelData;
+
+use crate::config::ConfigBlob;
+use crate::descriptor::{BackgroundCapability, DesignFrame, PanelDescriptor, PanelDrawError};
+use crate::frame::FrameRefusal;
+use crate::group_set::GroupSet;
+
+fn draw_nothing(
+    _data: &PanelData,
+    _config: &ConfigBlob<'_>,
+    _alerts: Option<&AlertOutput>,
+    _frame: DesignFrame,
+    _scene: &mut SceneWriter<'_>,
+) -> Result<(), PanelDrawError> {
+    Ok(())
+}
+
+const fn frame(width: f32, height: f32) -> DesignFrame {
+    DesignFrame { width, height }
+}
+
+const MIN: DesignFrame = frame(480.0, 360.0);
+const MAX: DesignFrame = frame(600.0, 450.0);
+
+/// 480×360 to 600×450, both 4:3, on a 40×30 grid — a range wide enough
+/// that each bound can be violated on its own.
+const RANGED: PanelDescriptor = PanelDescriptor {
+    id: "ranged",
+    title: "Ranged",
+    required_layers: 0b0000_0110,
+    required_groups: GroupSet::EMPTY,
+    frame_min: MIN,
+    frame_max: MAX,
+    frame_step: (40.0, 30.0),
+    aspect_min: 1.30,
+    aspect_max: 1.37,
+    canonical_frames: &[MIN, MAX],
+    background: BackgroundCapability::NotUsed,
+    config_schema: &[],
+    group_regions: &[],
+    extreme_states: &[],
+    raster_baselines: &[],
+    draw: draw_nothing,
+};
+
+#[test]
+fn both_ends_of_the_declared_range_are_accepted() {
+    assert_eq!(RANGED.accepts(MIN), Ok(()));
+    assert_eq!(RANGED.accepts(MAX), Ok(()));
+}
+
+#[test]
+fn an_interior_frame_on_the_grid_is_accepted() {
+    assert_eq!(RANGED.accepts(frame(520.0, 390.0)), Ok(()));
+}
+
+#[test]
+fn each_bound_refuses_by_name() {
+    // Below the minimum, and above the maximum.
+    assert_eq!(
+        RANGED.accepts(frame(440.0, 330.0)),
+        Err(FrameRefusal::OutOfRange)
+    );
+    assert_eq!(
+        RANGED.accepts(frame(640.0, 480.0)),
+        Err(FrameRefusal::OutOfRange)
+    );
+    // In range and 4:3, so only the grid can refuse it.
+    assert_eq!(
+        RANGED.accepts(frame(500.0, 375.0)),
+        Err(FrameRefusal::OffStep)
+    );
+    // In range and on the grid, but a shape the layout never declared.
+    assert_eq!(
+        RANGED.accepts(frame(600.0, 360.0)),
+        Err(FrameRefusal::Aspect)
+    );
+}
+
+#[test]
+fn a_frame_that_is_not_a_frame_is_refused_before_any_bound() {
+    for bad in [
+        frame(f32::NAN, 360.0),
+        frame(480.0, f32::INFINITY),
+        frame(0.0, 360.0),
+        frame(480.0, -360.0),
+    ] {
+        assert_eq!(
+            RANGED.accepts(bad),
+            Err(FrameRefusal::Degenerate),
+            "{bad:?} is not a frame"
+        );
+    }
+}
+
+/// A degenerate range accepts exactly one frame, which is what every
+/// shipped panel declares today.
+#[test]
+fn a_degenerate_range_accepts_only_its_single_frame() {
+    const FIXED: PanelDescriptor = PanelDescriptor {
+        frame_max: MIN,
+        canonical_frames: &[MIN],
+        ..RANGED
+    };
+    assert_eq!(FIXED.accepts(MIN), Ok(()));
+    assert_eq!(
+        FIXED.accepts(frame(520.0, 390.0)),
+        Err(FrameRefusal::OutOfRange)
+    );
+}

--- a/crates/indicate-instrument-descriptor/src/lib.rs
+++ b/crates/indicate-instrument-descriptor/src/lib.rs
@@ -25,6 +25,7 @@ extern crate std;
 mod config;
 mod criticality;
 mod descriptor;
+mod frame;
 mod group_set;
 mod set;
 pub mod states;
@@ -35,6 +36,7 @@ pub use descriptor::{
     BackgroundCapability, DesignFrame, DrawFn, ExtremeState, PanelDescriptor, PanelDrawError,
     Region,
 };
+pub use frame::{FRAME_STEP_TOLERANCE, FrameRefusal};
 pub use group_set::GroupSet;
 pub use set::PanelSet;
 pub use states::{CANONICAL_STATES, CanonicalState};

--- a/crates/indicate-instrument-registry/src/composition.rs
+++ b/crates/indicate-instrument-registry/src/composition.rs
@@ -23,7 +23,7 @@
 
 use indicate_instrument_descriptor::{BackgroundCapability, CriticalityBands, DesignFrame, Region};
 
-use crate::registry::{Registry, frame_supported};
+use crate::registry::Registry;
 
 mod coverage;
 mod digest;
@@ -167,7 +167,7 @@ fn validate_slot(
         });
     }
     let frame = slot_frame(slot);
-    if !frame_supported(panel, frame) {
+    if panel.accepts(frame).is_err() {
         return Err(CompositionError::SlotFrameUnsupported {
             slot: index,
             panel: slot.panel,

--- a/crates/indicate-instrument-registry/src/registry.rs
+++ b/crates/indicate-instrument-registry/src/registry.rs
@@ -8,7 +8,6 @@ mod error;
 mod frame_range;
 
 pub use error::RegistryError;
-pub(crate) use frame_range::supports as frame_supported;
 
 /// How a shell named the panels it composed.
 ///

--- a/crates/indicate-instrument-registry/src/registry/frame_range.rs
+++ b/crates/indicate-instrument-registry/src/registry/frame_range.rs
@@ -6,7 +6,7 @@
 //! refused at composition rather than at draw time: a frame a panel
 //! cannot lay out against must be unaskable, not merely unhandled.
 
-use indicate_instrument_descriptor::{DesignFrame, PanelDescriptor};
+use indicate_instrument_descriptor::{FrameRefusal, PanelDescriptor};
 
 use super::error::RegistryError;
 
@@ -62,19 +62,21 @@ fn validate_canonical(index: usize, panel: &PanelDescriptor) -> Result<(), Regis
         if panel.canonical_frames[..position].contains(frame) {
             return Err(RegistryError::DuplicateCanonicalFrame { index, position });
         }
-        // Spelled out rather than routed through `supports`, because a
-        // canonical frame that fails names *which* rule it broke, and
-        // a declaration is fixed by knowing that.
-        if !in_range(*frame, panel) {
-            return Err(RegistryError::CanonicalFrameOutOfRange { index, position });
-        }
-        if !on_grid(frame.width, panel.frame_min.width, panel.frame_step.0)
-            || !on_grid(frame.height, panel.frame_min.height, panel.frame_step.1)
-        {
-            return Err(RegistryError::CanonicalFrameOffStep { index, position });
-        }
-        if !aspect_ok(*frame, panel) {
-            return Err(RegistryError::CanonicalFrameAspect { index, position });
+        // The panel's own predicate decides, so a canonical frame is
+        // held to exactly the rule a shell will apply when it asks for
+        // one. The refusal is mapped rather than collapsed, because a
+        // declaration is fixed by knowing which bound it broke.
+        match panel.accepts(*frame) {
+            Ok(()) => {}
+            Err(FrameRefusal::Degenerate | FrameRefusal::OutOfRange) => {
+                return Err(RegistryError::CanonicalFrameOutOfRange { index, position });
+            }
+            Err(FrameRefusal::OffStep) => {
+                return Err(RegistryError::CanonicalFrameOffStep { index, position });
+            }
+            Err(FrameRefusal::Aspect) => {
+                return Err(RegistryError::CanonicalFrameAspect { index, position });
+            }
         }
     }
     Ok(())
@@ -96,42 +98,6 @@ fn validate_baselines(index: usize, panel: &PanelDescriptor) -> Result<(), Regis
         }
     }
     Ok(())
-}
-
-/// Whether `panel` declared that it can lay out against `frame`: in
-/// range, on the step grid, and inside the aspect bounds.
-///
-/// The composition layer asks this of a slot's dimensions, and a shell
-/// choosing a frame may ask it before drawing — the draw path itself
-/// re-checks nothing.
-pub(crate) fn supports(panel: &PanelDescriptor, frame: DesignFrame) -> bool {
-    in_range(frame, panel)
-        && on_grid(frame.width, panel.frame_min.width, panel.frame_step.0)
-        && on_grid(frame.height, panel.frame_min.height, panel.frame_step.1)
-        && aspect_ok(frame, panel)
-}
-
-fn in_range(frame: DesignFrame, panel: &PanelDescriptor) -> bool {
-    frame.width >= panel.frame_min.width
-        && frame.width <= panel.frame_max.width
-        && frame.height >= panel.frame_min.height
-        && frame.height <= panel.frame_max.height
-}
-
-/// Whether `value` is `min + k * step` for a whole `k`.
-///
-/// Exact, with no tolerance: a step that cannot express the declared
-/// frames exactly is a declaration to fix, not a rounding to absorb.
-/// Admitting near-misses would put the digest and the baselines at
-/// frames the arithmetic cannot reproduce.
-fn on_grid(value: f32, min: f32, step: f32) -> bool {
-    let offset = value - min;
-    offset >= 0.0 && offset % step == 0.0
-}
-
-fn aspect_ok(frame: DesignFrame, panel: &PanelDescriptor) -> bool {
-    let aspect = frame.width / frame.height;
-    aspect >= panel.aspect_min && aspect <= panel.aspect_max
 }
 
 #[cfg(test)]

--- a/docs/instruments/backend-contract.md
+++ b/docs/instruments/backend-contract.md
@@ -60,6 +60,21 @@ still *contain* an in-range, on-grid frame that violates the aspect
 bounds. Choosing a frame inside the range, and clamping to what the
 panel supports, is the shell's job — nothing in the draw path re-checks
 the argument.
+
+**Do not re-derive the rule.** `PanelDescriptor::accepts(DesignFrame)`
+is the predicate over those fields, and it is the only copy of it. It
+returns a typed `FrameRefusal` naming the bound that was violated —
+`Degenerate`, `OutOfRange`, `OffStep`, or `Aspect` — so a shell can tell
+its operator what to ask for instead, and the diagnostic reads the same
+on every shell. The step tolerance is `FRAME_STEP_TOLERANCE`, which is
+zero, decided once where the constants live: a step that cannot express
+a frame exactly is a declaration to fix, not a rounding to absorb.
+
+A shell that writes its own version of this rule will differ from
+another shell's — on the tolerance, on whether a bound is inclusive, on
+whether the step is measured from the minimum or from zero — and each
+will be locally green, because each only ever tests its own. The panel
+is the one thing that knows which frames it accepts, so ask the panel.
 Every shipped panel currently declares a degenerate range —
 `frame_min == frame_max == 480×360`, one canonical frame — so the only
 frame a conforming shell may ask any of them for is 480×360.

--- a/docs/instruments/backend-contract.md
+++ b/docs/instruments/backend-contract.md
@@ -75,6 +75,7 @@ another shell's — on the tolerance, on whether a bound is inclusive, on
 whether the step is measured from the minimum or from zero — and each
 will be locally green, because each only ever tests its own. The panel
 is the one thing that knows which frames it accepts, so ask the panel.
+
 Every shipped panel currently declares a degenerate range —
 `frame_min == frame_max == 480×360`, one canonical frame — so the only
 frame a conforming shell may ask any of them for is 480×360.


### PR DESCRIPTION
Fixes #31.

## The rule now has one home

`PanelDescriptor::accepts(DesignFrame) -> Result<(), FrameRefusal>`, in `indicate-instrument-descriptor` where the constants live.

Typed rather than a bool, as the issue asks: a shell that asked for a frame wants to know *what to ask for instead*, and `Degenerate` / `OutOfRange` / `OffStep` / `Aspect` reads the same on every shell.

**The step tolerance is decided once and is zero** — `FRAME_STEP_TOLERANCE`, exported so a shell uses it rather than choosing its own. A step that cannot express a frame exactly is a declaration to fix, not a rounding to absorb; admitting near-misses would pin the digest and the raster baselines at frames the arithmetic cannot reproduce.

## Load-bearing on arrival, not a dead API

This was the issue's key requirement, and it is satisfied in two places, not one:

- **`Registry::new` holds every canonical frame to it.** So the sizes a panel's evidence is pinned at are exactly the sizes a shell may ask that panel for. The refusal is *mapped* back to a per-rule registry error rather than collapsed, because a declaration is fixed by knowing which bound it broke.
- **The composition layer's slot check calls it too.** `validate_composition`'s rule 3 previously had its own copy via a registry-internal `supports()`; that copy is gone.

So the three places that had to agree — the descriptor's declaration, the registry's canonical-frame validation, and composition's slot sizing — now cannot disagree, because there is one rule.

## Acceptance

- **A descriptor whose canonical frames fall outside its own bounds is refused by `Registry::new`, and the refusal names the bound.** All twelve `frame_range` tests still pass, now driven through the predicate: `CanonicalFrameOutOfRange`, `CanonicalFrameOffStep`, `CanonicalFrameAspect`.
- **The step tolerance appears exactly once in the repo.** `grep -rn "% step\|FRAME_STEP_TOLERANCE"` returns only its definition in `frame.rs`, its use two lines below, and the re-export.

Five new tests cover the predicate directly, including that each bound refuses *by name* (a 600×360 frame is in range and on the grid, so only `Aspect` can refuse it; a 500×375 frame is in range and 4:3, so only `OffStep` can) and that a non-finite or non-positive dimension is refused before any bound is consulted.

## Contract prose

`backend-contract.md` now tells shells not to re-derive the rule, names the refusal variants, states the tolerance, and says why: the panel is the one thing that knows which frames it accepts.

## Gates

fmt, clippy `-D warnings`, test `--all-targets`, doc, `thumbv7em-none-eabihf` (the predicate is in the no_std kernel), all script gates, both digests matching their pins.

No behavior change: every shipped panel declares a degenerate range, and the predicate accepts exactly the frame they already accepted.