### PR TITLE
Keep the structure gate out of linked worktrees

### DIFF
--- a/scripts/check-structure.sh
+++ b/scripts/check-structure.sh
@@ -34,7 +34,7 @@ is_excluded_path() {
 
 collect_rs_files() {
     find . \
-        -type d \( -name target -o -name generated \) -prune -o \
+        -type d \( -name target -o -name generated -o -name .worktrees \) -prune -o \
         -type f -name '*.rs' -print
 }
 
@@ -233,7 +233,8 @@ check_crate_naming() {
                 status=1
                 ;;
         esac
-    done < <(find . -name Cargo.toml -not -path './target/*' -not -path './.git/*' -mindepth 2)
+    done < <(find . -name Cargo.toml -not -path './target/*' -not -path './.git/*' \
+        -not -path './.worktrees/*' -mindepth 2)
 }
 
 # The tier law from #13. The tiers are only real if the tree enforces
@@ -337,7 +338,8 @@ check_crate_map() {
             echo "FORBIDDEN: $map has no row for $name" >&2
             status=1
         fi
-    done < <(find . -name Cargo.toml -not -path './target/*' -not -path './.git/*' -mindepth 2)
+    done < <(find . -name Cargo.toml -not -path './target/*' -not -path './.git/*' \
+        -not -path './.worktrees/*' -mindepth 2)
     while IFS= read -r name; do
         if [ ! -d "crates/$name" ] && [ ! -d "sets/$name" ]; then
             echo "FORBIDDEN: $map names $name, which is not a crate in this workspace" >&2

--- a/scripts/test-structure.sh
+++ b/scripts/test-structure.sh
@@ -157,7 +157,7 @@ cat > "$worktree_probe_dir/probe/Cargo.toml" <<'EOF'
 members = []
 EOF
 printf '//! Structure probe inside a linked worktree.\n' \
-    > "$worktree_probe_dir/probe/src/lib.rs"
+    > "$worktree_probe_dir/probe/src/mod.rs"
 if INDICATE_STRUCTURE_SELFTEST_CHILD=1 bash scripts/check-structure.sh >/dev/null 2>&1; then
     echo "ok: content under .worktrees is not walked"
     passed=$((passed + 1))

--- a/scripts/test-structure.sh
+++ b/scripts/test-structure.sh
@@ -17,11 +17,13 @@ cd "$root_dir"
 
 probe_dir="sets/indicate-tier-probe"
 probe_doc="docs/instruments/zz-structure-probe.md"
+worktree_probe_dir=".worktrees/zz-structure-probe"
 lock_backup="$(mktemp)"
 cp Cargo.lock "$lock_backup"
 
 cleanup() {
     rm -rf "$probe_dir"
+    rm -rf "$worktree_probe_dir"
     rm -f "$probe_doc"
     cp "$lock_backup" Cargo.lock
     rm -f "$lock_backup"
@@ -142,6 +144,28 @@ expect_term_refusal() {
 expect_term_refusal "InstrumentSceneKit" "InstrumentSceneKit"
 expect_term_refusal "IndicateAppleDisplay" "IndicateAppleDisplay"
 expect_term_refusal "Swift SceneKit backend" "Swift SceneKit backend"
+
+# A linked worktree is a checkout, not content, and the gate walks the
+# tree with `find`, which reads no ignore file. Without the prune the
+# walks reach a worktree's own manifests and sources: the workspace-only
+# root manifest has no `[package]` name, so the gate reports findings
+# against a checkout of itself. Plant both a manifest and a source file,
+# because the manifest walks and the source walk are pruned separately.
+mkdir -p "$worktree_probe_dir/probe/src"
+cat > "$worktree_probe_dir/probe/Cargo.toml" <<'EOF'
+[workspace]
+members = []
+EOF
+printf '//! Structure probe inside a linked worktree.\n' \
+    > "$worktree_probe_dir/probe/src/lib.rs"
+if INDICATE_STRUCTURE_SELFTEST_CHILD=1 bash scripts/check-structure.sh >/dev/null 2>&1; then
+    echo "ok: content under .worktrees is not walked"
+    passed=$((passed + 1))
+else
+    echo "REGRESSION: the gate walked into a linked worktree and reported on a checkout" >&2
+    failed=$((failed + 1))
+fi
+rm -rf "$worktree_probe_dir"
 
 if [ "$failed" -ne 0 ]; then
     echo "structure-selftest: FAILED ($failed of $((passed + failed)) cases)" >&2


### PR DESCRIPTION
Found while reviewing #67. `scripts/check-structure.sh` walks the tree with `find`, which does not read `.gitignore`, so a worktree checked out under the repository root multiplies its work by the number of branches in flight.

Measured here with eight linked worktrees: the Cargo.toml sweep matches 161 manifests where 17 are real, and the gate does not finish in a usable time. That is the failure that matters — a contributor follows the pre-push list in `CONTRIBUTING.md`, watches the gate appear to hang, and pushes without it.

The three walks now prune `.worktrees/` exactly as they already prune `target` and `generated`. After the change the gate completes in about 100 seconds with the same eight worktrees present, and reports OK.

CI checks out without worktrees, so this cost was always local-only. That is the reason to fix it rather than a reason to leave it: a local gate nobody runs is not a gate.

Separate from #67 under the one-issue-per-PR rule; #67 added the `.gitignore` entry, which git honours and `find` does not.