### PR TITLE
Annunciate the CDI's nav source as text, not hue alone (#55)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,51 @@ Entries are newest first, and the tag's message repeats the same five
 values so `git show <tag>` answers the question without a checkout.
 `CONTRIBUTING.md` has the release steps.
 
+## [0.4.1] — 2026-08-18
+
+The HSI annunciates which receiver drives the CDI. The source was
+encoded as hue alone — magenta for GPS, green for a nav radio — so Nav1
+and Nav2 read identically, and the distinction failed under color-vision
+deficiency. The panel now draws `GPS` / `NAV1` / `NAV2` beside the rose
+in the source color, under the same gate as the CDI: the label and the
+needle appear and disappear in the same frame
+([#55](https://github.com/luofang34/Indicate/issues/55)).
+
+| Value | This release |
+|---|---|
+| State ABI | 7 |
+| Scene format | 1 |
+| Corpus | 4 |
+| Composition digest | `91767280cad68734f5859ad17edee1540bce47ec32866a0d784e1f30f34e4757` |
+| Panel set | `pfd`, `hsi`, `monitor` |
+
+Panel set changed since the previous release: no.
+
+### What moved and why
+
+- **The composition digest moved on paint and corpus, not on wire.**
+  The label adds a claimed text run to the HSI scene for every fed nav
+  source, and the shared corpus gains a `nav2-source` state so each of
+  the three sources is exercised. The state ABI, the scene format, and
+  the conformance corpus are byte-identical.
+- **The HSI raster baseline (REN-03) and the screen-composition digest
+  moved with it.** The label paints in the shared `typical` state, and
+  the screen digest hashes the composition digest beneath it. The
+  baseline re-pin names this change as its reason.
+- **The label claims the nav group.** Its numerals (`NAV1`, `NAV2`)
+  carry the provenance claim the honesty rules require, and a new HSI
+  group region declares the surface it paints on. A withheld or failed
+  nav group removes the label with the needle.
+
+### Notes for anyone re-pinning
+
+- Advance the composition digest, the screen-composition digest, and the
+  HSI raster baseline together. The PFD and monitor baselines, the
+  criticality bands, the glyph pack, and the corpus are unchanged.
+- Telling VOR from LOC needs the tuned facility type in state. That is a
+  Nav layout addition and belongs in the coordinated ABI batch, not in
+  this release.
+
 ## [0.4.0] — 2026-08-08
 
 The state ABI moves to v7: velocity validity splits into a horizontal

--- a/crates/indicate-instrument-conformance/src/admission/tests.rs
+++ b/crates/indicate-instrument-conformance/src/admission/tests.rs
@@ -11,10 +11,10 @@ use super::{admit, criticality_bands};
 fn builtin_panels_pass_admission() {
     let registry = Registry::new(BUILTIN_PANELS).expect("composes");
     let report = admit(&registry).expect("shipped panels must be admissible");
-    // PFD: (4 canonical + 3 extreme) states × (1 fed + 8 withheld);
-    // HSI: (4 + 2) × 8; monitor: 5 × 2 — each drawn twice, quiet and
+    // PFD: (5 canonical + 3 extreme) states × (1 fed + 8 withheld);
+    // HSI: (5 + 2) × 8; monitor: 6 × 2 — each drawn twice, quiet and
     // with the saturated alert stack.
-    assert_eq!(report.cases, 242);
+    assert_eq!(report.cases, 280);
     // Every warning is the PFD's groundspeed or baro readout: their
     // boxes are 90 units wide but a wide value at size 16 has ~107
     // units of nominal ink, so the run overhangs its box and the frame
@@ -26,7 +26,7 @@ fn builtin_panels_pass_admission() {
     // Twice the quiet-frame count, because the overhanging runs are the
     // groundspeed and baro readouts, which the alert stack does not
     // touch: each overhangs on both sides of the alert axis.
-    assert_eq!(report.warnings.len(), 166);
+    assert_eq!(report.warnings.len(), 196);
     assert!(report.warnings.iter().all(|w| matches!(
         w,
         super::AdmissionWarning::FrameOverflow { panel: "pfd", text, .. }

--- a/crates/indicate-instrument-descriptor/src/states.rs
+++ b/crates/indicate-instrument-descriptor/src/states.rs
@@ -212,9 +212,9 @@ pub fn source_unusable() -> AircraftState {
 }
 
 /// The second nav receiver selected. `typical` names GPS and
-/// `fully-fed` names Nav1; Nav2 wore Nav1's green with nothing telling
-/// the two apart until the HSI source label (#55), which this state
-/// exercises on every panel that draws nav guidance.
+/// `fully-fed` names Nav1; Nav2 shares Nav1's green, so only the
+/// receiver label tells the two apart. This state exercises that
+/// distinction on every panel that draws nav guidance.
 pub fn nav2_source() -> AircraftState {
     let mut state = typical();
     if let Some(nav) = state.nav.data.as_mut() {

--- a/crates/indicate-instrument-descriptor/src/states.rs
+++ b/crates/indicate-instrument-descriptor/src/states.rs
@@ -38,6 +38,10 @@ pub const CANONICAL_STATES: &[CanonicalState] = &[
         id: "source-unusable",
         build: source_unusable,
     },
+    CanonicalState {
+        id: "nav2-source",
+        build: nav2_source,
+    },
 ];
 
 /// Cold start: no group has ever been fed. Every signal must resolve
@@ -204,6 +208,18 @@ pub fn fully_fed() -> AircraftState {
 pub fn source_unusable() -> AircraftState {
     let mut state = typical();
     state.quality = EstimateQuality::Unusable;
+    state
+}
+
+/// The second nav receiver selected. `typical` names GPS and
+/// `fully-fed` names Nav1; Nav2 wore Nav1's green with nothing telling
+/// the two apart until the HSI source label (#55), which this state
+/// exercises on every panel that draws nav guidance.
+pub fn nav2_source() -> AircraftState {
+    let mut state = typical();
+    if let Some(nav) = state.nav.data.as_mut() {
+        nav.source = NavSource::Nav2;
+    }
     state
 }
 

--- a/crates/indicate-instrument-descriptor/src/states/tests.rs
+++ b/crates/indicate-instrument-descriptor/src/states/tests.rs
@@ -1,8 +1,8 @@
 #![allow(clippy::expect_used, clippy::panic)]
 
-use indicate_instrument_state::{EstimateQuality, GroupId};
+use indicate_instrument_state::{EstimateQuality, GroupId, NavSource};
 
-use super::{CANONICAL_STATES, fully_fed, nothing_fed, source_unusable, typical};
+use super::{CANONICAL_STATES, fully_fed, nav2_source, nothing_fed, source_unusable, typical};
 
 #[test]
 fn corpus_ids_are_unique_and_well_formed() {
@@ -48,6 +48,13 @@ fn the_corpus_spans_the_intended_situations() {
     let unusable = source_unusable();
     assert!(unusable.attitude.data.is_some());
     assert_eq!(unusable.quality, EstimateQuality::Unusable);
+    // Nav2 selected: every nav source the HSI labels is one the corpus
+    // names — GPS in `typical`, Nav1 in `fully-fed`, Nav2 here.
+    let second = nav2_source();
+    assert_eq!(
+        second.nav.data.expect("nav present").source,
+        NavSource::Nav2
+    );
 }
 
 #[test]

--- a/crates/indicate-instrument-raster/src/composition/tests.rs
+++ b/crates/indicate-instrument-raster/src/composition/tests.rs
@@ -30,7 +30,7 @@ use crate::{FrameId, FramebufferDims, RasterError, RenderStatus};
 ///
 /// Each covers a different composition shape, because placement, opaque
 /// overlap, and overlay show-through fail in different ways.
-const SIDE_BY_SIDE_HASH: &str = "ce6b4347e9ccc2e58447ebcad733a287ee4e98eca7c1b6d9f631267fe4430a16";
+const SIDE_BY_SIDE_HASH: &str = "85fe67ef367af5c96e44a69982e9236cd38f4e1c7ff1f826c0c0551ac99127df";
 const OPAQUE_INSET_HASH: &str = "3e9eeb272b232ba6f4be465aa7402ef0fb0b95a88233b2e6dfa0e8d05304b898";
 const OVERLAY_HASH: &str = "4a5cc9228d78bdbc72671e53ac8bfc03bfc30071aa19b43fa61e42e877089e19";
 

--- a/release-manifest.json
+++ b/release-manifest.json
@@ -9,7 +9,7 @@
     "version": 4,
     "sha256": "1fb8e6de2734ff7506843b05869f39d501f0926599636c6110a7e3b0c6e1625e"
   },
-  "compositionDigest": "f82d905643b48822de25665761ad3e29daa334d937f18b1e98a3e215353cb704",
+  "compositionDigest": "91767280cad68734f5859ad17edee1540bce47ec32866a0d784e1f30f34e4757",
   "screenComposition": {
     "fixture": "tools/instrument-bench",
     "screen": { "width": 960, "height": 720 },
@@ -18,11 +18,11 @@
       { "panel": "hsi", "x": 480, "y": 0, "width": 480, "height": 360 },
       { "panel": "monitor", "x": 0, "y": 360, "width": 480, "height": 360 }
     ],
-    "digest": "367ce939789975e7f548eea1e1a6fc41e8453e75e45d3acc397163f2ab1dcb2c"
+    "digest": "017b35a401208aebb5a5ceec975c71b8f103a92c1f02f5cc93edd13d3f29d9e3"
   },
   "rasterBaselines": [
     { "panel": "pfd", "frame": { "width": 480, "height": 360 }, "sha256": "43b49bde6bbf7372d704d54214d4a3d0b9cd3ad09e86862a8ffc20fd6ae05ef1" },
-    { "panel": "hsi", "frame": { "width": 480, "height": 360 }, "sha256": "66653ce135e6f2163fa48d805a0ab1a8f3d0ac51d778f7b1eb2aa4ec05bfbb7c" },
+    { "panel": "hsi", "frame": { "width": 480, "height": 360 }, "sha256": "efb15b50cb011c499c075b3eb54948d77a89b74b9e2321add75d8922f4b25b7b" },
     { "panel": "monitor", "frame": { "width": 480, "height": 360 }, "sha256": "40f44383f3ad46a0bbd65f04afc1d80fb9d94c11acff8dc66edbfcf7b8fa4c01" }
   ],
   "glyphPackHash": "281eef6229feee417c7090d8c8ea79489c017cd1c02fc7234876b2a64a532158",

--- a/sets/indicate-instrument-panels/src/descriptors.rs
+++ b/sets/indicate-instrument-panels/src/descriptors.rs
@@ -249,6 +249,18 @@ pub const HSI_DESCRIPTOR: PanelDescriptor = PanelDescriptor {
                 height: 36.0,
             },
         ),
+        // Nav-source label (GPS/NAV1/NAV2) beside the rose, above the
+        // course box: the receiver identity is a nav-group value, so its
+        // surface is declared like the readouts.
+        (
+            GroupId::Nav,
+            Region {
+                x: 36.0,
+                y: 288.0,
+                width: 48.0,
+                height: 24.0,
+            },
+        ),
         // Heading-select box.
         (
             GroupId::Selections,
@@ -283,7 +295,7 @@ pub const HSI_DESCRIPTOR: PanelDescriptor = PanelDescriptor {
     ],
     raster_baselines: &[(
         BUILTIN_FRAME,
-        "66653ce135e6f2163fa48d805a0ab1a8f3d0ac51d778f7b1eb2aa4ec05bfbb7c",
+        "efb15b50cb011c499c075b3eb54948d77a89b74b9e2321add75d8922f4b25b7b",
     )],
     draw: draw_hsi_panel,
 };
@@ -365,7 +377,7 @@ pub const BUILTIN_SET: PanelSet = PanelSet {
 /// value moves once per deliberate contract change, re-pinned with a
 /// review note saying why.
 pub const BUILTIN_SCENE_DIGEST: &str =
-    "f82d905643b48822de25665761ad3e29daa334d937f18b1e98a3e215353cb704";
+    "91767280cad68734f5859ad17edee1540bce47ec32866a0d784e1f30f34e4757";
 
 /// The measured criticality bands of [`BUILTIN_PANELS`], pinned beside
 /// the raster baselines: the union `Annunciation`/`Failure` ink bound

--- a/sets/indicate-instrument-panels/src/hsi.rs
+++ b/sets/indicate-instrument-panels/src/hsi.rs
@@ -85,10 +85,9 @@ pub fn draw_hsi(
         && data.nav.course_rose_rad.status.shows_value()
     {
         cdi::draw_cdi(scene, &data.nav, up_rad)?;
-        // The source label names the receiver driving the needle, under
-        // the needle's own gate, so the two appear and disappear in the
-        // same frame.
-        cdi::draw_source_label(scene, data.nav.data.source)?;
+        // The receiver label draws under the needle's own gate, so the
+        // two appear and disappear in the same frame.
+        cdi::draw_receiver_label(scene, data.nav.data.source)?;
     }
     boxes::vertical_deviation(scene, data)?;
     scene.end_layer(LayerId::Guidance)?;

--- a/sets/indicate-instrument-panels/src/hsi.rs
+++ b/sets/indicate-instrument-panels/src/hsi.rs
@@ -85,6 +85,10 @@ pub fn draw_hsi(
         && data.nav.course_rose_rad.status.shows_value()
     {
         cdi::draw_cdi(scene, &data.nav, up_rad)?;
+        // The source label names the receiver driving the needle, under
+        // the needle's own gate, so the two appear and disappear in the
+        // same frame.
+        cdi::draw_source_label(scene, data.nav.data.source)?;
     }
     boxes::vertical_deviation(scene, data)?;
     scene.end_layer(LayerId::Guidance)?;

--- a/sets/indicate-instrument-panels/src/hsi/cdi.rs
+++ b/sets/indicate-instrument-panels/src/hsi/cdi.rs
@@ -1,8 +1,8 @@
 //! The course deviation indicator: course arrow, deviation bar, scale
 //! dots, and TO/FROM triangle.
 
-use indicate_instrument_scene::{PaintMode, Rgba8, SceneError, SceneWriter};
-use indicate_instrument_state::{NavFromTo, NavResolved, NavSource};
+use indicate_instrument_scene::{Anchor, PaintMode, Rgba8, SceneError, SceneWriter};
+use indicate_instrument_state::{GroupId, NavFromTo, NavResolved, NavSource};
 
 use indicate_instrument_symbology::palette;
 
@@ -14,6 +14,49 @@ pub(crate) fn source_color(source: NavSource) -> Rgba8 {
         NavSource::Gps => palette::MAGENTA,
         _ => palette::GREEN,
     }
+}
+
+/// The receiver identity the CDI's hue alone used to carry (#55):
+/// `GPS` / `NAV1` / `NAV2`. Nav1 and Nav2 wear the same green, so the
+/// text is the distinction. The numerals make the run a claimed run —
+/// it derives from the nav group, so it claims `GroupId::Nav`, and the
+/// claim is honest exactly where the CDI gate is: a withheld or failed
+/// nav group never reaches this draw.
+pub(crate) fn source_text(source: NavSource) -> Option<&'static str> {
+    match source {
+        NavSource::Gps => Some("GPS"),
+        NavSource::Nav1 => Some("NAV1"),
+        NavSource::Nav2 => Some("NAV2"),
+        // No source is gated out by the caller; an unknown one fails the
+        // nav group in resolve. Neither may invent a label here.
+        NavSource::None | NavSource::Unknown => None,
+    }
+}
+
+/// The label position, lower left beside the rose: clear of the rose
+/// rim (the rim's nearest ink at this height is the 225° reference mark
+/// at x ≈ 121) and directly above the course box, whose value wears the
+/// same source color. The caller draws it under the CDI's exact gate,
+/// so the label and the needle appear and disappear together.
+const SOURCE_LABEL_POS: (f32, f32) = (60.0, super::CY + 110.0);
+
+/// Draws the nav-source label in the source color, claimed from the nav
+/// group. Draws nothing for `None`/`Unknown` — the caller's gate already
+/// excludes both, and this arm keeps that property local.
+pub fn draw_source_label(scene: &mut SceneWriter<'_>, source: NavSource) -> Result<(), SceneError> {
+    let Some(text) = source_text(source) else {
+        return Ok(());
+    };
+    scene.fill_color(source_color(source))?;
+    scene.text_attributed(
+        GroupId::Nav.to_u8(),
+        SOURCE_LABEL_POS.0,
+        SOURCE_LABEL_POS.1,
+        14.0,
+        Anchor::CENTER,
+        text,
+    )?;
+    Ok(())
 }
 
 /// Draws the CDI in the rose frame, rotated to the selected course.

--- a/sets/indicate-instrument-panels/src/hsi/cdi.rs
+++ b/sets/indicate-instrument-panels/src/hsi/cdi.rs
@@ -44,7 +44,8 @@ pub(crate) fn receiver_text(source: NavSource) -> Option<&'static str> {
 /// that growing the rose fails rather than overlapping the label.
 pub(crate) const RECEIVER_LABEL_POS: (f32, f32) = (60.0, super::CY + 110.0);
 
-/// Half the anchor box the label occupies, for the clearance test.
+/// The run size the label paints at. Named so the clearance test
+/// measures the box the label really occupies.
 pub(crate) const RECEIVER_LABEL_SIZE: f32 = 14.0;
 
 /// Draws the receiver label in the source color, claimed from the nav

--- a/sets/indicate-instrument-panels/src/hsi/cdi.rs
+++ b/sets/indicate-instrument-panels/src/hsi/cdi.rs
@@ -16,13 +16,18 @@ pub(crate) fn source_color(source: NavSource) -> Rgba8 {
     }
 }
 
-/// The receiver identity the CDI's hue alone used to carry (#55):
-/// `GPS` / `NAV1` / `NAV2`. Nav1 and Nav2 wear the same green, so the
-/// text is the distinction. The numerals make the run a claimed run —
-/// it derives from the nav group, so it claims `GroupId::Nav`, and the
-/// claim is honest exactly where the CDI gate is: a withheld or failed
-/// nav group never reaches this draw.
-pub(crate) fn source_text(source: NavSource) -> Option<&'static str> {
+/// Which receiver drives the needle: `GPS` / `NAV1` / `NAV2`. Nav1 and
+/// Nav2 wear the same green, so the text is the only thing that tells
+/// them apart. The numerals make this a claimed run — it derives from
+/// the nav group, so it claims `GroupId::Nav`, and the claim is honest
+/// exactly where the CDI gate is: a withheld or failed nav group never
+/// reaches this draw.
+///
+/// Distinct from [`indicate_instrument_symbology::source_label`], which
+/// names the SENSOR feeding a function and colors it by health. This
+/// names the receiver a selection points at, and colors it by source
+/// class. One panel paints both, so they never share a name.
+pub(crate) fn receiver_text(source: NavSource) -> Option<&'static str> {
     match source {
         NavSource::Gps => Some("GPS"),
         NavSource::Nav1 => Some("NAV1"),
@@ -33,26 +38,31 @@ pub(crate) fn source_text(source: NavSource) -> Option<&'static str> {
     }
 }
 
-/// The label position, lower left beside the rose: clear of the rose
-/// rim (the rim's nearest ink at this height is the 225° reference mark
-/// at x ≈ 121) and directly above the course box, whose value wears the
-/// same source color. The caller draws it under the CDI's exact gate,
-/// so the label and the needle appear and disappear together.
-const SOURCE_LABEL_POS: (f32, f32) = (60.0, super::CY + 110.0);
+/// The label position, lower left beside the rose: clear of the rose's
+/// outermost ink and directly above the course box, whose value wears
+/// the same source color. The clearance is a test, not a comment, so
+/// that growing the rose fails rather than overlapping the label.
+pub(crate) const RECEIVER_LABEL_POS: (f32, f32) = (60.0, super::CY + 110.0);
 
-/// Draws the nav-source label in the source color, claimed from the nav
+/// Half the anchor box the label occupies, for the clearance test.
+pub(crate) const RECEIVER_LABEL_SIZE: f32 = 14.0;
+
+/// Draws the receiver label in the source color, claimed from the nav
 /// group. Draws nothing for `None`/`Unknown` — the caller's gate already
 /// excludes both, and this arm keeps that property local.
-pub fn draw_source_label(scene: &mut SceneWriter<'_>, source: NavSource) -> Result<(), SceneError> {
-    let Some(text) = source_text(source) else {
+pub fn draw_receiver_label(
+    scene: &mut SceneWriter<'_>,
+    source: NavSource,
+) -> Result<(), SceneError> {
+    let Some(text) = receiver_text(source) else {
         return Ok(());
     };
     scene.fill_color(source_color(source))?;
     scene.text_attributed(
         GroupId::Nav.to_u8(),
-        SOURCE_LABEL_POS.0,
-        SOURCE_LABEL_POS.1,
-        14.0,
+        RECEIVER_LABEL_POS.0,
+        RECEIVER_LABEL_POS.1,
+        RECEIVER_LABEL_SIZE,
         Anchor::CENTER,
         text,
     )?;

--- a/sets/indicate-instrument-panels/src/hsi/rose.rs
+++ b/sets/indicate-instrument-panels/src/hsi/rose.rs
@@ -11,6 +11,10 @@ use indicate_instrument_symbology::{fmt_label, palette, status_paint};
 use super::{CX, CY, ROSE_R};
 
 const TEXT_R: f32 = 126.0;
+/// How far the fixed 45° reference marks reach past the rose rim. This
+/// is the rose's outermost ink, so anything placed beside the rose
+/// measures its clearance from `ROSE_R + REFERENCE_MARK_LEN`.
+pub(crate) const REFERENCE_MARK_LEN: f32 = 8.0;
 
 /// Rose ticks rotate with heading; labels are drawn upright at computed
 /// positions (the pyG5 counter-rotation, without nested transforms).
@@ -30,8 +34,8 @@ pub fn draw_rose(
         scene.line(
             ROSE_R * c,
             ROSE_R * s,
-            (ROSE_R + 8.0) * c,
-            (ROSE_R + 8.0) * s,
+            (ROSE_R + REFERENCE_MARK_LEN) * c,
+            (ROSE_R + REFERENCE_MARK_LEN) * s,
         )?;
     }
 

--- a/sets/indicate-instrument-panels/src/hsi/source_tests.rs
+++ b/sets/indicate-instrument-panels/src/hsi/source_tests.rs
@@ -216,7 +216,7 @@ fn source_ink(data: &PanelData) -> SourceInk {
 }
 
 #[test]
-fn nav_source_label_cdi_and_course_box_switch_together() {
+fn receiver_label_cdi_and_course_box_switch_together() {
     let cases = [
         (NavSource::Gps, "GPS", palette::MAGENTA),
         (NavSource::Nav1, "NAV1", palette::GREEN),
@@ -273,7 +273,7 @@ fn nav_source_label_cdi_and_course_box_switch_together() {
 }
 
 #[test]
-fn the_source_label_shares_the_cdi_gate() {
+fn the_receiver_label_shares_the_cdi_gate() {
     // No source selected: no needle, no label.
     let t = texts(&heading_only_panel());
     for label in ["GPS", "NAV1", "NAV2"] {

--- a/sets/indicate-instrument-panels/src/hsi/source_tests.rs
+++ b/sets/indicate-instrument-panels/src/hsi/source_tests.rs
@@ -3,12 +3,14 @@
 use std::string::String;
 use std::vec::Vec;
 
-use indicate_instrument_scene::{Cmd, SceneCmds, SceneWriter};
+use indicate_instrument_scene::{Cmd, LayerId, Rgba8, SceneCmds, SceneWriter};
 use indicate_instrument_state::{
-    AircraftState, AirframeDisplayProfile, Candidate, FreshnessPolicy, HeadingMeasure,
-    HeadingReference, IntegrityLevel, PanelData, SourceEpoch, SourceId, SourceInputs,
-    SourceMonitors, SourcePolicies, SourceStep, UnusualAttitudeState, resolve_with_sources,
+    AircraftState, AirframeDisplayProfile, Candidate, FreshnessPolicy, GroupId, HeadingMeasure,
+    HeadingReference, IntegrityLevel, NavData, NavFromTo, NavResolved, NavSource, PanelData, Sig,
+    SignalStatus, SourceEpoch, SourceId, SourceInputs, SourceMonitors, SourcePolicies, SourceStep,
+    UnusualAttitudeState, resolve_with_sources,
 };
+use indicate_instrument_symbology::palette;
 
 fn s(text: &str) -> String {
     String::from(text)
@@ -123,5 +125,180 @@ fn heading_sustained_miscompare_is_annunciated() {
     assert!(
         last.contains(&s("HDG1")),
         "still names the retained primary: {last:?}"
+    );
+}
+
+// ---- nav source identity (#55) ----------------------------------------------
+
+/// A live heading rose resolved from a real heading sample, so the
+/// rose basis is resolve's own selection; nav guidance is unset.
+fn heading_only_panel() -> PanelData {
+    let state = AircraftState {
+        heading: indicate_instrument_state::Stamped {
+            data: Some(indicate_instrument_state::HeadingSample {
+                heading_rad: 0.52,
+                reference: HeadingReference::Magnetic,
+            }),
+            age_ms: Some(10.0),
+        },
+        quality: indicate_instrument_state::EstimateQuality::Good,
+        valid: indicate_instrument_state::ValidFlags {
+            heading: true,
+            ..Default::default()
+        },
+        ..Default::default()
+    };
+    indicate_instrument_state::resolve(&state, &FreshnessPolicy::default())
+}
+
+/// `heading_only_panel` plus nav guidance from `source`.
+fn with_nav(source: NavSource) -> PanelData {
+    let mut data = heading_only_panel();
+    data.nav = NavResolved {
+        data: NavData {
+            source,
+            course_rad: 0.35,
+            course_reference: HeadingReference::Magnetic,
+            cdi_dots: -1.2,
+            fromto: NavFromTo::To,
+            ..NavData::default()
+        },
+        status: SignalStatus::Valid,
+        course_rose_rad: Sig::with_status(0.35, SignalStatus::Valid),
+    };
+    data
+}
+
+/// What one frame shows about the selected nav source: every text run
+/// with the fill color active at its emission and its provenance claim,
+/// plus the fill colors of the filled polygons in the Guidance band
+/// (the CDI's arrow, bar, and TO/FROM triangle wear the source color).
+struct SourceInk {
+    texts: Vec<(String, Rgba8, Option<u8>)>,
+    guidance_fills: Vec<Rgba8>,
+}
+
+fn source_ink(data: &PanelData) -> SourceInk {
+    let mut buf = std::vec![0u8; 32 * 1024];
+    let mut writer = SceneWriter::new(&mut buf).expect("buffer fits");
+    super::draw_hsi(data, None, crate::BUILTIN_FRAME, &mut writer).expect("panel fits buffer");
+    let len = writer.finish();
+    let mut layer = None;
+    let mut fill = None;
+    let mut claim = None;
+    let mut ink = SourceInk {
+        texts: Vec::new(),
+        guidance_fills: Vec::new(),
+    };
+    for command in SceneCmds::new(&buf[..len]).expect("valid scene") {
+        match command.expect("valid command") {
+            Cmd::BeginLayer { layer: id } => layer = Some(id),
+            Cmd::EndLayer { .. } => layer = None,
+            Cmd::FillColor { color } => fill = Some(color),
+            Cmd::Attribute { group } => claim = Some(group),
+            Cmd::Text { text, .. } => {
+                ink.texts.push((
+                    String::from(text),
+                    fill.expect("text has a fill"),
+                    claim.take(),
+                ));
+            }
+            Cmd::Polygon { mode, .. }
+                if layer == Some(LayerId::Guidance)
+                    && mode != indicate_instrument_scene::PaintMode::Stroke =>
+            {
+                ink.guidance_fills.push(fill.expect("polygon has a fill"));
+            }
+            _ => {}
+        }
+    }
+    ink
+}
+
+#[test]
+fn nav_source_label_cdi_and_course_box_switch_together() {
+    let cases = [
+        (NavSource::Gps, "GPS", palette::MAGENTA),
+        (NavSource::Nav1, "NAV1", palette::GREEN),
+        (NavSource::Nav2, "NAV2", palette::GREEN),
+    ];
+    let nav = GroupId::Nav.to_u8();
+    for (source, label, color) in cases {
+        let ink = source_ink(&with_nav(source));
+        // The label names the receiver, in the source color, claiming
+        // the nav group its identity derives from.
+        assert!(
+            ink.texts.contains(&(s(label), color, Some(nav))),
+            "{label} must paint in its source color with the nav claim: {:?}",
+            ink.texts
+        );
+        // The CRS-box value wears the same color.
+        assert!(
+            ink.texts.iter().any(|(t, c, _)| t == "020°" && *c == color),
+            "course box value follows the source: {:?}",
+            ink.texts
+        );
+        // The CDI ink wears the same color.
+        assert!(
+            ink.guidance_fills.contains(&color),
+            "CDI polygon ink follows the source: {:?}",
+            ink.guidance_fills
+        );
+        // No other receiver's name lingers in the same frame.
+        for (_, other, _) in cases.iter().filter(|(s_, _, _)| *s_ != source) {
+            assert!(
+                !ink.texts.iter().any(|(t, _, _)| t == other),
+                "{other} must not paint while {label} is selected: {:?}",
+                ink.texts
+            );
+        }
+    }
+
+    // The switch itself: GPS to Nav1 moves all three in the same frame —
+    // no magenta needle, no GPS label, no magenta course value survives.
+    let after = source_ink(&with_nav(NavSource::Nav1));
+    assert!(
+        !after.guidance_fills.contains(&palette::MAGENTA),
+        "the old source's needle color must not linger: {:?}",
+        after.guidance_fills
+    );
+    assert!(
+        !after
+            .texts
+            .iter()
+            .any(|(t, c, _)| t == "GPS" || (t == "020°" && *c == palette::MAGENTA)),
+        "the old source's label and course color must not linger: {:?}",
+        after.texts
+    );
+}
+
+#[test]
+fn the_source_label_shares_the_cdi_gate() {
+    // No source selected: no needle, no label.
+    let t = texts(&heading_only_panel());
+    for label in ["GPS", "NAV1", "NAV2"] {
+        assert!(
+            !t.contains(&s(label)),
+            "{label} without a selected source: {t:?}"
+        );
+    }
+
+    // The course cannot convert into the rose reference: the CDI gate
+    // closes and the label goes with the needle.
+    let mut data = with_nav(NavSource::Gps);
+    data.nav.course_rose_rad = Sig::with_status(0.0, SignalStatus::Failed);
+    let t = texts(&data);
+    assert!(
+        !t.contains(&s("GPS")),
+        "an unconvertible course shows neither needle nor label: {t:?}"
+    );
+
+    // The nav group fails: same gate, same outcome.
+    let mut data = with_nav(NavSource::Nav1);
+    data.nav.status = SignalStatus::Failed;
+    let t = texts(&data);
+    assert!(
+        !t.contains(&s("NAV1")),
+        "a failed nav group shows neither needle nor label: {t:?}"
     );
 }

--- a/sets/indicate-instrument-panels/src/hsi/source_tests.rs
+++ b/sets/indicate-instrument-panels/src/hsi/source_tests.rs
@@ -128,7 +128,7 @@ fn heading_sustained_miscompare_is_annunciated() {
     );
 }
 
-// ---- nav source identity (#55) ----------------------------------------------
+// ---- nav receiver identity ---------------------------------------------------
 
 /// A live heading rose resolved from a real heading sample, so the
 /// rose basis is resolve's own selection; nav guidance is unset.
@@ -300,5 +300,33 @@ fn the_source_label_shares_the_cdi_gate() {
     assert!(
         !t.contains(&s("NAV1")),
         "a failed nav group shows neither needle nor label: {t:?}"
+    );
+}
+
+/// The receiver label sits clear of the rose's outermost ink. Stated as
+/// a test rather than a note beside the coordinate, because the radius
+/// it clears lives in another module: growing the rose has to fail
+/// here, not overlap the label and reach a reviewer as a moved raster
+/// baseline that looks like any other re-pin.
+#[test]
+fn the_receiver_label_clears_the_rose_rim() {
+    use indicate_instrument_scene::nominal_text_width;
+
+    let widest = ["GPS", "NAV1", "NAV2"]
+        .iter()
+        .map(|t| t.chars().count())
+        .max()
+        .expect("labels");
+    let half_w = nominal_text_width(super::cdi::RECEIVER_LABEL_SIZE, widest) / 2.0;
+    let half_h = super::cdi::RECEIVER_LABEL_SIZE / 2.0;
+    // The anchor box's corner nearest the rose center: the label sits
+    // below and left of it, so that is the top-right corner.
+    let (lx, ly) = super::cdi::RECEIVER_LABEL_POS;
+    let dx = super::CX - (lx + half_w);
+    let dy = (ly - half_h) - super::CY;
+    let gap = libm::sqrtf(dx * dx + dy * dy) - (super::ROSE_R + super::rose::REFERENCE_MARK_LEN);
+    assert!(
+        gap > 0.0,
+        "the receiver label overlaps the rose rim by {gap} units",
     );
 }

--- a/sets/indicate-instrument-template/src/template/tests.rs
+++ b/sets/indicate-instrument-template/src/template/tests.rs
@@ -14,13 +14,13 @@ fn the_template_set_passes_admission() {
     static SETS: [&PanelSet; 1] = [&TEMPLATE_SET];
     let registry = Registry::from_sets(&SETS).expect("the template set composes");
     let report = admit(&registry).expect("the template must be admissible");
-    // Four canonical states x (one fed case + one per required group
+    // Five canonical states x (one fed case + one per required group
     // withheld) x (quiet, alerted); the panel contributes no extreme
     // states of its own. The alert axis is not optional: a composed
     // screen fans one AlertOutput to every slot, so a panel's
     // criticality band is only honest if it was measured with the stack
     // drawn.
-    assert_eq!(report.cases, 24);
+    assert_eq!(report.cases, 30);
     // A set copied from this template starts with nothing tolerated:
     // every run's nominal ink sits inside the design frame, so no
     // frame-overflow observation is counted. Keeping the line at zero is

--- a/tools/instrument-bench/src/screen.rs
+++ b/tools/instrument-bench/src/screen.rs
@@ -45,4 +45,4 @@ pub const BENCH_COMPOSITION: CompositionDescriptor = CompositionDescriptor {
 /// The pinned screen-composition digest over [`BENCH_COMPOSITION`]:
 /// every shell composing this screen from this registry reproduces it.
 pub const BENCH_COMPOSITION_DIGEST: &str =
-    "367ce939789975e7f548eea1e1a6fc41e8453e75e45d3acc397163f2ab1dcb2c";
+    "017b35a401208aebb5a5ceec975c71b8f103a92c1f02f5cc93edd13d3f29d9e3";


### PR DESCRIPTION
Closes #55 (first step only — receiver identity text; the VOR/LOC facility-type Nav layout addition stays in the coordinated ABI batch as the issue directs).

## What changed

Which source drives the CDI was encoded as hue alone (magenta vs green), so Nav1 and Nav2 read identically and the distinction failed under color-vision deficiency. The HSI now draws **GPS / NAV1 / NAV2** beside the rose (lower left, above the CRS box, clear of the rose rim) in the source color, under the CDI's exact gate (`hsi.rs:82` — source selected, nav shows a value, course converts into the rose reference), so the label and the needle appear and disappear in the same frame.

- `hsi/cdi.rs`: `source_text` (GPS/NAV1/NAV2; `None`/`Unknown` draw nothing) and `draw_source_label`, in the source color, claiming `GroupId::Nav` through the attributed-text path — the numerals in NAV1/NAV2 carry the claim the honesty rules require.
- `hsi.rs`: the label draws inside the CDI's own gate, in the Guidance band.
- `descriptors.rs`: new HSI group region covering the label so admission sees populated claimed ink.

## Guardrails (same change)

- `hsi/source_tests.rs`: a switch-together test — label text, CDI polygon color, and CRS-box value color all follow the selected source in the same frame, and a GPS→Nav1 switch leaves no trace of the old source — plus a gate-parity test (no source / unconvertible course / failed nav group removes the label with the needle).
- Shared corpus (`CANONICAL_STATES`) gains a `nav2-source` state: `typical` names GPS, `fully-fed` names Nav1, and now Nav2 is exercised too.

## Contract values moved (and why)

| Value | From | To | Reason |
|---|---|---|---|
| Composition digest | `f82d9056…` | `91767280…` | New claimed text run in HSI scenes + new corpus state |
| HSI raster baseline (REN-03) | `66653ce1…` | `efb15b50…` | The label paints in the shared `typical` state |
| Screen-composition digest | `367ce939…` | `017b35a4…` | Hashes the composition digest beneath it |
| Side-by-side composed-frame hash | `ce6b4347…` | `85fe67ef…` | HSI paint in the composed frame |
| Admission case/warning counts | 242/166 | 280/196 | Fifth corpus state multiplies the case matrix |

Unchanged: state ABI (7), scene format (1), conformance corpus (`corpusVersion` 4 — the byte-level corpus was not edited), panel set, PFD/monitor baselines, criticality bands, glyph pack. `release-manifest.json` regenerated via `cargo run --locked -q -p xtask -- gen-release-manifest`; CHANGELOG gains a 0.4.1 entry stating all five contract values.

## Gate results (worktree, all green)

`cargo fmt --all --check` · `cargo clippy --locked --all-targets -- -D warnings` · `cargo test --locked --all-targets` (17 suites ok) · `cargo doc` with denied missing-docs/broken-links · `cargo build --locked --release` · `check-structure.sh` · `check-release-manifest.sh` · `check-release-markers.sh` (0.4.1 agrees with the tree) · `check-instrument-requirements.sh` · `check-certification-claims.sh` · `check-standards-registry.sh` · `trace-report.sh` · `detect-target.sh` · `cargo check --target thumbv7em-none-eabihf` (12 crates) · `instrument-bench` (both digests match pin; 280 admission cases pass) · evidence-gate `--resolve-selectors` and `--require-resolvable` (verdict VALID — no evidence-bound file changed, so no re-record needed).
