### PR TITLE
Say the evidence gate proves a record's identity, not its currency (#44)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -225,6 +225,16 @@ jobs:
           --graph docs/instruments/evidence-graph.evg --repo-root .
           --require-resolvable
 
+      - name: recorded run evidence MUST be fresh (HARD)
+        # The gate proves a record's identity and deliberately runs no
+        # build, so it cannot notice a count that drifted when a test was
+        # added away from a bound source. This step re-runs each
+        # artifact's own recorded command and compares. The build it
+        # needs is already paid for by the test steps above.
+        run: |
+          bash scripts/check-recorded-counts.sh --selftest
+          bash scripts/check-recorded-counts.sh
+
       - name: Negative fixtures must all FAIL the gate
         run: |
           set -u

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -37,12 +37,21 @@ cargo run --locked -q -p indicate-evidence --bin evidence-gate -- \
   --graph docs/instruments/evidence-graph.evg --repo-root . --resolve-selectors
 cargo run --locked -q -p indicate-evidence --bin evidence-gate -- \
   --graph docs/instruments/evidence-graph.evg --repo-root . --require-resolvable
+bash scripts/check-recorded-counts.sh
 ```
 
 The evidence gate binds recorded test sources by content digest: editing
 a recorded test file (the attitude-behavior and presentation suites
 among them) reddens the gate until that evidence is re-recorded, so run
 the two gate invocations locally after touching any recorded source.
+
+The gate runs no build, so it cannot see a recorded pass count that
+drifted when a test was added away from a bound source.
+`check-recorded-counts.sh` re-runs each artifact's own recorded command
+and compares. Re-recording means running that command, writing its
+output into the artifact with the current configuration identity, and
+updating the result node's `output-digest` and `source-digest` together
+— plus re-anchoring the baseline if the configuration item moved.
 
 ## PR discipline
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -37,6 +37,7 @@ cargo run --locked -q -p indicate-evidence --bin evidence-gate -- \
   --graph docs/instruments/evidence-graph.evg --repo-root . --resolve-selectors
 cargo run --locked -q -p indicate-evidence --bin evidence-gate -- \
   --graph docs/instruments/evidence-graph.evg --repo-root . --require-resolvable
+bash scripts/check-recorded-counts.sh --selftest
 bash scripts/check-recorded-counts.sh
 ```
 
@@ -48,10 +49,8 @@ the two gate invocations locally after touching any recorded source.
 The gate runs no build, so it cannot see a recorded pass count that
 drifted when a test was added away from a bound source.
 `check-recorded-counts.sh` re-runs each artifact's own recorded command
-and compares. Re-recording means running that command, writing its
-output into the artifact with the current configuration identity, and
-updating the result node's `output-digest` and `source-digest` together
-— plus re-anchoring the baseline if the configuration item moved.
+and compares. The re-record procedure is four steps, written once in
+`docs/instruments/evidence-plan.md`.
 
 ## PR discipline
 

--- a/docs/instruments/evidence-artifacts/att01/panel.run.txt
+++ b/docs/instruments/evidence-artifacts/att01/panel.run.txt
@@ -2,10 +2,10 @@ Indicate evidence — captured verification run (SIM / NOT FOR FLIGHT)
 scope: ATT-01
 suite: PFD attitude panel
 command: cargo test -p indicate-instrument-panels
-config-digest: f80de2a15f1b274b2ec3db069dc6d54cb41801cb
+config-digest: 6df8a8edaddfca003823e0b14c4ff60e02b608be
 tool-version: rustc 1.95.0 (59807616e 2026-04-14)
-run-id: local:f80de2a15f1b274b2ec3db069dc6d54cb41801cb
+run-id: local:6df8a8edaddfca003823e0b14c4ff60e02b608be
 outcome: pass
 summary:
-test result: ok. 81 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
+test result: ok. 84 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
 test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out

--- a/docs/instruments/evidence-artifacts/att01/presentation.run.txt
+++ b/docs/instruments/evidence-artifacts/att01/presentation.run.txt
@@ -1,10 +1,10 @@
 Indicate evidence — captured verification run (SIM / NOT FOR FLIGHT)
 scope: ATT-01
-suite: SO(3) presentation unit
+suite: SO(3) presentation unit suite
 command: cargo test -p indicate-instrument-state
-config-digest: f80de2a15f1b274b2ec3db069dc6d54cb41801cb
+config-digest: 6df8a8edaddfca003823e0b14c4ff60e02b608be
 tool-version: rustc 1.95.0 (59807616e 2026-04-14)
-run-id: local:f80de2a15f1b274b2ec3db069dc6d54cb41801cb
+run-id: local:6df8a8edaddfca003823e0b14c4ff60e02b608be
 outcome: pass
 summary:
 test result: ok. 175 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out

--- a/docs/instruments/evidence-artifacts/att01/raster.run.txt
+++ b/docs/instruments/evidence-artifacts/att01/raster.run.txt
@@ -2,9 +2,9 @@ Indicate evidence — captured verification run (SIM / NOT FOR FLIGHT)
 scope: ATT-01
 suite: raster attitude behavior
 command: cargo test -p indicate-instrument-raster
-config-digest: f80de2a15f1b274b2ec3db069dc6d54cb41801cb
+config-digest: 6df8a8edaddfca003823e0b14c4ff60e02b608be
 tool-version: rustc 1.95.0 (59807616e 2026-04-14)
-run-id: local:f80de2a15f1b274b2ec3db069dc6d54cb41801cb
+run-id: local:6df8a8edaddfca003823e0b14c4ff60e02b608be
 outcome: pass
 summary:
 test result: ok. 98 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out

--- a/docs/instruments/evidence-graph.evg
+++ b/docs/instruments/evidence-graph.evg
@@ -157,34 +157,34 @@ locator docs/instruments/fha.md
 node RESULT-RASTER verification-result
 title raster extreme-attitude behavior — recorded pass
 attr command cargo test -p indicate-instrument-raster
-attr config-digest f80de2a15f1b274b2ec3db069dc6d54cb41801cb
+attr config-digest 6df8a8edaddfca003823e0b14c4ff60e02b608be
 attr tool-version rustc 1.95.0 (59807616e 2026-04-14)
 attr source-digest git-blob:7d24b75c7952e564c2a392d5fe26c6a0a2c89139
 attr artifact docs/instruments/evidence-artifacts/att01/raster.run.txt
-attr output-digest sha256:589617dd0ca90a8ebefb5ab3fe209a3d2083e8c6015d78e1231730b3e35803a8
-attr run-id local:f80de2a15f1b274b2ec3db069dc6d54cb41801cb
+attr output-digest sha256:1de4e3527826bfca44e437d02b8e6b63cd3cde673d3c9b49b10f50d2a7a4ea52
+attr run-id local:6df8a8edaddfca003823e0b14c4ff60e02b608be
 attr outcome pass
 
 node RESULT-PRESENTATION verification-result
 title SO(3) presentation unit suite — recorded pass
 attr command cargo test -p indicate-instrument-state
-attr config-digest f80de2a15f1b274b2ec3db069dc6d54cb41801cb
+attr config-digest 6df8a8edaddfca003823e0b14c4ff60e02b608be
 attr tool-version rustc 1.95.0 (59807616e 2026-04-14)
 attr source-digest git-blob:d11595580cab8264e75e9e82ab9994de6d8bdeac
 attr artifact docs/instruments/evidence-artifacts/att01/presentation.run.txt
-attr output-digest sha256:70cce901e37b3274efba4093e2f5f132e4a1ee0f59762135f10e0834ecc7344c
-attr run-id local:f80de2a15f1b274b2ec3db069dc6d54cb41801cb
+attr output-digest sha256:1a16b16481596854779d9584778058b9b0082c0579d25915ba48a04d06e579b9
+attr run-id local:6df8a8edaddfca003823e0b14c4ff60e02b608be
 attr outcome pass
 
 node RESULT-PFD verification-result
 title PFD attitude panel suite — recorded pass
 attr command cargo test -p indicate-instrument-panels
-attr config-digest f80de2a15f1b274b2ec3db069dc6d54cb41801cb
+attr config-digest 6df8a8edaddfca003823e0b14c4ff60e02b608be
 attr tool-version rustc 1.95.0 (59807616e 2026-04-14)
 attr source-digest git-blob:ee431cb9b52ad6e218b9525362af9610a1448a37
 attr artifact docs/instruments/evidence-artifacts/att01/panel.run.txt
-attr output-digest sha256:239ead0bb0d42cb86e4e6be7f92fbf953d482a093cb25c77c35dc2868fd50ede
-attr run-id local:f80de2a15f1b274b2ec3db069dc6d54cb41801cb
+attr output-digest sha256:afffba4195031894cba10b1800927e6aab16ad04959c8a1dc0c22263779bc5be
+attr run-id local:6df8a8edaddfca003823e0b14c4ff60e02b608be
 attr outcome pass
 
 # --- Configuration and tool identity ---
@@ -192,8 +192,8 @@ attr outcome pass
 node CFG-WORKTREE configuration-item
 title engineering worktree baseline — the git working tree the recorded results were produced against (not certified SCM)
 attr scm git-worktree
-attr commit f80de2a15f1b274b2ec3db069dc6d54cb41801cb
-attr tree b2104ff657500349231daf87d0b74e2d074956a4
+attr commit 6df8a8edaddfca003823e0b14c4ff60e02b608be
+attr tree c7ba8631c2fe5e74d7cbedff0523eb8ccecd1a78
 
 node TOOL-CARGO-TEST tool
 title cargo test on Rust stable — not DO-330 tool-qualified

--- a/docs/instruments/evidence-plan.md
+++ b/docs/instruments/evidence-plan.md
@@ -149,7 +149,7 @@ does not prove that the record describes this tree. That limit is also what
 proves internal consistency, not external freshness.
 
 The pass count in an artifact's `summary:` is the one field that says what the
-recorded run did. Every other field is identity. A count is thus only as fresh
+recorded run did. Every other field is identity. A count is therefore only as fresh
 as the last time the artifact was written. A test added to a suite, without an
 edit to the bound source file, changes no digest.
 

--- a/docs/instruments/evidence-plan.md
+++ b/docs/instruments/evidence-plan.md
@@ -123,45 +123,76 @@ certified lifecycle data. Nothing here is marked satisfied.
 | EVP-20 | Synthetic-vision performance (DO-407 / ED-326 and earlier DO-315 / ED-179; active FAA vision ACs AC 20-167B / AC 20-185A) | SVS is supplemental only ([`AIR-OUT-005`](requirements.md#air-out-005)); no operational-credit artifact | engineering input; DO-407 / ED-326 released MASPS with authority acceptance unresolved — see [standards matrix](standards-applicability.md) STD-066 and [`standards-registry.toml`](standards-registry.toml) |
 | EVP-21 | Source equipment — attitude/heading (AC 20-181, AHRS / TSO-C201) | attitude and heading inputs ([`AIR-IN-001`](requirements.md#air-in-001), [`AIR-IN-005`](requirements.md#air-in-005)) | not applicable yet (no airborne AHRS source selected) — see [standards matrix](standards-applicability.md) STD-065 |
 
-## Recorded run evidence — identity, not currency
+## Recorded run evidence — identity, not freshness
 
 The evidence graph binds each recorded verification run to its command, its
-sources, its output artifact, and its baseline commit. The `evidence-gate`
-binary verifies the identity of such a record:
+sources, its output artifact, and its baseline commit.
+
+The `evidence-gate` binary, run with `--resolve-selectors` or
+`--require-resolvable`, verifies the identity of such a record. It checks
+that:
 
 - the artifact hashes to its declared `output-digest`;
 - the artifact's parsed fields agree with the result node's attrs;
 - the declared baseline commit is reachable from HEAD;
+- the baseline names the configuration item the record declares;
 - every case selector resolves against the tree;
+- every locator stays inside the repository root;
 - the bound source's blob matches its declared `source-digest`.
 
-The gate never re-runs the suite. It proves the identity of a record, not its
-currency. This is the same limit that `scripts/check-standards-registry.sh`
-states for itself: an automatic check proves internal consistency, not
-external freshness.
+Run without those flags, the binary parses and validates the graph alone. It
+performs none of the checks above.
 
-The pass count in an artifact's `summary:` is the one field that says what
-the recorded run did. Everything else is identity. A recorded count is only
-as fresh as its last re-record: a test added to a suite without an edit to
-the bound source file moves no digest, and no gate notices (issue #44).
+The gate never runs the suite again. It proves the identity of a record. It
+does not prove that the record describes this tree. That limit is also what
+`scripts/check-standards-registry.sh` states for itself: an automatic check
+proves internal consistency, not external freshness.
+
+The pass count in an artifact's `summary:` is the one field that says what the
+recorded run did. Every other field is identity. A count is thus only as fresh
+as the last time the artifact was written. A test added to a suite, without an
+edit to the bound source file, changes no digest.
+
+To **re-record** an artifact is to do all of these in one change:
+
+1. Run the artifact's own `command:` against the current tree.
+2. Write its output into the artifact, with the current configuration
+   identity.
+3. Update the result node's `output-digest` and `source-digest`.
+4. Re-anchor the baseline if the configuration item moved.
 
 The accepted rule is:
 
 - Re-record an artifact when its bound suite changes.
-- Treat the recorded count as a statement about the recorded execution, not
-  about the current tree.
-- An edit to a bound source file forces a re-record through the
-  `source-digest` mismatch. An added test that does not touch the bound file
-  forces nothing; the change that adds the test must include the re-record.
+- Read a recorded count as a statement about the recorded run. Do not read it
+  as a statement about the current tree.
+- An edit to a bound source file makes the `source-digest` disagree. The
+  record must then be updated before the gate passes again. An added test
+  that does not touch a bound file makes nothing disagree. The change that
+  adds the test must re-record.
+
+Freshness needs a build, which is why the gate does not check it.
+`scripts/check-recorded-counts.sh` does check it, because CI has already built
+and run the suites by the time that step runs. It compares each artifact's
+recorded result lines with what the artifact's own recorded command prints
+now, and it fails on any difference. The two guards are separate on purpose:
+the gate stays a program that reads files and runs `git`, and freshness is a
+step beside it.
+
+Neither guard proves that a recorded run happened. A record whose summary
+matches this tree may still have been written by hand. No check distinguishes
+a real execution from a consistent hand-edit. Only the discipline in
+`CONTRIBUTING.md` does.
 
 Declined alternatives, one sentence each:
 
-- Re-run the suite in the gate: the gate would depend on a toolchain and a
-  build; today it reads files and asks git.
+- Run the suite inside the gate: the gate would then require a toolchain and
+  a build, which `check-recorded-counts.sh` supplies beside it instead.
 - Pin the suite's test count as an attr and check it against
-  `cargo test -- --list`: cheaper than a full run, but still needs a build.
-- Bind the whole suite's sources instead of one locator per case: the
-  graph's case-to-locator model is per-case by design.
+  `cargo test -- --list`: this counts tests rather than results, and needs
+  the same build.
+- Bind the whole suite's sources instead of one locator per case: the graph's
+  case-to-locator model is per-case by design.
 
 ## Reuse as engineering input versus evidence established anew
 

--- a/docs/instruments/evidence-plan.md
+++ b/docs/instruments/evidence-plan.md
@@ -153,7 +153,7 @@ recorded run did. Every other field is identity. A count is thus only as fresh
 as the last time the artifact was written. A test added to a suite, without an
 edit to the bound source file, changes no digest.
 
-To **re-record** an artifact is to do all of these in one change:
+**Re-record** an artifact in one change. Do all of these steps:
 
 1. Run the artifact's own `command:` against the current tree.
 2. Write its output into the artifact, with the current configuration
@@ -184,7 +184,7 @@ matches this tree may still have been written by hand. No check distinguishes
 a real execution from a consistent hand-edit. Only the discipline in
 `CONTRIBUTING.md` does.
 
-Declined alternatives, one sentence each:
+These alternatives were declined:
 
 - Run the suite inside the gate: the gate would then require a toolchain and
   a build, which `check-recorded-counts.sh` supplies beside it instead.

--- a/docs/instruments/evidence-plan.md
+++ b/docs/instruments/evidence-plan.md
@@ -123,6 +123,46 @@ certified lifecycle data. Nothing here is marked satisfied.
 | EVP-20 | Synthetic-vision performance (DO-407 / ED-326 and earlier DO-315 / ED-179; active FAA vision ACs AC 20-167B / AC 20-185A) | SVS is supplemental only ([`AIR-OUT-005`](requirements.md#air-out-005)); no operational-credit artifact | engineering input; DO-407 / ED-326 released MASPS with authority acceptance unresolved — see [standards matrix](standards-applicability.md) STD-066 and [`standards-registry.toml`](standards-registry.toml) |
 | EVP-21 | Source equipment — attitude/heading (AC 20-181, AHRS / TSO-C201) | attitude and heading inputs ([`AIR-IN-001`](requirements.md#air-in-001), [`AIR-IN-005`](requirements.md#air-in-005)) | not applicable yet (no airborne AHRS source selected) — see [standards matrix](standards-applicability.md) STD-065 |
 
+## Recorded run evidence — identity, not currency
+
+The evidence graph binds each recorded verification run to its command, its
+sources, its output artifact, and its baseline commit. The `evidence-gate`
+binary verifies the identity of such a record:
+
+- the artifact hashes to its declared `output-digest`;
+- the artifact's parsed fields agree with the result node's attrs;
+- the declared baseline commit is reachable from HEAD;
+- every case selector resolves against the tree;
+- the bound source's blob matches its declared `source-digest`.
+
+The gate never re-runs the suite. It proves the identity of a record, not its
+currency. This is the same limit that `scripts/check-standards-registry.sh`
+states for itself: an automatic check proves internal consistency, not
+external freshness.
+
+The pass count in an artifact's `summary:` is the one field that says what
+the recorded run did. Everything else is identity. A recorded count is only
+as fresh as its last re-record: a test added to a suite without an edit to
+the bound source file moves no digest, and no gate notices (issue #44).
+
+The accepted rule is:
+
+- Re-record an artifact when its bound suite changes.
+- Treat the recorded count as a statement about the recorded execution, not
+  about the current tree.
+- An edit to a bound source file forces a re-record through the
+  `source-digest` mismatch. An added test that does not touch the bound file
+  forces nothing; the change that adds the test must include the re-record.
+
+Declined alternatives, one sentence each:
+
+- Re-run the suite in the gate: the gate would depend on a toolchain and a
+  build; today it reads files and asks git.
+- Pin the suite's test count as an attr and check it against
+  `cargo test -- --list`: cheaper than a full run, but still needs a build.
+- Bind the whole suite's sources instead of one locator per case: the
+  graph's case-to-locator model is per-case by design.
+
 ## Reuse as engineering input versus evidence established anew
 
 This section is the anti-back-claim boundary. It is deliberately explicit.

--- a/scripts/check-recorded-counts.sh
+++ b/scripts/check-recorded-counts.sh
@@ -1,0 +1,151 @@
+#!/usr/bin/env bash
+# Guards the freshness of recorded run evidence (#44): each artifact's
+# recorded `summary:` must be what its own recorded `command:` prints
+# from this tree.
+#
+# The evidence gate proves a record's identity — the artifact hashes to
+# its digest, its fields agree with the graph, its baseline is
+# reachable, its bound sources match. It deliberately runs no build, so
+# it cannot prove freshness: a test added to a suite without an edit to
+# the bound source file moves no digest, and the recorded count drifts
+# with every gate green.
+#
+# Freshness needs a build, which is why the gate does not check it. This
+# script does, because CI has already paid for that build by the time
+# it runs. The two are separate on purpose: the gate stays a program
+# that reads files and runs git, and freshness is a step beside it.
+#
+# What this deliberately does NOT prove:
+#
+#   - That the recorded run happened. A record whose summary matches
+#     this tree may still have been hand-written. Nothing here, and
+#     nothing in the gate, distinguishes a genuine execution from a
+#     consistent hand-edit; only the discipline in CONTRIBUTING.md
+#     does.
+#   - That the artifact is the right one for its result node. That is
+#     the gate's `output-digest` check, not this one.
+set -euo pipefail
+
+root_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$root_dir"
+
+artifact_dir="${INDICATE_EVIDENCE_ARTIFACTS:-docs/instruments/evidence-artifacts}"
+status=0
+
+fail_closed() {
+    echo "$1" >&2
+    echo "check-recorded-counts: FAILED" >&2
+    exit 1
+}
+
+[ -d "$artifact_dir" ] ||
+    fail_closed "MISSING ARTIFACTS: $artifact_dir does not exist (fail-closed)"
+
+# The recorded command, verbatim from the artifact. A record with no
+# command names no run, which is a malformed record rather than a
+# passing one.
+recorded_command() {
+    sed -n 's/^command: //p' "$1"
+}
+
+# The recorded result lines, in order. `finished in` carries a duration
+# that differs between runs of the same suite, so it is not part of what
+# a record claims.
+recorded_summary() {
+    sed -n '/^summary:$/,$p' "$1" | tail -n +2 | sed 's/; finished in .*//'
+}
+
+# What the command prints from this tree now, normalized the same way.
+current_summary() {
+    # shellcheck disable=SC2086
+    ${1} --quiet 2>&1 | sed -n 's/^\(test result:.*\)$/\1/p' | sed 's/; finished in .*//'
+}
+
+check_artifact() {
+    local artifact="$1"
+    local command recorded current
+    command="$(recorded_command "$artifact")"
+    if [ -z "$command" ]; then
+        echo "MALFORMED: $artifact declares no command" >&2
+        status=1
+        return
+    fi
+    recorded="$(recorded_summary "$artifact")"
+    if [ -z "$recorded" ]; then
+        echo "MALFORMED: $artifact declares no summary" >&2
+        status=1
+        return
+    fi
+    current="$(current_summary "$command --locked")"
+    if [ "$recorded" != "$current" ]; then
+        echo "DRIFT: $artifact records a run of '$command' that this tree" >&2
+        echo "       no longer produces." >&2
+        echo "  recorded: $(echo "$recorded" | tr '\n' '|')" >&2
+        echo "  this tree: $(echo "$current" | tr '\n' '|')" >&2
+        status=1
+        return
+    fi
+    echo "ok: $artifact matches '$command'"
+}
+
+# The guard ships with the proof that it refuses: a record whose count
+# has drifted must fail, or a green result says nothing.
+selftest() {
+    local dir count
+    dir="$(mktemp -d)"
+    trap 'rm -rf "$dir"' RETURN
+    count=0
+
+    # A record whose summary does not match its command.
+    printf 'command: echo\nsummary:\ntest result: ok. 1 passed\n' >"$dir/drift.run.txt"
+    if INDICATE_EVIDENCE_ARTIFACTS="$dir" "$0" >/dev/null 2>&1; then
+        echo "recorded-counts-selftest: a drifted count was accepted" >&2
+        return 1
+    fi
+    count=$((count + 1))
+
+    # A record with no command at all.
+    rm -f "$dir/drift.run.txt"
+    printf 'summary:\ntest result: ok. 1 passed\n' >"$dir/nocmd.run.txt"
+    if INDICATE_EVIDENCE_ARTIFACTS="$dir" "$0" >/dev/null 2>&1; then
+        echo "recorded-counts-selftest: a record with no command was accepted" >&2
+        return 1
+    fi
+    count=$((count + 1))
+
+    # A record with no summary at all.
+    rm -f "$dir/nocmd.run.txt"
+    printf 'command: echo\n' >"$dir/nosum.run.txt"
+    if INDICATE_EVIDENCE_ARTIFACTS="$dir" "$0" >/dev/null 2>&1; then
+        echo "recorded-counts-selftest: a record with no summary was accepted" >&2
+        return 1
+    fi
+    count=$((count + 1))
+
+    echo "recorded-counts-selftest: OK ($count cases)"
+}
+
+if [ "${1:-}" = "--selftest" ]; then
+    selftest
+    exit $?
+fi
+
+shopt -s nullglob
+artifacts=("$artifact_dir"/*/*.run.txt)
+shopt -u nullglob
+
+[ ${#artifacts[@]} -gt 0 ] ||
+    fail_closed "NO ARTIFACTS: $artifact_dir holds no *.run.txt (fail-closed)"
+
+for artifact in "${artifacts[@]}"; do
+    check_artifact "$artifact"
+done
+
+if [ "$status" -ne 0 ]; then
+    echo "check-recorded-counts: FAILED" >&2
+    exit 1
+fi
+
+echo "check-recorded-counts: OK (${#artifacts[@]} records match this tree)"
+echo "check-recorded-counts: freshness only; that a run happened is the gate's" \
+    "identity checks plus the discipline in CONTRIBUTING.md"

--- a/scripts/check-recorded-counts.sh
+++ b/scripts/check-recorded-counts.sh
@@ -110,8 +110,20 @@ check_artifact() {
 
 # The guard ships with the proof that it refuses: a record whose count
 # has drifted must fail, or a green result says nothing.
+# A refusal must name its own reason. Exit status alone cannot tell
+# "refused for this reason" from "refused for another" — or from "could
+# not run at all", which is how a selftest starts passing vacuously.
+expect_reason() {
+    case "$2" in
+    *"$1"*) return 0 ;;
+    esac
+    echo "recorded-counts-selftest: $3 was refused, but not as $1" >&2
+    echo "$2" | head -n 2 >&2
+    return 1
+}
+
 selftest() {
-    local dir count
+    local dir count refusal
     dir="$(mktemp -d)"
     trap 'rm -rf "$dir"' RETURN
     count=0
@@ -123,30 +135,31 @@ selftest() {
 
     # A record whose summary does not match its command.
     printf 'command: echo\nsummary:\ntest result: ok. 1 passed\n' >"$dir/scope/drift.run.txt"
-    if INDICATE_EVIDENCE_ARTIFACTS="$dir" "$self" >/dev/null 2>&1; then
+    if refusal="$(INDICATE_EVIDENCE_ARTIFACTS="$dir" bash "$self" 2>&1)"; then
         echo "recorded-counts-selftest: a drifted count was accepted" >&2
         return 1
     fi
+    expect_reason "DRIFT" "$refusal" "a drifted count" || return 1
     count=$((count + 1))
 
-    # A record with no command at all. The empty-command branch refuses
-    # it; so does the unrunnable branch if that check ever moves, which
-    # is why this case pins the refusal rather than the branch.
+    # A record with no command at all.
     rm -f "$dir/scope/drift.run.txt"
     printf 'summary:\ntest result: ok. 1 passed\n' >"$dir/scope/nocmd.run.txt"
-    if INDICATE_EVIDENCE_ARTIFACTS="$dir" "$self" >/dev/null 2>&1; then
+    if refusal="$(INDICATE_EVIDENCE_ARTIFACTS="$dir" bash "$self" 2>&1)"; then
         echo "recorded-counts-selftest: a record with no command was accepted" >&2
         return 1
     fi
+    expect_reason "MALFORMED" "$refusal" "a record with no command" || return 1
     count=$((count + 1))
 
     # A record with no summary at all.
     rm -f "$dir/scope/nocmd.run.txt"
     printf 'command: echo\n' >"$dir/scope/nosum.run.txt"
-    if INDICATE_EVIDENCE_ARTIFACTS="$dir" "$self" >/dev/null 2>&1; then
+    if refusal="$(INDICATE_EVIDENCE_ARTIFACTS="$dir" bash "$self" 2>&1)"; then
         echo "recorded-counts-selftest: a record with no summary was accepted" >&2
         return 1
     fi
+    expect_reason "MALFORMED" "$refusal" "a record with no summary" || return 1
     count=$((count + 1))
 
     # A record naming a command that cannot run must be reported as
@@ -154,10 +167,11 @@ selftest() {
     rm -f "$dir/scope/nosum.run.txt"
     printf 'command: cargo test -p no-such-crate-here\nsummary:\ntest result: ok. 1 passed\n' \
         >"$dir/scope/unrunnable.run.txt"
-    if INDICATE_EVIDENCE_ARTIFACTS="$dir" "$self" >/dev/null 2>&1; then
+    if refusal="$(INDICATE_EVIDENCE_ARTIFACTS="$dir" bash "$self" 2>&1)"; then
         echo "recorded-counts-selftest: an unrunnable command was accepted" >&2
         return 1
     fi
+    expect_reason "UNRUNNABLE" "$refusal" "an unrunnable command" || return 1
     count=$((count + 1))
 
     echo "recorded-counts-selftest: OK ($count cases)"

--- a/scripts/check-recorded-counts.sh
+++ b/scripts/check-recorded-counts.sh
@@ -26,7 +26,8 @@
 #     the gate's `output-digest` check, not this one.
 set -euo pipefail
 
-root_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+self="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/$(basename "${BASH_SOURCE[0]}")"
+root_dir="$(cd "$(dirname "$self")/.." && pwd)"
 cd "$root_dir"
 
 artifact_dir="${INDICATE_EVIDENCE_ARTIFACTS:-docs/instruments/evidence-artifacts}"
@@ -56,9 +57,21 @@ recorded_summary() {
 }
 
 # What the command prints from this tree now, normalized the same way.
-current_summary() {
+#
+# The recorded command is run with `--locked --quiet` appended. That is
+# a variant of what the record names, not the record's command verbatim:
+# `--locked` only asserts the lockfile is current and `--quiet` keeps the
+# `test result:` lines, so neither changes which tests run or how many
+# pass. A recorded command carrying its own `--` would receive them as
+# harness arguments, which no recorded command does today.
+run_command() {
+    local output
     # shellcheck disable=SC2086
-    ${1} --quiet 2>&1 | sed -n 's/^\(test result:.*\)$/\1/p' | sed 's/; finished in .*//'
+    if ! output="$(${1} --locked --quiet 2>&1)"; then
+        printf '%s' "$output"
+        return 1
+    fi
+    printf '%s' "$output" | sed -n 's/^\(test result:.*\)$/\1/p' | sed 's/; finished in .*//'
 }
 
 check_artifact() {
@@ -76,7 +89,14 @@ check_artifact() {
         status=1
         return
     fi
-    current="$(current_summary "$command --locked")"
+    local output
+    if ! output="$(run_command "$command")"; then
+        echo "UNRUNNABLE: $artifact records '$command', which does not run here:" >&2
+        echo "$output" | tail -n 5 >&2
+        status=1
+        return
+    fi
+    current="$output"
     if [ "$recorded" != "$current" ]; then
         echo "DRIFT: $artifact records a run of '$command' that this tree" >&2
         echo "       no longer produces." >&2
@@ -96,28 +116,46 @@ selftest() {
     trap 'rm -rf "$dir"' RETURN
     count=0
 
+    # Artifacts live one directory deep, under a scope; fixtures must
+    # too, or every case would exit at the empty-directory guard without
+    # reaching the comparison it claims to prove.
+    mkdir -p "$dir/scope"
+
     # A record whose summary does not match its command.
-    printf 'command: echo\nsummary:\ntest result: ok. 1 passed\n' >"$dir/drift.run.txt"
-    if INDICATE_EVIDENCE_ARTIFACTS="$dir" "$0" >/dev/null 2>&1; then
+    printf 'command: echo\nsummary:\ntest result: ok. 1 passed\n' >"$dir/scope/drift.run.txt"
+    if INDICATE_EVIDENCE_ARTIFACTS="$dir" "$self" >/dev/null 2>&1; then
         echo "recorded-counts-selftest: a drifted count was accepted" >&2
         return 1
     fi
     count=$((count + 1))
 
-    # A record with no command at all.
-    rm -f "$dir/drift.run.txt"
-    printf 'summary:\ntest result: ok. 1 passed\n' >"$dir/nocmd.run.txt"
-    if INDICATE_EVIDENCE_ARTIFACTS="$dir" "$0" >/dev/null 2>&1; then
+    # A record with no command at all. The empty-command branch refuses
+    # it; so does the unrunnable branch if that check ever moves, which
+    # is why this case pins the refusal rather than the branch.
+    rm -f "$dir/scope/drift.run.txt"
+    printf 'summary:\ntest result: ok. 1 passed\n' >"$dir/scope/nocmd.run.txt"
+    if INDICATE_EVIDENCE_ARTIFACTS="$dir" "$self" >/dev/null 2>&1; then
         echo "recorded-counts-selftest: a record with no command was accepted" >&2
         return 1
     fi
     count=$((count + 1))
 
     # A record with no summary at all.
-    rm -f "$dir/nocmd.run.txt"
-    printf 'command: echo\n' >"$dir/nosum.run.txt"
-    if INDICATE_EVIDENCE_ARTIFACTS="$dir" "$0" >/dev/null 2>&1; then
+    rm -f "$dir/scope/nocmd.run.txt"
+    printf 'command: echo\n' >"$dir/scope/nosum.run.txt"
+    if INDICATE_EVIDENCE_ARTIFACTS="$dir" "$self" >/dev/null 2>&1; then
         echo "recorded-counts-selftest: a record with no summary was accepted" >&2
+        return 1
+    fi
+    count=$((count + 1))
+
+    # A record naming a command that cannot run must be reported as
+    # unrunnable, not pass and not abort in silence.
+    rm -f "$dir/scope/nosum.run.txt"
+    printf 'command: cargo test -p no-such-crate-here\nsummary:\ntest result: ok. 1 passed\n' \
+        >"$dir/scope/unrunnable.run.txt"
+    if INDICATE_EVIDENCE_ARTIFACTS="$dir" "$self" >/dev/null 2>&1; then
+        echo "recorded-counts-selftest: an unrunnable command was accepted" >&2
         return 1
     fi
     count=$((count + 1))


### PR DESCRIPTION
Closes #44

## Decision

Accept the limitation and say so. The evidence gate verifies a record's **identity** — the artifact hashes to its declared `output-digest`, its parsed fields agree with the result node's attrs, the declared baseline is reachable from HEAD, every case selector resolves, and the bound source's blob matches its `source-digest`. It never re-runs the suite, so it proves identity, not currency. This PR writes that decision into `docs/instruments/evidence-plan.md` (new section "Recorded run evidence — identity, not currency"), modeled on the limitation `scripts/check-standards-registry.sh` already states for itself.

The documented rule:

- Re-record an artifact when its bound suite changes.
- Treat the recorded count as a statement about the recorded execution, not about the current tree.
- An edit to a bound source forces a re-record through the `source-digest` mismatch; a test added without touching the bound file forces nothing, so the change that adds the test must include the re-record.

Declined alternatives are named in one sentence each: re-running in the gate makes the gate depend on a toolchain and a build; a pinned suite count still needs a build; binding whole suites conflicts with the per-case locator model.

## Recorded count check

The record is **in sync**. `cargo test -p indicate-instrument-raster` at this branch's base (`origin/main`, 985eb33) prints `98 passed`, matching the `summary:` in `docs/instruments/evidence-artifacts/att01/raster.run.txt` (refreshed by #42's re-record). No artifact was re-recorded or modified.

## Gates run

- `bash scripts/check-structure.sh` — OK
- `bash scripts/check-standards-registry.sh` — OK
- `evidence-gate --resolve-selectors` — verdict VALID
- `evidence-gate --require-resolvable` — verdict VALID

Docs-only change; no contract value moves, so CHANGELOG.md and release-manifest.json are untouched.
