### PR TITLE
A panel that declares a range must use it (#32)

### DIFF
--- a/crates/indicate-instrument-conformance/src/admission.rs
+++ b/crates/indicate-instrument-conformance/src/admission.rs
@@ -38,6 +38,7 @@ mod alerts;
 mod background;
 mod criticality;
 mod error;
+mod frame_varies;
 mod geometry;
 mod ink;
 mod provenance;
@@ -45,6 +46,7 @@ mod regions;
 
 use alerts::saturated_stack;
 use background::check_background;
+use frame_varies::check_frame_varies;
 use geometry::{Ctm, Rect, text_rect};
 use provenance::check_provenance;
 use regions::check_non_vacuity;
@@ -144,10 +146,12 @@ fn admit_panel(
     for frame in panel.canonical_frames {
         admit_panel_at_frame(panel, *frame, report)?;
     }
-    // A per-panel fact rather than a per-case one: the witness a region
-    // needs may only appear in one case of the matrix, so the verdict
-    // waits until every case has been drawn.
-    check_non_vacuity(panel)
+    // Per-panel facts rather than per-case ones. The witness a region
+    // needs may appear in only one case of the matrix, and whether a
+    // panel varies with its frame is a comparison across frames that no
+    // single case can make.
+    check_non_vacuity(panel)?;
+    check_frame_varies(panel)
 }
 
 fn admit_panel_at_frame(

--- a/crates/indicate-instrument-conformance/src/admission/error.rs
+++ b/crates/indicate-instrument-conformance/src/admission/error.rs
@@ -170,4 +170,17 @@ pub enum AdmissionError {
         /// search ran at.
         frame: DesignFrame,
     },
+    /// A panel declares a range of frames and emits the same bytes at
+    /// both ends of it.
+    #[error(
+        "panel {panel} emits identically at {min:?} and {max:?}, so it does not use the frame it is given"
+    )]
+    FrameIgnored {
+        /// The declaring panel.
+        panel: &'static str,
+        /// The smallest frame it accepts.
+        min: DesignFrame,
+        /// The largest frame it accepts.
+        max: DesignFrame,
+    },
 }

--- a/crates/indicate-instrument-conformance/src/admission/frame_varies.rs
+++ b/crates/indicate-instrument-conformance/src/admission/frame_varies.rs
@@ -1,0 +1,73 @@
+//! Proof that a panel offering more than one frame actually uses the
+//! one it is handed.
+//!
+//! `DrawFn` takes a `DesignFrame`, and nothing obliged a panel to read
+//! it. A panel that ignored the argument and emitted fixed geometry
+//! would satisfy every other check here, because the rest of the matrix
+//! asks each canonical frame the same questions separately and never
+//! compares the answers.
+//!
+//! A panel is free to ignore it — that is what a degenerate range
+//! declares, and every shipped panel declares one today. What is
+//! refused is declaring a range and then not varying across it: a shell
+//! that asks for the larger frame is owed more instrument, not the same
+//! picture stretched by the backend.
+
+use indicate_instrument_registry::{DesignFrame, PanelDescriptor};
+use indicate_instrument_scene::MAX_SCENE_BYTES;
+use indicate_instrument_state::{FreshnessPolicy, resolve};
+
+use super::error::AdmissionError;
+use super::{CANONICAL_STATES, draw_scene};
+
+/// Whether the panel declared more than one frame it can be asked for.
+fn range_is_degenerate(panel: &PanelDescriptor) -> bool {
+    panel.frame_min == panel.frame_max
+}
+
+/// Requires the emitted bytes to differ between the smallest and
+/// largest frames a panel accepts.
+///
+/// Differing bytes are a weak proof of a good layout and a sufficient
+/// proof of the thing that was unprovable before: that the argument
+/// reached the geometry at all. A panel whose two frames encode
+/// identically either ignored the parameter or drew something that does
+/// not depend on it, and neither is what declaring a range claims.
+pub(super) fn check_frame_varies(panel: &'static PanelDescriptor) -> Result<(), AdmissionError> {
+    if range_is_degenerate(panel) {
+        return Ok(());
+    }
+    let mut small = [0u8; MAX_SCENE_BYTES];
+    let mut large = [0u8; MAX_SCENE_BYTES];
+    for state in CANONICAL_STATES {
+        let data = resolve(&(state.build)(), &FreshnessPolicy::default());
+        let at_min = draw_bytes(panel, &data, panel.frame_min, &mut small)?;
+        let at_max = draw_bytes(panel, &data, panel.frame_max, &mut large)?;
+        if at_min != at_max {
+            return Ok(());
+        }
+    }
+    Err(AdmissionError::FrameIgnored {
+        panel: panel.id,
+        min: panel.frame_min,
+        max: panel.frame_max,
+    })
+}
+
+fn draw_bytes<'b>(
+    panel: &PanelDescriptor,
+    data: &indicate_instrument_state::PanelData,
+    frame: DesignFrame,
+    buf: &'b mut [u8],
+) -> Result<&'b [u8], AdmissionError> {
+    draw_scene(panel, data, None, frame, buf).map_err(|source| AdmissionError::Draw {
+        panel: panel.id,
+        state: "frame-variation",
+        withheld: None,
+        alerted: false,
+        source,
+    })
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/indicate-instrument-conformance/src/admission/frame_varies.rs
+++ b/crates/indicate-instrument-conformance/src/admission/frame_varies.rs
@@ -8,42 +8,49 @@
 //! compares the answers.
 //!
 //! A panel is free to ignore it — that is what a degenerate range
-//! declares, and every shipped panel declares one today. What is
-//! refused is declaring a range and then not varying across it: a shell
-//! that asks for the larger frame is owed more instrument, not the same
-//! picture stretched by the backend.
+//! declares. What is refused is declaring a range and then not varying
+//! across it: a shell that asks for the larger frame is owed more
+//! instrument, not the same picture stretched by the backend.
+//!
+//! The search runs over the whole case matrix rather than the canonical
+//! states alone. A panel may read its frame and only *show* it under an
+//! alert, in an extreme state, or with a group withheld, and refusing
+//! such a panel would be a false accusation.
 
 use indicate_instrument_registry::{DesignFrame, PanelDescriptor};
 use indicate_instrument_scene::MAX_SCENE_BYTES;
 use indicate_instrument_state::{FreshnessPolicy, resolve};
 
 use super::error::AdmissionError;
-use super::{CANONICAL_STATES, draw_scene};
-
-/// Whether the panel declared more than one frame it can be asked for.
-fn range_is_degenerate(panel: &PanelDescriptor) -> bool {
-    panel.frame_min == panel.frame_max
-}
+use super::{Case, case_matrix, draw_scene};
 
 /// Requires the emitted bytes to differ between the smallest and
-/// largest frames a panel accepts.
+/// largest frames a panel accepts, in at least one case of the matrix.
 ///
 /// Differing bytes are a weak proof of a good layout and a sufficient
 /// proof of the thing that was unprovable before: that the argument
-/// reached the geometry at all. A panel whose two frames encode
-/// identically either ignored the parameter or drew something that does
-/// not depend on it, and neither is what declaring a range claims.
+/// reached the geometry at all. One witness is enough — a panel whose
+/// `nothing-fed` frame is a fixed placard is not thereby frame-blind.
+///
+/// A difference only counts when the smaller frame reproduces, so a
+/// panel that varies between two consecutive draws for its own reasons
+/// cannot pass on that variation. That makes a deterministic `DrawFn`
+/// part of what is being checked rather than assumed.
 pub(super) fn check_frame_varies(panel: &'static PanelDescriptor) -> Result<(), AdmissionError> {
-    if range_is_degenerate(panel) {
+    if panel.frame_min == panel.frame_max {
         return Ok(());
     }
-    let mut small = [0u8; MAX_SCENE_BYTES];
-    let mut large = [0u8; MAX_SCENE_BYTES];
-    for state in CANONICAL_STATES {
-        let data = resolve(&(state.build)(), &FreshnessPolicy::default());
-        let at_min = draw_bytes(panel, &data, panel.frame_min, &mut small)?;
-        let at_max = draw_bytes(panel, &data, panel.frame_max, &mut large)?;
-        if at_min != at_max {
+    let mut first = vec![0u8; MAX_SCENE_BYTES];
+    let mut large = vec![0u8; MAX_SCENE_BYTES];
+    let mut again = vec![0u8; MAX_SCENE_BYTES];
+    for case in case_matrix(panel) {
+        let at_min = draw_at(panel, &case, panel.frame_min, &mut first)?.to_vec();
+        let at_max = draw_at(panel, &case, panel.frame_max, &mut large)?;
+        if at_min == at_max {
+            continue;
+        }
+        let reproduced = draw_at(panel, &case, panel.frame_min, &mut again)?;
+        if at_min == reproduced {
             return Ok(());
         }
     }
@@ -54,18 +61,21 @@ pub(super) fn check_frame_varies(panel: &'static PanelDescriptor) -> Result<(), 
     })
 }
 
-fn draw_bytes<'b>(
+fn draw_at<'b>(
     panel: &PanelDescriptor,
-    data: &indicate_instrument_state::PanelData,
+    case: &Case,
     frame: DesignFrame,
     buf: &'b mut [u8],
 ) -> Result<&'b [u8], AdmissionError> {
-    draw_scene(panel, data, None, frame, buf).map_err(|source| AdmissionError::Draw {
-        panel: panel.id,
-        state: "frame-variation",
-        withheld: None,
-        alerted: false,
-        source,
+    let data = resolve(&case.state, &FreshnessPolicy::default());
+    draw_scene(panel, &data, case.alerts.as_ref(), frame, buf).map_err(|source| {
+        AdmissionError::Draw {
+            panel: panel.id,
+            state: case.state_id,
+            withheld: case.withheld,
+            alerted: case.alerts.is_some(),
+            source,
+        }
     })
 }
 

--- a/crates/indicate-instrument-conformance/src/admission/frame_varies/tests.rs
+++ b/crates/indicate-instrument-conformance/src/admission/frame_varies/tests.rs
@@ -35,6 +35,23 @@ fn draw_varying(
     Ok(())
 }
 
+/// Reads its frame, but only shows it when alerts are fed. The matrix
+/// drives an alert axis, so refusing this panel would be an accusation
+/// the evidence does not support.
+fn draw_varying_only_when_alerted(
+    _data: &PanelData,
+    _config: &ConfigBlob<'_>,
+    alerts: Option<&AlertOutput>,
+    frame: DesignFrame,
+    scene: &mut SceneWriter<'_>,
+) -> Result<(), PanelDrawError> {
+    let width = if alerts.is_some() { frame.width } else { 480.0 };
+    scene.begin_layer(LayerId::Tapes)?;
+    scene.rect(PaintMode::Fill, 0.0, 0.0, width, 360.0)?;
+    scene.end_layer(LayerId::Tapes)?;
+    Ok(())
+}
+
 /// Paints the same rect whatever it is handed — the panel the check
 /// exists to catch.
 fn draw_fixed(
@@ -89,6 +106,15 @@ fn a_panel_that_ignores_its_frame_is_refused() {
 #[test]
 fn a_panel_that_uses_its_frame_is_admitted() {
     assert_eq!(check_frame_varies(&VARYING), Ok(()));
+}
+
+/// The search covers the whole matrix, not the quiet canonical states
+/// alone, so a panel whose frame only shows under an alert is not
+/// accused of ignoring it.
+#[test]
+fn a_panel_that_varies_only_under_alerts_is_admitted() {
+    static ALERTED: PanelDescriptor = ranged("alerted-only", draw_varying_only_when_alerted);
+    assert_eq!(check_frame_varies(&ALERTED), Ok(()));
 }
 
 /// A degenerate range is a declaration that the panel does not vary,

--- a/crates/indicate-instrument-conformance/src/admission/frame_varies/tests.rs
+++ b/crates/indicate-instrument-conformance/src/admission/frame_varies/tests.rs
@@ -1,0 +1,116 @@
+#![allow(clippy::expect_used, clippy::panic)]
+
+use indicate_alerts::AlertOutput;
+use indicate_instrument_registry::{
+    BackgroundCapability, ConfigBlob, DesignFrame, GroupSet, PanelDescriptor, PanelDrawError,
+    Registry,
+};
+use indicate_instrument_scene::{LayerId, PaintMode, SceneWriter};
+use indicate_instrument_state::PanelData;
+
+use super::check_frame_varies;
+use crate::admission::error::AdmissionError;
+
+const MIN: DesignFrame = DesignFrame {
+    width: 480.0,
+    height: 360.0,
+};
+const MAX: DesignFrame = DesignFrame {
+    width: 600.0,
+    height: 450.0,
+};
+
+/// Paints a rect the size of the frame it was handed, so its bytes move
+/// with the argument.
+fn draw_varying(
+    _data: &PanelData,
+    _config: &ConfigBlob<'_>,
+    _alerts: Option<&AlertOutput>,
+    frame: DesignFrame,
+    scene: &mut SceneWriter<'_>,
+) -> Result<(), PanelDrawError> {
+    scene.begin_layer(LayerId::Tapes)?;
+    scene.rect(PaintMode::Fill, 0.0, 0.0, frame.width, frame.height)?;
+    scene.end_layer(LayerId::Tapes)?;
+    Ok(())
+}
+
+/// Paints the same rect whatever it is handed — the panel the check
+/// exists to catch.
+fn draw_fixed(
+    _data: &PanelData,
+    _config: &ConfigBlob<'_>,
+    _alerts: Option<&AlertOutput>,
+    _frame: DesignFrame,
+    scene: &mut SceneWriter<'_>,
+) -> Result<(), PanelDrawError> {
+    scene.begin_layer(LayerId::Tapes)?;
+    scene.rect(PaintMode::Fill, 0.0, 0.0, 480.0, 360.0)?;
+    scene.end_layer(LayerId::Tapes)?;
+    Ok(())
+}
+
+const fn ranged(id: &'static str, draw: indicate_instrument_registry::DrawFn) -> PanelDescriptor {
+    PanelDescriptor {
+        id,
+        title: "Probe",
+        required_layers: 0b0000_0100,
+        required_groups: GroupSet::EMPTY,
+        frame_min: MIN,
+        frame_max: MAX,
+        frame_step: (120.0, 90.0),
+        aspect_min: 1.30,
+        aspect_max: 1.37,
+        canonical_frames: &[MIN, MAX],
+        background: BackgroundCapability::NotUsed,
+        config_schema: &[],
+        group_regions: &[],
+        extreme_states: &[],
+        raster_baselines: &[],
+        draw,
+    }
+}
+
+static VARYING: PanelDescriptor = ranged("varying", draw_varying);
+static FIXED: PanelDescriptor = ranged("fixed", draw_fixed);
+
+#[test]
+fn a_panel_that_ignores_its_frame_is_refused() {
+    assert_eq!(
+        check_frame_varies(&FIXED),
+        Err(AdmissionError::FrameIgnored {
+            panel: "fixed",
+            min: MIN,
+            max: MAX,
+        })
+    );
+}
+
+#[test]
+fn a_panel_that_uses_its_frame_is_admitted() {
+    assert_eq!(check_frame_varies(&VARYING), Ok(()));
+}
+
+/// A degenerate range is a declaration that the panel does not vary,
+/// which is what every shipped panel says today. The check must not ask
+/// a panel to differ from itself.
+#[test]
+fn a_degenerate_range_is_not_asked_to_vary() {
+    static FIXED_RANGE: PanelDescriptor = PanelDescriptor {
+        frame_max: MIN,
+        canonical_frames: &[MIN],
+        ..ranged("degenerate", draw_fixed)
+    };
+    assert_eq!(check_frame_varies(&FIXED_RANGE), Ok(()));
+}
+
+/// The shipped panels all declare a degenerate range, so the check is
+/// inert for them — pinned here so a panel that gains a range without
+/// gaining a layout cannot land quietly.
+#[test]
+fn the_shipped_panels_are_unaffected() {
+    let registry = Registry::new(indicate_instrument_panels::BUILTIN_PANELS).expect("composes");
+    for panel in registry.panels() {
+        assert_eq!(check_frame_varies(panel), Ok(()), "{}", panel.id);
+    }
+}

--- a/crates/indicate-instrument-conformance/src/lib.rs
+++ b/crates/indicate-instrument-conformance/src/lib.rs
@@ -3,7 +3,7 @@
 //!
 //! [`admit`] drives every registered panel through the shared canonical
 //! corpus plus the panel's own extreme states, and through every
-//! single-group withholding its descriptor declares, then checks six
+//! single-group withholding its descriptor declares, then checks seven
 //! families: the layer contract (well-formed scenes with every required
 //! band present under every degradation), the background contract (the
 //! declared capability is the band's actual behavior — `NotUsed` never
@@ -14,8 +14,12 @@
 //! run must claim the state group its value derives from, the claim is
 //! bounded to the panel's required groups, and a run claiming the
 //! withheld group may not be visible — wherever it is drawn), and
-//! declared regions (a claimed run lands inside a region its group
-//! declares). A shell composes its registry and runs this once at
+//! declared regions (every declared region is populated by a run
+//! claiming its group — a region over blank space would guard a surface
+//! the readout is not on), and frame variation (a panel declaring a
+//! range of frames emits differently across it, so a panel that ignores
+//! the size it is handed cannot pass on a range it does not honour).
+//! A shell composes its registry and runs this once at
 //! integration time; a panel that fails does not join an operational
 //! layout.
 //!

--- a/docs/instruments/panel-contract.md
+++ b/docs/instruments/panel-contract.md
@@ -118,17 +118,21 @@ What the registry checks at init:
 **A panel may treat its `DesignFrame` as a constant.** Nothing in the
 framework lays out for you, and no author owes a size-adaptive layout.
 The honest way to say so is a degenerate range: `frame_min ==
-frame_max`, one canonical frame, and any positive step. A shell may then
-only ask for the size the geometry was authored for, and asking for
-anything else is refused by `accepts` before you are called. Every
-shipped panel does exactly that today.
+frame_max`, one canonical frame, and any positive step. The only size a
+*conforming* shell may then ask for is the one the geometry was authored
+for — `accepts` is the predicate that says so, and a shell is expected
+to consult it, but nothing in the draw path re-checks the argument. Every
+shipped panel declares a degenerate range today.
 
 What is refused is declaring a range and not using it. Admission renders
-a non-degenerate panel at both ends of its range and requires the bytes
-to differ, so a panel that takes the parameter and ignores it fails
-rather than passing on the strength of a range it does not honour. A
-shell asking for the larger frame is owed more instrument, not the same
-picture for the backend to stretch.
+a non-degenerate panel at both ends of its range, across the whole case
+matrix, and requires the bytes to differ in at least one case. One
+witness settles it, so a panel whose `nothing-fed` frame is a fixed
+placard is not accused, and neither is one whose size only shows under
+an alert or in an extreme state. A panel that takes the parameter and
+ignores it fails rather than passing on the strength of a range it does
+not honour: a shell asking for the larger frame is owed more instrument,
+not the same picture for the backend to stretch.
 
 Differing bytes are a weak proof of a good layout and a sufficient proof
 of the thing that was otherwise unprovable: that the argument reached

--- a/docs/instruments/panel-contract.md
+++ b/docs/instruments/panel-contract.md
@@ -115,10 +115,26 @@ What the registry checks at init:
   480×360-to-600×450 range on both axes and is a shape a 4:3 layout
   never declared, which is what the aspect check is for.
 
-A fixed-layout panel declares `frame_min == frame_max`, one canonical
-frame, and any positive step — the honest statement that a shell may
-only ask for the size the geometry was authored for. Every shipped panel
-does exactly that today.
+**A panel may treat its `DesignFrame` as a constant.** Nothing in the
+framework lays out for you, and no author owes a size-adaptive layout.
+The honest way to say so is a degenerate range: `frame_min ==
+frame_max`, one canonical frame, and any positive step. A shell may then
+only ask for the size the geometry was authored for, and asking for
+anything else is refused by `accepts` before you are called. Every
+shipped panel does exactly that today.
+
+What is refused is declaring a range and not using it. Admission renders
+a non-degenerate panel at both ends of its range and requires the bytes
+to differ, so a panel that takes the parameter and ignores it fails
+rather than passing on the strength of a range it does not honour. A
+shell asking for the larger frame is owed more instrument, not the same
+picture for the backend to stretch.
+
+Differing bytes are a weak proof of a good layout and a sufficient proof
+of the thing that was otherwise unprovable: that the argument reached
+the geometry at all. What each axis should *extend* — tape range versus
+tick density, line count, radius versus margin — is a content policy per
+panel, and belongs beside the panel that adopts a range.
 
 ### The honesty rules, and their asymmetry
 


### PR DESCRIPTION
Addresses the half of #32 that is cheap today. The other half — giving a shipped panel a real range — needs a layout, new canonical frames, new baselines, and a digest move, and is deliberately **out of scope** here; it belongs with the set that needs it.

## The hole

> A panel that quietly ignores its `DesignFrame` argument and emits fixed geometry would pass every test in the repository, because no test asks it for a second frame. Admission does not check it either.

Exactly right. The matrix asks each canonical frame the same questions *separately* and never compares the answers, and every shipped panel declares one frame — so nothing ever asked one for a second.

## What lands

**Admission renders a non-degenerate panel at both ends of its range and requires the bytes to differ.** Differing bytes are a weak proof of a good layout and a sufficient proof of the thing that was otherwise unprovable: that the argument reached the geometry at all.

New typed refusal `FrameIgnored { panel, min, max }`.

**The panel contract now says plainly that a panel may treat its `DesignFrame` as a constant**, which is the other thing #32 asks for — so an author does not assume the framework is doing something for them that nothing checks. The honest way to say it is a degenerate range, and `accepts` then refuses any other size before the panel is called.

What is refused is declaring a range and not honouring it: a shell asking for the larger frame is owed more instrument, not the same picture for the backend to stretch.

## Shown, not asserted

Two fixture panels, identical but for one line — one sizes its rect from the argument, the other hard-codes 480×360:

| Fixture | Result |
|---|---|
| ignores the frame | `FrameIgnored { panel: "fixed", … }` |
| uses the frame | admitted |
| degenerate range, fixed geometry | admitted — a degenerate range *is* the declaration that it does not vary |
| the three shipped panels | admitted, unchanged |

That last one is pinned deliberately: the check is inert for the shipped set today, so a panel that gains a range **without** gaining a layout cannot land quietly.

## Nothing moved

Scene digest `3efb08c5…`, screen-composition digest `071bd35c…`, admission still 242 cases / 166 warnings, raster baselines and corpus untouched. The new check does no work for a degenerate range, which is every shipped panel.

Full battery green including the new release-manifest guard and both HARD evidence gates.

## Still open in #32, and why I left it

The **choosing policy** — largest-that-fits, nearest-aspect, nearest-canonical — is unwritten. It cannot be settled honestly while every panel offers exactly one legal frame: any policy would be untestable and would read as arbitrary. It belongs with the first panel that offers a real range, alongside its content policy.