### PR TITLE
Name the Apple backend as the Core Graphics consumer it is (#45)

### DIFF
--- a/docs/instruments/backend-contract.md
+++ b/docs/instruments/backend-contract.md
@@ -27,8 +27,8 @@ mode, into a caller-supplied buffer:
   ceilings.
 - Adding a panel adds commands — never a new mechanism. A backend that
   interprets the opcode vocabulary renders every current and future
-  panel; the Swift SceneKit backend is frozen against the opcodes, not
-  the panel set.
+  panel; the Apple Core Graphics backend is frozen against the opcodes,
+  not the panel set.
 
 There is no retained scene graph, no diffing, and no per-frame heap
 traffic to tune. If a backend is slow, the cost is in the backend.

--- a/docs/instruments/renderer-verification.md
+++ b/docs/instruments/renderer-verification.md
@@ -3,8 +3,10 @@
 This document is the verification wall for the instrument rendering backends. It
 defines what each backend must prove before a frame reaches a display, records
 the hard resource budgets, states the target-independent execution-time
-measurement method, and specifies the shared conformance corpus that cross-checks
-the browser Canvas interpreter against the deterministic reference rasterizer.
+measurement method, and specifies the shared conformance corpus that
+cross-checks each downstream interpreter — the browser Canvas interpreter and
+the Apple Core Graphics interpreter — against the deterministic reference
+rasterizer.
 
 The Canvas/browser backend is **SIM / NOT FOR FLIGHT**. Its verification is
 engineering conformance for the simulator; it makes no certification claim.
@@ -16,14 +18,31 @@ engineering conformance for the simulator; it makes no certification claim.
 | Reference software rasterizer | `indicate-instrument-raster::render` | Bit-exact: pinned SHA-256 frame hashes (`src/raster/tests/frame_hashes.rs`), reproducible via `libm` + IEEE-754 `f32`. |
 | Reference composition harness | `indicate-instrument-raster::render_composition` | Bit-exact: pinned SHA-256 composed-frame hashes (`src/composition/tests.rs`), plus the overlay show-through property. |
 | Browser Canvas2D | Pilotage repository, `clients/web/instruments.js` (`interpretScene`) | Semantic conformance + documented, limited tolerances. **Not** pixel-deterministic — Canvas2D anti-aliasing and font/geometry rounding are platform-owned. |
+| Apple Core Graphics | Apple shell repository (iPad); scene IR crosses the FFI boundary from the Rust static library | Semantic conformance against the same corpus. **Not** pixel-deterministic — Core Graphics anti-aliasing and font rendering are platform-owned. |
 | wgpu / embedded framebuffer | future | Consume the identical scene IR; verified by the same corpus when they land. |
 
-Both backends share one authoritative structural gate: the strong layer contract
-`indicate-instrument-scene::validate_layers`. In the browser it runs inside the
-wasm renderer (the Pilotage repository's instrument wasm bundle) on the scene
-the wasm itself produced, before any bytes reach `interpretScene`;
-`interpretScene` re-checks framing (`validateSceneStructure`) as defence in
-depth.
+All three implementations share one authoritative structural gate: the strong
+layer contract `indicate-instrument-scene::validate_layers`. In the browser it
+runs inside the wasm renderer (the Pilotage repository's instrument wasm
+bundle) on the scene the wasm itself produced, before any bytes reach
+`interpretScene`; `interpretScene` re-checks framing
+(`validateSceneStructure`) as defence in depth. In the Apple shell it runs
+inside the Rust static library on the scene the library produced, before any
+bytes cross the FFI boundary.
+
+### Ownership boundary
+
+Indicate owns the scene IR, the conformance corpus, the release manifest, the
+panels, and the registry. A change to any of them lands here, once, and
+reaches every consumer through the pinned revision.
+
+Each backend owns its downstream corpus drift check. The consuming repository
+pins `corpusVersion` and `corpusSha256` and compares them in its own CI; a
+corpus change here reddens that check there, and the consumer resolves it by
+re-running its suite against the new corpus, never by unpinning. This
+repository carries no Swift or Apple dependency and no registry of downstream
+repositories: the Apple Core Graphics backend is a consumer that pins by
+revision, exactly as the browser shell does.
 
 ## Resource budgets
 
@@ -199,9 +218,9 @@ guards accidental drift on every side.
 | Paint fail-safe | non-finite coordinate, out-of-range coordinate, over-vertex-budget shape, non-finite rotation, out-of-range translation, non-finite arc angle, out-of-range stroke width |
 
 Budget-boundary streams that would be megabytes of hex are carried as a compact
-`generator` descriptor (`fill_bytes`, `repeat_unknown`, `nest_saves`) that both
-backends reconstruct byte-identically; the corpus hash covers the reconstructed
-bytes, so a generator divergence surfaces immediately.
+`generator` descriptor (`fill_bytes`, `repeat_unknown`, `nest_saves`) that
+every backend reconstructs byte-identically; the corpus hash covers the
+reconstructed bytes, so a generator divergence surfaces immediately.
 
 ### What each side checks (capability asymmetry)
 
@@ -239,7 +258,7 @@ case name and the differing index. `GuardMissing` is the fail-closed direction:
 a case the golden marks `interpreterRejects` that the interpreter paints anyway
 means a browser-side guard has been weakened or removed.
 
-### Fail-closed geometry guards on both backends
+### Fail-closed geometry guards on the rasterizer and the Canvas interpreter
 
 Canvas2D itself has no fail-safe for non-finite or absurd geometry — it will
 happily accept a NaN rectangle or a ten-million-pixel translation. The browser
@@ -267,7 +286,8 @@ rejected by the interpreter and painted by the rasterizer; the conformance claim
 for the browser backend is accordingly scoped to encoder-producible scenes, and
 the browser remains SIM / NOT FOR FLIGHT.
 
-No unexpected divergence was found between the backends at the levels they can be
+No unexpected divergence was found between the reference rasterizer and the
+browser interpreter at the levels they can be
 compared: framing, decode, unknown-opcode counting, guard placement, and the
 interpreter's opcode-to-Canvas mapping all agree across the corpus.
 

--- a/scripts/check-structure.sh
+++ b/scripts/check-structure.sh
@@ -7,6 +7,9 @@
 #     /generated/ path)
 #   - no lib.rs over 100 lines
 #   - no function body over 80 lines
+#   - no retired Apple-backend term (InstrumentSceneKit,
+#     IndicateAppleDisplay, "Swift SceneKit backend") in an active
+#     contract document under docs/instruments/
 #
 # The function-length check is an AWK brace-depth heuristic: it counts lines
 # between a `fn` header and the point where brace depth returns to the level
@@ -343,6 +346,24 @@ check_crate_map() {
     done < <(grep -oE '`indicate-[a-z0-9-]+`' "$map" | tr -d '`' | sort -u)
 }
 
+# The Apple backend is a Core Graphics consumer of the scene IR, not a
+# SceneKit scene graph, and its pieces are named after this repository.
+# These strings name the superseded boundary; an active contract
+# document under docs/instruments/ must not re-introduce one. Fixed-string
+# matching, so a term inside a longer word still counts — that is the
+# intent for retired names.
+check_backend_boundary_terms() {
+    local file term
+    while IFS= read -r file; do
+        for term in "InstrumentSceneKit" "IndicateAppleDisplay" "Swift SceneKit backend"; do
+            if grep -qF "$term" "$file"; then
+                echo "FORBIDDEN: $file mentions '$term'; the Apple backend is the Apple Core Graphics backend" >&2
+                status=1
+            fi
+        done
+    done < <(find docs/instruments -type f -name '*.md')
+}
+
 check_forbidden_filenames
 check_file_length
 check_function_length
@@ -351,6 +372,7 @@ check_safety_constant_count
 check_crate_naming
 check_tier_law
 check_crate_map
+check_backend_boundary_terms
 
 # The tier law is the one check here that a manifest can spell its way
 # around, so it carries a selftest proving it refuses each spelling. The

--- a/scripts/test-structure.sh
+++ b/scripts/test-structure.sh
@@ -16,11 +16,13 @@ root_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "$root_dir"
 
 probe_dir="sets/indicate-tier-probe"
+probe_doc="docs/instruments/zz-structure-probe.md"
 lock_backup="$(mktemp)"
 cp Cargo.lock "$lock_backup"
 
 cleanup() {
     rm -rf "$probe_dir"
+    rm -f "$probe_doc"
     cp "$lock_backup" Cargo.lock
     rm -f "$lock_backup"
 }
@@ -121,6 +123,25 @@ indicate-instrument-scene = { workspace = true }'
 expect_acceptance "registry as a DEV dependency" \
 '[dev-dependencies]
 indicate-instrument-registry = { workspace = true }'
+
+# The retired Apple-backend terms get the same treatment as the tier law:
+# plant each one in a contract document and require the guard to refuse.
+expect_term_refusal() {
+    local name="$1" term="$2"
+    printf 'A probe sentence naming %s.\n' "$term" > "$probe_doc"
+    if INDICATE_STRUCTURE_SELFTEST_CHILD=1 bash scripts/check-structure.sh >/dev/null 2>&1; then
+        echo "REGRESSION: $name was accepted; a retired Apple-backend term passed unseen" >&2
+        failed=$((failed + 1))
+    else
+        echo "ok: $name refused"
+        passed=$((passed + 1))
+    fi
+    rm -f "$probe_doc"
+}
+
+expect_term_refusal "InstrumentSceneKit" "InstrumentSceneKit"
+expect_term_refusal "IndicateAppleDisplay" "IndicateAppleDisplay"
+expect_term_refusal "Swift SceneKit backend" "Swift SceneKit backend"
 
 if [ "$failed" -ne 0 ]; then
     echo "structure-selftest: FAILED ($failed of $((passed + failed)) cases)" >&2


### PR DESCRIPTION
Closes #45.

## What changes

- `backend-contract.md`: the backend frozen against the opcode vocabulary is
  the **Apple Core Graphics backend**, not a "Swift SceneKit backend".
- `renderer-verification.md`:
  - The backends table gains the Apple Core Graphics backend (semantic
    conformance against the shared corpus; not pixel-deterministic, as with
    Canvas2D).
  - "Both backends" becomes "all three implementations" for the shared
    structural gate; the fail-closed-guards section names the two backends it
    actually compares.
  - New **Ownership boundary** section: Indicate owns the scene IR, the
    corpus, the release manifest, the panels, and the registry; each backend
    owns its downstream corpus drift check.
- `scripts/check-structure.sh`: a new check rejects `InstrumentSceneKit`,
  `IndicateAppleDisplay`, and "Swift SceneKit backend" in active contract
  documents under `docs/instruments/`.
- `scripts/test-structure.sh`: selftest plants each forbidden term and
  requires the guard to refuse it (12 cases now).

## Non-goals honored

No Swift or Apple dependency, no downstream repository registry, no corpus or
digest change, no consumer pin advance. `release-manifest.json` and every
pinned digest are byte-identical; the diff touches two docs and two scripts
only.

## Verification

- `bash scripts/check-structure.sh` — OK (selftest 12/12)
- `bash scripts/test-structure.sh` — OK
- `bash scripts/check-instrument-requirements.sh` — OK (73 requirements)
- `cargo test --locked --all-targets` — exit 0, all 21 suites green

## Tracking

#36 remains the cross-shell tracker; no new tracking issue was opened. #35
and #36 stay open until all consumers record compatible revisions and
digests. Two related design decisions were filed separately: #46
(DisplayReason registry) and #47 (generation semantics).