### PR TITLE
A public API addition is worth a tag (#39)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,56 @@ from a rewritten one. Entries are newest first, and the tag's message
 repeats the same five values so `git show <tag>` answers the question
 without a checkout. `CONTRIBUTING.md` has the release steps.
 
+## [0.3.0] — 2026-08-08
+
+Two additions made for consumers, neither of which moves a contract
+value — which is why the release trigger now covers a public API
+addition as well as the five. A predicate nobody can pin by name does
+not stop the second copy being written, and a manifest nobody can pin by
+name does not get diffed.
+
+| Value | This release |
+|---|---|
+| State ABI | 6 |
+| Scene format | 1 |
+| Corpus | 4 |
+| Composition digest | `3efb08c55eadadc2b006ee6b006b29e4b3a3f8d4ec3ce1324f401dbc16dc85ca` |
+| Panel set | `pfd`, `hsi`, `monitor` |
+
+Panel set changed since the previous release: no.
+
+- **`PanelDescriptor::accepts(DesignFrame) -> Result<(), FrameRefusal>`.**
+  The rule over the declared frame bounds, in the crate where the
+  constants live, so a shell does not write its own. The refusal names
+  the bound it broke, and `FRAME_STEP_TOLERANCE` settles the one
+  parameter two shells would otherwise each choose. `Registry::new` and
+  composition's slot check both call it, so it cannot rot as an unused
+  API.
+- **`release-manifest.json` and `scripts/check-release-manifest.sh`.**
+  Every pinned value this revision holds down, generated from the
+  constants rather than grepped for, with CI failing when the file
+  disagrees with the tree. It states what *this* revision pins;
+  comparing that against its own is each consumer's check to write.
+- **Admission refuses a panel that declares a frame range and emits
+  identically across it.** Inert for every shipped panel, all of which
+  declare a degenerate range, and the panel contract now says outright
+  that treating the frame as a constant is allowed.
+- **sha1 and sha2 at 0.11.** No pinned value moved; the algorithms did
+  not change, only the crate API around them, and this tree's use of
+  `Digest` was untouched by it.
+
+### Notes for anyone re-pinning
+
+- Nothing to re-verify. Every value in the table above is what `v0.2.0`
+  carried, the raster baselines and criticality bands are unchanged, and
+  the corpus is untouched. Advancing a pin across this release is a
+  manifest bump and nothing else.
+- If you wrote your own frame-bounds check while migrating to `v0.2.0`,
+  `accepts` replaces it. The tolerance it applies to the step is zero,
+  which is the value the descriptor's own canonical frames are validated
+  against — a local check using an epsilon would accept frames this
+  repository refuses.
+
 ## [0.2.0] — 2026-08-07
 
 The design frame becomes an emission input. `DrawFn` gains a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,10 @@ Consumers pin this repository by revision. A bare revision says nothing
 about what it contains, so a revision meant to be pinned is given an
 annotated tag and an entry here naming the contract versions it carries.
 
-Five values decide whether a given revision is the one a consumer wants.
-Each entry states all five, and `scripts/check-release-markers.sh` fails
-the build when the newest entry disagrees with the code it describes — a
+Five values decide whether a revision's *contract* differs from the one
+you already pinned. Each entry states all five, and
+`scripts/check-release-markers.sh` fails the build when the newest entry
+disagrees with the code it describes — a
 changelog that has to be checked against the source is the archaeology
 it was written to remove.
 
@@ -30,11 +31,17 @@ baselines, the glyph-pack content hash, and the criticality bands — and
 states the panel set through the per-panel keys rather than as a row. A
 consumer's CI can diff it; prose it cannot.
 
-A release is cut whenever any of the five moves — review's job, since a
-guard comparing the newest entry to the tree cannot tell an added entry
-from a rewritten one. Entries are newest first, and the tag's message
-repeats the same five values so `git show <tag>` answers the question
-without a checkout. `CONTRIBUTING.md` has the release steps.
+A release is cut whenever any of the five moves, and also when a public
+API addition lands that consumers are expected to call — a predicate or
+a file published for consumers is of no use to them if reaching it means
+pinning a bare revision. Either way it is review's job to notice, since
+a guard comparing the newest entry to the tree cannot tell an added
+entry from a rewritten one. An entry whose five values match the one
+below it is the second kind, and says so.
+
+Entries are newest first, and the tag's message repeats the same five
+values so `git show <tag>` answers the question without a checkout.
+`CONTRIBUTING.md` has the release steps.
 
 ## [0.3.0] — 2026-08-08
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -63,8 +63,24 @@ the two gate invocations locally after touching any recorded source.
 Consumers pin a bare revision, so a revision meant to be pinned carries
 an annotated tag and a `CHANGELOG.md` entry naming what it contains.
 
-Cut one whenever any of the five contract values moves: state ABI, scene
-format, corpus, composition digest, or the panel set.
+Cut one whenever any of the five contract values moves — state ABI,
+scene format, corpus, composition digest, or the panel set — **or when a
+public API addition lands that consumers are expected to call.**
+
+The second trigger exists because the first one misses the additions
+made *for* consumers. A predicate published so nobody writes their own
+copy does not stop the second copy from being written if it cannot be
+pinned by name; a manifest published for a consumer's CI to diff does
+not get diffed if reaching it means pinning a bare revision and
+explaining in a comment which commit it is. That is the archaeology tags
+were introduced to remove, reappearing through the trigger rather than
+through the absence of tags.
+
+A tag therefore marks a revision worth pinning, not only one whose
+contract values moved. That means some tags carry no contract change,
+which is harmless here: the changelog entry and the release manifest
+both state exactly what did and did not move, so a consumer can see at a
+glance that it has nothing to re-verify.
 
 1. Regenerate the manifest and commit it with the entry:
 


### PR DESCRIPTION
Fixes #39. Doc-only plus a release entry; no code changes.

## The choice

The issue offers two ways out and says they are not equivalent. I took **widen the trigger**, because the alternative — documenting that tags track contract values only — would leave the two additions that exist *for consumers* permanently unpinnable by name, and both fail at their own purpose when unreachable:

- a predicate published so no shell writes its own copy does not stop the second copy from being written;
- a manifest published for a consumer's CI to diff does not get diffed.

Reaching either meant pinning a bare revision and explaining in a comment which commit it was — the archaeology tags were introduced to remove (#8), arriving through the trigger rather than through the absence of tags.

## What changes

`CONTRIBUTING.md`'s trigger gains "or when a public API addition lands that consumers are expected to call", with the reasoning recorded so the next reader knows it is deliberate.

The issue names the cost honestly and so does the doc: some tags now carry no contract change. That is harmless here precisely because the changelog entry and the release manifest both state exactly what did and did not move — a consumer sees at a glance whether it has anything to re-verify.

## 0.3.0

Cut for the two additions the issue names, plus the frame-variation check and the sha1/sha2 bump. Its table is **identical to 0.2.0's** — same ABI, scene format, corpus, composition digest, and panel set — and the entry says so plainly, so advancing a pin across it is a manifest bump and nothing else.

The re-pinning note also tells anyone who wrote their own frame-bounds check while migrating to 0.2.0 that `accepts` replaces it, and warns that a local epsilon on the step would accept frames this repository refuses — the tolerance here is zero, and it is what the descriptors' own canonical frames are validated against.

`check-release-markers.sh` validates the new entry against the tree: `OK (0.3.0; ABI 6, scene 1, corpus 4, panels: pfd, hsi, monitor)`. The manifest is unchanged and still regenerates identically, which is the point.

I will tag `v0.3.0` on the merge commit, per the release steps.