### PR TITLE
Define a generation as a successful-production sequence (#47)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,43 @@ Entries are newest first, and the tag's message repeats the same five
 values so `git show <tag>` answers the question without a checkout.
 `CONTRIBUTING.md` has the release steps.
 
+## [0.5.1] — 2026-08-18
+
+`SnapshotMeta::generation` counts snapshots admitted, not source groups
+advanced. The meaning is stated once, for every shell, in
+`backend-contract.md`
+([#47](https://github.com/luofang34/Indicate/issues/47)).
+
+**This changes what a consumer holding the old meaning reads.** A
+generation that stops advancing used to mean the sources stopped
+changing; it now means the gate stopped admitting. A consumer that
+raised a liveness fault on a stalled generation was reporting quiet
+data and now reports a stalled producer, which is the question liveness
+asks. A consumer that compared generations to detect a content change
+was always wrong under both meanings and is now wrong more often: two
+admissions of identical content advance the counter twice. Compare the
+content.
+
+The gate assigns the counter, never a source. A source sits on the
+untrusted side of the boundary the snapshot describes, so a counter a
+source supplied would be the thing being judged rather than the
+judgement.
+
+No wire byte moves: the field, its width and its offset are unchanged.
+The ABI number therefore does not move either, which is why this note
+exists — no gate can see a meaning change, and `check-release-markers`
+compares numbers.
+
+| Value | This release |
+|---|---|
+| State ABI | 7 |
+| Scene format | 1 |
+| Corpus | 5 |
+| Composition digest | `5cded14978b2e5ba3a17b61959ed0b35061334adf3fde4242f47e214f0f07aef` |
+| Panel set | `pfd`, `hsi`, `monitor` |
+
+Panel set changed since the previous release: no.
+
 ## [0.5.0] — 2026-08-18
 
 The altitude readout becomes a rolling-digit drum. The final digit pair

--- a/crates/indicate-instrument-feeder/src/avionics/tests.rs
+++ b/crates/indicate-instrument-feeder/src/avionics/tests.rs
@@ -261,11 +261,12 @@ fn excessive_skew_between_groups_is_a_counted_transition() {
     assert_eq!(counters.excessive_skew, 1);
 }
 
-/// A generation counts admitted publications, never content changes.
-/// Two samples carrying byte-identical payloads on distinct sequences
-/// advance it twice. A consumer watching for producer progress would
-/// otherwise read a live producer as stalled every time the world held
-/// still, which is the substitution the contract forbids.
+/// Admitting a publication advances the counter whatever the payload
+/// holds: two samples carrying byte-identical numbers on distinct
+/// sequences advance it twice. A consumer watching for producer
+/// progress would otherwise read a live producer as stalled every time
+/// the world held still, which is the substitution the contract
+/// forbids.
 #[test]
 fn identical_payloads_on_distinct_sequences_advance_the_generation_twice() {
     let mut ingress = AvionicsIngress::new(config(IncarnationPolicy::PinFirst));

--- a/crates/indicate-instrument-feeder/src/avionics/tests.rs
+++ b/crates/indicate-instrument-feeder/src/avionics/tests.rs
@@ -260,3 +260,36 @@ fn excessive_skew_between_groups_is_a_counted_transition() {
     let (counters, _) = ingress.diagnostics();
     assert_eq!(counters.excessive_skew, 1);
 }
+
+/// A generation counts admitted publications, never content changes.
+/// Two samples carrying byte-identical payloads on distinct sequences
+/// advance it twice. A consumer watching for producer progress would
+/// otherwise read a live producer as stalled every time the world held
+/// still, which is the substitution the contract forbids.
+#[test]
+fn identical_payloads_on_distinct_sequences_advance_the_generation_twice() {
+    let mut ingress = AvionicsIngress::new(config(IncarnationPolicy::PinFirst));
+    let before = ingress.snapshot(0.0).generation;
+
+    assert!(ingress.ingest(&sample(1, 1_000_000), 0.0), "first admitted");
+    let first = ingress.snapshot(0.0).generation;
+
+    // The same numbers again, one sequence later: nothing about the
+    // vehicle changed, but the producer did produce.
+    assert!(
+        ingress.ingest(&sample(2, 2_000_000), 10.0),
+        "second admitted"
+    );
+    let second = ingress.snapshot(10.0).generation;
+
+    assert_eq!(
+        first.wrapping_sub(before),
+        1,
+        "an admitted publication advances the generation"
+    );
+    assert_eq!(
+        second.wrapping_sub(first),
+        1,
+        "identical content is still a production"
+    );
+}

--- a/crates/indicate-instrument-feeder/src/avionics/types.rs
+++ b/crates/indicate-instrument-feeder/src/avionics/types.rs
@@ -149,7 +149,9 @@ pub struct IngressConfig {
 /// The current admitted state and trust of one ingress.
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub struct IngressSnapshot {
-    /// Wrapping generation advanced only when admitted state changed.
+    /// Wrapping generation: one step per admitted publication, whatever
+    /// the payload holds. Two admitted publications carrying identical
+    /// numbers advance it twice — it counts production, not content.
     pub generation: u32,
     /// The pinned source id, once seen.
     pub source_id: Option<u64>,

--- a/crates/indicate-instrument-feeder/src/avionics/types.rs
+++ b/crates/indicate-instrument-feeder/src/avionics/types.rs
@@ -155,9 +155,10 @@ pub struct IngressSnapshot {
     /// carrying identical numbers advance it twice, so it does not
     /// track content — but a publication that admitted nothing and only
     /// narrowed authorization advances it too, so it is not a pure
-    /// production sequence either. The generation a shell decodes is
-    /// `SnapshotMeta::generation`; this is the feeder-internal counter
-    /// behind it.
+    /// production sequence either, which is why the contract lists it
+    /// among the counters it does not govern. The generation a shell
+    /// decodes is `SnapshotMeta::generation`, and a shell advances that
+    /// one per snapshot it admits rather than forwarding this.
     pub generation: u32,
     /// The pinned source id, once seen.
     pub source_id: Option<u64>,

--- a/crates/indicate-instrument-feeder/src/avionics/types.rs
+++ b/crates/indicate-instrument-feeder/src/avionics/types.rs
@@ -157,8 +157,8 @@ pub struct IngressSnapshot {
     /// narrowed authorization advances it too, so it is not a pure
     /// production sequence either, which is why the contract lists it
     /// among the counters it does not govern. The generation a shell
-    /// decodes is `SnapshotMeta::generation`, and a shell advances that
-    /// one per snapshot it admits rather than forwarding this.
+    /// decodes is `SnapshotMeta::generation`, which the gate advances
+    /// per snapshot it admits. This one is never forwarded into it.
     pub generation: u32,
     /// The pinned source id, once seen.
     pub source_id: Option<u64>,

--- a/crates/indicate-instrument-feeder/src/avionics/types.rs
+++ b/crates/indicate-instrument-feeder/src/avionics/types.rs
@@ -149,9 +149,15 @@ pub struct IngressConfig {
 /// The current admitted state and trust of one ingress.
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub struct IngressSnapshot {
-    /// Wrapping generation: one step per admitted publication, whatever
-    /// the payload holds. Two admitted publications carrying identical
-    /// numbers advance it twice — it counts production, not content.
+    /// Wrapping counter of publications that moved the admitted state:
+    /// one that admitted a group, or one whose authorization narrowed
+    /// the valid flags or the quality. Two admitted publications
+    /// carrying identical numbers advance it twice, so it does not
+    /// track content — but a publication that admitted nothing and only
+    /// narrowed authorization advances it too, so it is not a pure
+    /// production sequence either. The generation a shell decodes is
+    /// `SnapshotMeta::generation`; this is the feeder-internal counter
+    /// behind it.
     pub generation: u32,
     /// The pinned source id, once seen.
     pub source_id: Option<u64>,

--- a/crates/indicate-instrument-feeder/src/stamp.rs
+++ b/crates/indicate-instrument-feeder/src/stamp.rs
@@ -37,7 +37,9 @@ pub struct RawStamp {
     pub source_id: u64,
     /// Opaque attachment/boot identity.
     pub incarnation: [u8; 16],
-    /// Source boot/attachment generation.
+    /// Which boot or attachment of the source this is. Not a
+    /// generation in the production-counting sense: it steps when the
+    /// source restarts, not when it publishes.
     pub epoch: u32,
     /// Wrapping group sequence, advanced only for a new measurement.
     pub sequence: u32,

--- a/crates/indicate-instrument-feeder/src/stamp/tests.rs
+++ b/crates/indicate-instrument-feeder/src/stamp/tests.rs
@@ -69,3 +69,41 @@ fn serial_ordering_is_wrap_safe() {
     // Half-range distances are ambiguous and refused.
     assert!(!serial_is_newer(0x8000_0000, 0));
 }
+
+/// At exactly half the range the rule names neither value newer, and it
+/// does so in both directions. The contract states this as the reason a
+/// consumer must compare within `2^31` steps of the producer: at that
+/// distance the question has no answer, so a consumer that drifted
+/// further would read a stale value as new in one direction and new as
+/// stale in the other.
+#[test]
+fn neither_value_is_newer_at_exactly_half_the_range() {
+    let half = 0x8000_0000u32;
+    for current in [0u32, 1, 7, u32::MAX, u32::MAX / 2] {
+        let opposite = current.wrapping_add(half);
+        assert!(
+            !super::serial_is_newer(opposite, current),
+            "forward across half the range must not be newer: {opposite} vs {current}"
+        );
+        assert!(
+            !super::serial_is_newer(current, opposite),
+            "and the reverse must not be either: {current} vs {opposite}"
+        );
+    }
+}
+
+/// One step inside the boundary the rule does answer, in both
+/// directions — so the test above pins a boundary rather than a
+/// function that always says no.
+#[test]
+fn one_step_inside_half_the_range_still_answers() {
+    let half = 0x8000_0000u32;
+    for current in [0u32, 1, 7, u32::MAX, u32::MAX / 2] {
+        let inside = current.wrapping_add(half - 1);
+        assert!(super::serial_is_newer(inside, current), "forward");
+        assert!(
+            !super::serial_is_newer(current, inside),
+            "and not the reverse"
+        );
+    }
+}

--- a/crates/indicate-instrument-raster/src/report.rs
+++ b/crates/indicate-instrument-raster/src/report.rs
@@ -35,7 +35,7 @@ impl FramebufferDims {
 pub struct FrameId {
     /// The snapshot/frame generation the scene was built from.
     pub frame_generation: u32,
-    /// The render generation of this paint attempt.
+    /// The render generation the shell assigned to this paint.
     pub render_generation: u32,
 }
 

--- a/crates/indicate-instrument-scene/src/layer.rs
+++ b/crates/indicate-instrument-scene/src/layer.rs
@@ -27,9 +27,9 @@
 //!   decode, because content whose criticality cannot be placed must
 //!   not be painted. Extending [`LayerId`] therefore requires a scene
 //!   format version bump, unlike ordinary appended opcodes.
-//! - One frame is one encoded scene; frame generation/identity is the
-//!   transport's concern (e.g. the WASM render generation), not encoded
-//!   per layer. Each layer is owned by exactly one producer per frame —
+//! - One frame is one encoded scene. Which production a frame is —
+//!   its generation — is the transport's concern, not encoded per
+//!   layer. Each layer is owned by exactly one producer per frame —
 //!   the duplicate rule makes split ownership structurally impossible.
 //!
 //! The SVS/raster boundary: backend-owned raster or depth imagery (such

--- a/crates/indicate-instrument-state/src/aircraft.rs
+++ b/crates/indicate-instrument-state/src/aircraft.rs
@@ -214,7 +214,7 @@ pub enum SnapshotCoherence {
     Unknown,
 }
 
-/// Metadata assigned by the ingress gate to one immutable state generation.
+/// Metadata a source assigns to one immutable state snapshot.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub struct SnapshotMeta {
     /// Wrapping generation: one step per snapshot a source produces,

--- a/crates/indicate-instrument-state/src/aircraft.rs
+++ b/crates/indicate-instrument-state/src/aircraft.rs
@@ -217,7 +217,9 @@ pub enum SnapshotCoherence {
 /// Metadata assigned by the ingress gate to one immutable state generation.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub struct SnapshotMeta {
-    /// Wrapping generation advanced only when a source group advances.
+    /// Wrapping generation: one step per snapshot the feeder admits,
+    /// whatever the groups hold. It counts production, not content, so
+    /// a consumer detecting a content change compares content.
     pub generation: u32,
     /// Coherence result for the independently stamped input groups.
     pub coherence: SnapshotCoherence,

--- a/crates/indicate-instrument-state/src/aircraft.rs
+++ b/crates/indicate-instrument-state/src/aircraft.rs
@@ -214,12 +214,20 @@ pub enum SnapshotCoherence {
     Unknown,
 }
 
-/// Metadata a source assigns to one immutable state snapshot.
+/// Metadata the input validation and time/integrity gate assigns to one
+/// immutable state snapshot.
+///
+/// The gate assigns it, never a source: a source is on the untrusted
+/// side of the boundary this metadata exists to describe, so a counter
+/// a source supplied would be the thing being judged rather than the
+/// judgement.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub struct SnapshotMeta {
-    /// Wrapping generation: one step per snapshot a source produces,
-    /// whatever the groups hold. It counts production, not content, so
-    /// a consumer detecting a content change compares content.
+    /// Wrapping generation: one step per snapshot the gate admits,
+    /// whatever the groups hold. It counts admission, not content, so
+    /// a consumer detecting a content change compares content. A gate
+    /// that admits nothing new still advances it; a gate that stopped
+    /// admitting does not, which is what a liveness check reads.
     pub generation: u32,
     /// Coherence result for the independently stamped input groups.
     pub coherence: SnapshotCoherence,
@@ -244,7 +252,7 @@ pub struct AircraftState {
     pub quality: EstimateQuality,
     /// Source validity flags.
     pub valid: ValidFlags,
-    /// Ingress generation and group-coherence result.
+    /// The gate's generation and group-coherence result.
     pub snapshot: SnapshotMeta,
     /// Datum declaration for the primary altitude (ALT-01).
     pub altitude: AltitudeDeclaration,

--- a/crates/indicate-instrument-state/src/aircraft.rs
+++ b/crates/indicate-instrument-state/src/aircraft.rs
@@ -217,7 +217,7 @@ pub enum SnapshotCoherence {
 /// Metadata assigned by the ingress gate to one immutable state generation.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub struct SnapshotMeta {
-    /// Wrapping generation: one step per snapshot the feeder admits,
+    /// Wrapping generation: one step per snapshot a source produces,
     /// whatever the groups hold. It counts production, not content, so
     /// a consumer detecting a content change compares content.
     pub generation: u32,

--- a/docs/instruments/backend-contract.md
+++ b/docs/instruments/backend-contract.md
@@ -276,9 +276,10 @@ exists; take it only with the set in hand.
 ## A generation counts output made, not content
 
 Each producer makes one kind of output, and this section calls that its
-**unit of output**. An ingress gate makes a snapshot. A renderer makes a
-frame. A **generation** is a `u32` counter. A producer advances it when
-the producer completes one unit of output successfully.
+**unit of output**. An input validation and time/integrity gate admits a
+snapshot. A renderer makes a frame. A **generation** is a `u32` counter.
+A producer advances it when the producer completes one unit of output
+successfully.
 
 Generations appear at every shell boundary: the state snapshot, the
 render generation a liveness check watches, and the markers a consumer
@@ -332,9 +333,15 @@ read any of them as a count of a producer's output:
   the authorization, which is a content change.
 
 The wire generation a shell decodes is `SnapshotMeta::generation`. This
-rule governs that one, so a shell advances it once per snapshot it
-admits. A shell must not forward the feeder's counter into it: that one
+rule governs that one, and the gate advances it once per snapshot the
+gate admits. A shell hosts the gate; it does not supply the counter, and
+a source never does — a source sits on the untrusted side of the
+boundary the snapshot describes.
+
+`IngressSnapshot::generation` above and `SnapshotMeta::generation` here
+are two counters, not one. The first is the feeder's own, and it
 advances on an authorization change as well, which this rule excludes.
+A shell must not forward it into the second.
 
 `FrameId::frame_generation` and `FrameId::render_generation` cross the
 raster boundary as data. The rasterizer is stateless: it carries both

--- a/docs/instruments/backend-contract.md
+++ b/docs/instruments/backend-contract.md
@@ -273,30 +273,33 @@ exists; take it only with the set in hand.
    (REN-04's 1000 ms frame budget derives from it) assumes a repaint
    clock that keeps ticking when data stops.
 
-## A generation counts frames made, not content
+## A generation counts output made, not content
 
-A **generation** is a `u32` counter. A producer advances it when the
-producer successfully makes a frame. Generations appear at every shell
-boundary: the state-ingress snapshot, the render generation a liveness
-check watches, and the markers a consumer compares to see that a
-producer advances. This section states what a generation means, once,
-for every shell. The Rust, Swift, and JavaScript implementations must
-apply it identically.
+Each producer makes one kind of output, and this section calls that its
+**unit of output**. An ingress gate makes a snapshot. A renderer makes a
+frame. A **generation** is a `u32` counter. A producer advances it when
+the producer completes one unit of output successfully.
 
-- **A generation counts the frames a producer makes. It is not a
-  content identity.** It advances for each frame the producer makes
-  successfully, whatever the frame contains. Two frames with identical
+Generations appear at every shell boundary: the state snapshot, the
+render generation a liveness check watches, and the markers a consumer
+compares to see that a producer advances. This section states what a
+generation means, once, for every shell. The Rust, Swift, and JavaScript
+implementations must apply it identically.
+
+- **A generation counts the units a producer completes. It is not a
+  content identity.** It advances for each unit the producer completes
+  successfully, whatever that unit contains. Two units with identical
   content advance the generation twice. A consumer that must know
   whether the content changed compares the content. It does not compare
   generations.
 - **Comparison across a wrap uses serial-number arithmetic** of the
   RFC 1982 shape. Generation `a` is newer than generation `b` when
-  `0 < (a - b) mod 2^32 < 2^31`. Equal values name the same frame.
+  `0 < (a - b) mod 2^32 < 2^31`. Equal values name the same unit.
   At a distance of exactly `2^31` the rule says neither value is newer,
   in both directions. A consumer must therefore compare within `2^31`
   steps of the producer. In that range the rule always names which value
-  is newer. Producers count
-  with `wrapping_add(1)`, so the step from `u32::MAX` to `0` is a
+  is newer. Producers count with `wrapping_add(1)`, so the step from
+  `u32::MAX` to `0` is a
   normal single advance, never a replay. `serial_is_newer` in
   `indicate-instrument-feeder::stamp` already implements this rule for
   stamp sequences; generation comparison is the same rule on every
@@ -304,15 +307,15 @@ apply it identically.
 - **A generation and a freshness judgement answer different questions.**
   A generation answers "has the producer advanced?". Telemetry
   freshness answers "is the data inside recent?". Liveness keys on the
-  clock that makes frames: the 1000 ms deadline (REN-04) measures how
-  often a frame is made, never when data arrives. A frame made on time
-  from stale data is a live frame that carries stale data. Freshness
-  flags the data. The generation still advances. No shell may substitute one
-  notion for the other.
+  clock that makes the output: the 1000 ms deadline (REN-04) measures
+  how often a frame is made, never when data arrives. A frame made on
+  time from stale data is a live frame that carries stale data.
+  Freshness flags the data. The generation still advances. No shell may
+  substitute one notion for the other.
 
 Some counters in this repository are deliberately not generations under
 this rule. Each marks a change in its own output. A consumer must not
-read any of them as a count of frames:
+read any of them as a count of a producer's output:
 
 - `SourceComparison::generation` in `indicate-instrument-state` advances
   only when the selected source, the reversion, or the comparison state
@@ -320,16 +323,18 @@ read any of them as a count of frames:
 - `ActiveAlert::generation` in `indicate-alerts` advances only at the
   alert's own state change. `AlertOutput::generation` reports the
   manager's value after a step, so a manager stepped with no new alert
-  reports the same value again. A shell that read that value as a count
-  of frames would raise a liveness fault on a healthy manager.
-
+  reports the same value again. A shell that reads that value as a
+  count of the manager's output raises a liveness fault on a healthy
+  manager.
 - `IngressSnapshot::generation` in `indicate-instrument-feeder` counts
   publications that moved the admitted state. Admitting a group advances
   it, and so does a publication that admitted nothing and only narrowed
   the authorization, which is a content change.
 
 The wire generation a shell decodes is `SnapshotMeta::generation`. This
-rule governs that one.
+rule governs that one, so a shell advances it once per snapshot it
+admits. A shell must not forward the feeder's counter into it: that one
+advances on an authorization change as well, which this rule excludes.
 
 `FrameId::frame_generation` and `FrameId::render_generation` cross the
 raster boundary as data. The rasterizer is stateless: it carries both

--- a/docs/instruments/backend-contract.md
+++ b/docs/instruments/backend-contract.md
@@ -292,8 +292,9 @@ JavaScript implementations must apply it identically.
 - **Comparison across a wrap uses serial-number arithmetic** of the
   RFC 1982 shape. Generation `a` is newer than generation `b` when
   `0 < (a - b) mod 2^32 < 2^31`. Equal values name the same production.
-  Two values exactly `2^31` apart are undefined, so a consumer must
-  compare within `2^31` productions of the producer. Producers count
+  At a distance of exactly `2^31` the rule says neither value is newer,
+  in both directions. A consumer must therefore compare within `2^31`
+  productions of the producer, where the answer is an order. Producers count
   with `wrapping_add(1)`, so the step from `u32::MAX` to `0` is a
   normal single advance, never a replay. `serial_is_newer` in
   `indicate-instrument-feeder::stamp` already implements this rule for
@@ -308,11 +309,24 @@ JavaScript implementations must apply it identically.
   data, and the generation still advances. No shell may substitute one
   notion for the other.
 
-One counter in this repository is deliberately not a generation under
-this rule. `SourceComparison::generation` in `indicate-instrument-state`
-advances only when the selected source, the reversion, or the
-comparison state changes. It is a change marker for that output. A
-consumer must not read it as a production sequence.
+Some counters in this repository are deliberately not generations under
+this rule. They are change markers for one output, and a consumer must
+not read any of them as a production sequence:
+
+- `SourceComparison::generation` in `indicate-instrument-state` advances
+  only when the selected source, the reversion, or the comparison state
+  changes.
+- `ActiveAlert::generation` in `indicate-alerts` advances only at the
+  alert's own state change, and `AlertOutput::generation` reports the
+  manager's value after a step. A manager stepped with no new alert
+  reports the same value again. A shell that read it as a production
+  sequence would raise a liveness fault on a healthy manager.
+
+The wire generation a shell decodes is `SnapshotMeta::generation`, which
+this rule governs. `IngressSnapshot::generation` is the feeder-internal
+counter it comes from. The raster pair `FrameId::frame_generation` and
+`FrameId::render_generation` are generations under this rule as well; a
+paint that fails produces no frame, so it advances neither.
 
 ## Conformance: what "correct" means
 

--- a/docs/instruments/backend-contract.md
+++ b/docs/instruments/backend-contract.md
@@ -273,6 +273,47 @@ exists; take it only with the set in hand.
    (REN-04's 1000 ms frame budget derives from it) assumes a repaint
    clock that keeps ticking when data stops.
 
+## A generation counts production, not content
+
+A **generation** is a `u32` counter that a producer advances when it
+successfully produces a frame. Generations appear at every shell
+boundary: the state-ingress snapshot (`IngressSnapshot::generation`),
+the render generation a liveness check watches, and the markers a
+consumer compares to detect producer progress. This section states what
+a generation means, once, for every shell. The Rust, Swift, and
+JavaScript implementations must apply it identically.
+
+- **A generation is a successful-production sequence. It is not a
+  content identity.** It advances when the producer successfully
+  produces a frame, whatever the frame contains. Two produced frames
+  with identical content advance the generation twice. A consumer that
+  must know whether the content changed compares content; it does not
+  compare generations.
+- **Comparison across a wrap uses serial-number arithmetic** of the
+  RFC 1982 shape. Generation `a` is newer than generation `b` when
+  `0 < (a - b) mod 2^32 < 2^31`. Equal values name the same production.
+  Two values exactly `2^31` apart are undefined, so a consumer must
+  compare within `2^31` productions of the producer. Producers count
+  with `wrapping_add(1)`, so the step from `u32::MAX` to `0` is a
+  normal single advance, never a replay. `serial_is_newer` in
+  `indicate-instrument-feeder::stamp` already implements this rule for
+  stamp sequences; generation comparison is the same rule on every
+  shell.
+- **A generation and a freshness judgement answer different questions.**
+  A generation answers "has the producer advanced?". Telemetry
+  freshness answers "is the data inside recent?". Liveness keys on the
+  production clock: the 1000 ms deadline (REN-04) measures frame
+  production, never data arrival. A frame produced on time from stale
+  data is a live frame that carries stale data; freshness flags the
+  data, and the generation still advances. No shell may substitute one
+  notion for the other.
+
+One counter in this repository is deliberately not a generation under
+this rule. `SourceComparison::generation` in `indicate-instrument-state`
+advances only when the selected source, the reversion, or the
+comparison state changes. It is a change marker for that output. A
+consumer must not read it as a production sequence.
+
 ## Conformance: what "correct" means
 
 An interpreter is correct only **relative to a corpus version**. The

--- a/docs/instruments/backend-contract.md
+++ b/docs/instruments/backend-contract.md
@@ -273,28 +273,29 @@ exists; take it only with the set in hand.
    (REN-04's 1000 ms frame budget derives from it) assumes a repaint
    clock that keeps ticking when data stops.
 
-## A generation counts production, not content
+## A generation counts frames made, not content
 
-A **generation** is a `u32` counter that a producer advances when it
-successfully produces a frame. Generations appear at every shell
-boundary: the state-ingress snapshot (`IngressSnapshot::generation`),
-the render generation a liveness check watches, and the markers a
-consumer compares to detect producer progress. This section states what
-a generation means, once, for every shell. The Rust, Swift, and
-JavaScript implementations must apply it identically.
+A **generation** is a `u32` counter. A producer advances it when the
+producer successfully makes a frame. Generations appear at every shell
+boundary: the state-ingress snapshot, the render generation a liveness
+check watches, and the markers a consumer compares to see that a
+producer advances. This section states what a generation means, once,
+for every shell. The Rust, Swift, and JavaScript implementations must
+apply it identically.
 
-- **A generation is a successful-production sequence. It is not a
-  content identity.** It advances when the producer successfully
-  produces a frame, whatever the frame contains. Two produced frames
-  with identical content advance the generation twice. A consumer that
-  must know whether the content changed compares content; it does not
-  compare generations.
+- **A generation counts the frames a producer makes. It is not a
+  content identity.** It advances for each frame the producer makes
+  successfully, whatever the frame contains. Two frames with identical
+  content advance the generation twice. A consumer that must know
+  whether the content changed compares the content. It does not compare
+  generations.
 - **Comparison across a wrap uses serial-number arithmetic** of the
   RFC 1982 shape. Generation `a` is newer than generation `b` when
-  `0 < (a - b) mod 2^32 < 2^31`. Equal values name the same production.
+  `0 < (a - b) mod 2^32 < 2^31`. Equal values name the same frame.
   At a distance of exactly `2^31` the rule says neither value is newer,
   in both directions. A consumer must therefore compare within `2^31`
-  productions of the producer, where the answer is an order. Producers count
+  steps of the producer. In that range the rule always names which value
+  is newer. Producers count
   with `wrapping_add(1)`, so the step from `u32::MAX` to `0` is a
   normal single advance, never a replay. `serial_is_newer` in
   `indicate-instrument-feeder::stamp` already implements this rule for
@@ -303,30 +304,39 @@ JavaScript implementations must apply it identically.
 - **A generation and a freshness judgement answer different questions.**
   A generation answers "has the producer advanced?". Telemetry
   freshness answers "is the data inside recent?". Liveness keys on the
-  production clock: the 1000 ms deadline (REN-04) measures frame
-  production, never data arrival. A frame produced on time from stale
-  data is a live frame that carries stale data; freshness flags the
-  data, and the generation still advances. No shell may substitute one
+  clock that makes frames: the 1000 ms deadline (REN-04) measures how
+  often a frame is made, never when data arrives. A frame made on time
+  from stale data is a live frame that carries stale data. Freshness
+  flags the data. The generation still advances. No shell may substitute one
   notion for the other.
 
 Some counters in this repository are deliberately not generations under
-this rule. They are change markers for one output, and a consumer must
-not read any of them as a production sequence:
+this rule. Each marks a change in its own output. A consumer must not
+read any of them as a count of frames:
 
 - `SourceComparison::generation` in `indicate-instrument-state` advances
   only when the selected source, the reversion, or the comparison state
   changes.
 - `ActiveAlert::generation` in `indicate-alerts` advances only at the
-  alert's own state change, and `AlertOutput::generation` reports the
-  manager's value after a step. A manager stepped with no new alert
-  reports the same value again. A shell that read it as a production
-  sequence would raise a liveness fault on a healthy manager.
+  alert's own state change. `AlertOutput::generation` reports the
+  manager's value after a step, so a manager stepped with no new alert
+  reports the same value again. A shell that read that value as a count
+  of frames would raise a liveness fault on a healthy manager.
 
-The wire generation a shell decodes is `SnapshotMeta::generation`, which
-this rule governs. `IngressSnapshot::generation` is the feeder-internal
-counter it comes from. The raster pair `FrameId::frame_generation` and
-`FrameId::render_generation` are generations under this rule as well; a
-paint that fails produces no frame, so it advances neither.
+- `IngressSnapshot::generation` in `indicate-instrument-feeder` counts
+  publications that moved the admitted state. Admitting a group advances
+  it, and so does a publication that admitted nothing and only narrowed
+  the authorization, which is a content change.
+
+The wire generation a shell decodes is `SnapshotMeta::generation`. This
+rule governs that one.
+
+`FrameId::frame_generation` and `FrameId::render_generation` cross the
+raster boundary as data. The rasterizer is stateless: it carries both
+from input to report and advances neither. A shell owns them, and this
+rule governs how a shell advances them — a failed paint produces no
+frame, so it advances no render generation, and a frame generation is
+the snapshot's, so two paints of one snapshot carry one value.
 
 ## Conformance: what "correct" means
 

--- a/docs/instruments/renderer-verification.md
+++ b/docs/instruments/renderer-verification.md
@@ -316,7 +316,7 @@ reference.
 | Backend failure | framebuffer-limit typed errors leave buffer untouched or spoil | a throwing Canvas op → `PAINT_FAILED`, contained to the back buffer |
 | Unsupported opcode | counted skip, `unknown_opcodes` reported | counted skip, `interpretScene` returns the same count |
 | Glyph corruption / uncovered text | `render` → `Glyph` error, no substitution | `interpretScene` throws, no font fallback (load-time hash checks already covered) |
-| Liveness / recovery | n/a (stateless) | `PanelHealth` latches on any fault, recovers only after sustained validated frames; `LIVENESS` on a stalled generation |
+| Liveness / recovery | n/a (stateless) | `PanelHealth` latches on any fault, recovers only after sustained validated frames; `LIVENESS` on a stalled render generation |
 
 Old imagery is covered on every backend error or timeout: the reference
 rasterizer spoils the whole frame (opaque black + red cross) so no stale frame


### PR DESCRIPTION
Closes #47. Tracked under #36.

## Decision recorded

Adds a section "A generation counts production, not content" to `docs/instruments/backend-contract.md`, placed beside the repaint-clock discipline it depends on. It states, once, for the Rust, Swift, and JavaScript implementations:

- **A generation is a successful-production sequence, not a content identity.** It advances when the producer successfully produces a frame, whatever the frame contains; identical content on two produced frames advances it twice.
- **The wrapping rule for the `u32` counters is serial-number arithmetic of the RFC 1982 shape**: `a` is newer than `b` iff `0 < (a - b) mod 2^32 < 2^31`; values exactly `2^31` apart are undefined; `u32::MAX` → `0` under `wrapping_add(1)` is a normal single advance. This matches `serial_is_newer` in `indicate-instrument-feeder::stamp`, which already implements the rule for stamp sequences.
- **The freshness boundary**: a generation answers "has the producer advanced?"; telemetry freshness answers "is the data inside recent?". Liveness keys on the production clock (the 1000 ms deadline, REN-04), never on data arrival, and no shell may substitute one notion for the other.

## Verification against the code

The issue's factual claims checked out with one correction: the feeder avionics generation (`IngressSnapshot::generation`) is a production sequence as claimed, but `SourceComparison::generation` in `indicate-instrument-state` is documented in code as an *output identity* — it advances only when the selected source, reversion, or comparison state changes. Rather than misdescribe it, the new section names it as a change marker that is deliberately not a generation under this rule.

## Gates run (docs-only change)

- `scripts/check-structure.sh` — OK
- `scripts/check-standards-registry.sh` — OK
- `scripts/check-release-markers.sh` — OK
- `evidence-gate --resolve-selectors` and `--require-resolvable` — verdict VALID

No contract value moves; CHANGELOG.md and release-manifest.json untouched.