### PR TITLE
Take sha1 and sha2 0.11 (#2, #3)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -31,11 +31,11 @@ checksum = "b588b76d00fde79687d7646a9b5bdf3cc0f655e0bbd080335a95d7e96f3587da"
 
 [[package]]
 name = "block-buffer"
-version = "0.10.4"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+checksum = "d2f6c7dbe95a6ed67ad9f18e57daf93a2f034c524b99fd2b76d18fdfeb6660aa"
 dependencies = [
- "generic-array",
+ "hybrid-array",
 ]
 
 [[package]]
@@ -45,31 +45,37 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
-name = "cpufeatures"
-version = "0.2.17"
+name = "const-oid"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
+
+[[package]]
+name = "cpufeatures"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
 dependencies = [
  "libc",
 ]
 
 [[package]]
 name = "crypto-common"
-version = "0.1.7"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
+checksum = "ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453"
 dependencies = [
- "generic-array",
- "typenum",
+ "hybrid-array",
 ]
 
 [[package]]
 name = "digest"
-version = "0.10.7"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
 dependencies = [
  "block-buffer",
+ "const-oid",
  "crypto-common",
 ]
 
@@ -96,16 +102,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
-name = "generic-array"
-version = "0.14.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
-dependencies = [
- "typenum",
- "version_check",
-]
-
-[[package]]
 name = "getrandom"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -126,6 +122,15 @@ dependencies = [
  "cfg-if",
  "libc",
  "r-efi 6.0.0",
+]
+
+[[package]]
+name = "hybrid-array"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "707114b52a152fa7bdb290cd7cd5912d9467273b6d74e21b8d81aca1f8533f6b"
+dependencies = [
+ "typenum",
 ]
 
 [[package]]
@@ -487,9 +492,9 @@ dependencies = [
 
 [[package]]
 name = "sha1"
-version = "0.10.7"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a978451301f4db1d02937a4ab3ccce137717b81826e79b7d49ffe3244a13c3b8"
+checksum = "aacc4cc499359472b4abe1bf11d0b12e688af9a805fa5e3016f9a386dc2d0214"
 dependencies = [
  "cfg-if",
  "cpufeatures",
@@ -498,9 +503,9 @@ dependencies = [
 
 [[package]]
 name = "sha2"
-version = "0.10.9"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
+checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
 dependencies = [
  "cfg-if",
  "cpufeatures",
@@ -666,12 +671,6 @@ name = "valuable"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
-
-[[package]]
-name = "version_check"
-version = "0.9.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "wait-timeout"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ edition = "2024"
 libm = "0.2.16"
 thiserror = { version = "2.0.18", default-features = false }
 proptest = "1.11.0"
-sha2 = "0.10.9"
+sha2 = "0.11.0"
 tracing = "0.1.44"
 tracing-subscriber = "0.3.23"
 indicate-frames = { path = "crates/indicate-frames" }

--- a/crates/indicate-evidence/Cargo.toml
+++ b/crates/indicate-evidence/Cargo.toml
@@ -14,7 +14,7 @@ sha2 = { workspace = true }
 # Git blob identity (`git-blob:<sha1>`) of the test sources a recorded result
 # was produced from — SHA-1 because that is git's object id, not a security
 # boundary; the content it names is separately pinned by sha2 digests.
-sha1 = "0.10.6"
+sha1 = "0.11.0"
 
 [[bin]]
 name = "evidence-gate"


### PR DESCRIPTION
Supersedes the two dependabot PRs, #2 (sha1 0.10.7 → 0.11.0) and #3 (sha2 0.10.9 → 0.11.0), rebased onto current `main` and taken together because they share a transitive dependency change.

## Why these two need more than a green build

Both compute values something downstream **pins**:

- **sha2** — the REN-03 raster frame hashes, the three composed-frame hashes, the corpus hash, and every recorded evidence artifact digest.
- **sha1** — the git blob identity of the test sources a recorded verification result binds itself to.

A major bump of a hashing crate is therefore a question about pinned values, not about compilation. If any of them moved, every consumer would go red at its next pin advance and the evidence graph would stop resolving.

## None moved — checked, not assumed

| Pin | Result |
|---|---|
| Scene digest | `3efb08c5…` matches |
| Screen-composition digest | `071bd35c…` matches |
| REN-03 panel hashes (×3) | reproduce and match |
| Composed-frame hashes (×3) | reproduce and match |
| Corpus | unchanged |
| Release manifest | regenerates identically |
| Admission | 242 cases / 166 warnings |

The **evidence gate exercises both crates at once** — sha1 on every bound source digest, sha2 on every artifact — and resolves to the same graph digest `f993634c…` with `verdict: VALID`. All 26 negative fixtures still fail closed.

That is the expected outcome: SHA-1 and SHA-256 are the same algorithms they were. What 0.11 changes is the crate API, and this tree's use of `Digest` is untouched by it — no source file needed editing.

## Dependency graph

Loses `generic-array` and `version_check`, gains `hybrid-array` — all transitive, none a wire-protocol, host, or shell crate, so the downstream-agnostic boundary is unmoved and its CI gate stays green.

## Full battery

fmt, clippy `-D warnings`, test `--all-targets`, doc, release build, `thumbv7em-none-eabihf` closure, and all six script gates including the new `check-release-manifest.sh`.