### PR TITLE
Merge evidence-touching changes without rewriting their baseline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -235,6 +235,18 @@ jobs:
           bash scripts/check-recorded-counts.sh --selftest
           bash scripts/check-recorded-counts.sh
 
+      - name: baselines that a squash would orphan (advisory)
+        # Advisory by construction: a pull request that re-records
+        # evidence declares a baseline that is not yet on main, so this
+        # reports on every legitimate evidence change. Its value is that
+        # the requirement appears on the pull request page at the moment
+        # someone picks a merge button, rather than only in
+        # CONTRIBUTING.md. The hard reachability gate cannot cover this:
+        # a pull request build checks out the synthetic merge ref, where
+        # the lane commit is already an ancestor.
+        continue-on-error: true
+        run: bash scripts/check-baseline-survives-merge.sh
+
       - name: Negative fixtures must all FAIL the gate
         run: |
           set -u

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -235,7 +235,14 @@ jobs:
           bash scripts/check-recorded-counts.sh --selftest
           bash scripts/check-recorded-counts.sh
 
-      - name: baselines that a squash would orphan (advisory)
+      - name: the baseline advisory can still fail
+        # A hard gate, deliberately outside the advisory step below: the
+        # advisory carries `continue-on-error`, so a selftest run inside
+        # it could go red without anyone noticing — which is the exact
+        # failure the selftest exists to catch.
+        run: bash scripts/test-baseline-survives-merge.sh
+
+      - name: baselines that a squash or rebase would orphan (advisory)
         # Advisory by construction: a pull request that re-records
         # evidence declares a baseline that is not yet on main, so this
         # reports on every legitimate evidence change. Its value is that

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -39,6 +39,8 @@ cargo run --locked -q -p indicate-evidence --bin evidence-gate -- \
   --graph docs/instruments/evidence-graph.evg --repo-root . --require-resolvable
 bash scripts/check-recorded-counts.sh --selftest
 bash scripts/check-recorded-counts.sh
+bash scripts/test-baseline-survives-merge.sh
+bash scripts/check-baseline-survives-merge.sh
 ```
 
 The evidence gate binds recorded test sources by content digest: editing
@@ -147,14 +149,18 @@ the tag is what a human owes it.
   advisory step on every pull request: the step exits non-zero when it
   has something to say, so the requirement is on the page when someone
   picks a merge button.
-- **Do not re-anchor the record at an older commit instead.** When the
+- **Do not move the record back to an older commit instead.** When the
   branch changed a bound source, the gate refuses loudly, because the
   older baseline never contained that source. When it changed only a
-  count, both gates pass while the record claims a run against a tree
-  that produces a different count. The first is noisy and the second is
-  silent, and neither is a way to keep the record true.
-- Re-anchoring after the merge does work, and this repository has done
-  it repeatedly. It leaves `main` red until the re-anchor lands.
+  count, the reachability check and the artifact check both pass while
+  the record claims a run against a tree that produces a different
+  count. The first is noisy and the second is silent, and neither keeps
+  the record true.
+- Re-anchoring the record after the merge does work, and this
+  repository has done it repeatedly. It leaves `main` red until the
+  re-anchor lands. Merge style is what preserves the commit a record
+  names; changing what a baseline *is* would be a change to the gate,
+  not to merge policy.
 - Panels are authored against the frame range their descriptor declares
   and receive the chosen frame as a draw argument; unclipped ink past
   that frame's edge is counted and ratcheted per frame by the admission

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -138,13 +138,15 @@ the tag is what a human owes it.
   recorded source file requires re-recording that evidence, and history
   rewrites that orphan the baseline commit are forbidden.
 - **Use a merge commit when a branch changes a `config-digest` in the
-  evidence graph. Do not use a squash merge.** The test is mechanical:
-  `git diff` shows whether the branch moved one. A squash replaces the
-  commit that the record names, and the gate then refuses the record as
-  unreachable, correctly, because a fresh clone cannot fetch it.
-  `scripts/check-baseline-survives-merge.sh` reports which baselines a
-  squash would orphan, and CI runs it as an advisory step on every pull
-  request.
+  evidence graph. Do not squash and do not rebase.** The test is
+  mechanical: `git diff` shows whether the branch moved one. Squash and
+  rebase both replace the commit that the record names, and the gate
+  then refuses the record as unreachable, correctly, because a fresh
+  clone cannot fetch it. `scripts/check-baseline-survives-merge.sh`
+  reports which baselines either would orphan, and CI runs it as an
+  advisory step on every pull request: the step exits non-zero when it
+  has something to say, so the requirement is on the page when someone
+  picks a merge button.
 - **Do not re-anchor the record at an older commit instead.** When the
   branch changed a bound source, the gate refuses loudly, because the
   older baseline never contained that source. When it changed only a

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -137,16 +137,22 @@ the tag is what a human owes it.
   sources by content digest and its baseline by commit: editing a
   recorded source file requires re-recording that evidence, and history
   rewrites that orphan the baseline commit are forbidden.
-- **Merge a pull request that touches recorded evidence with a merge
-  commit, not a squash.** A squash replaces the commit the run was
-  produced against, and the gate then refuses the record as unreachable
-  — correctly, because a fresh clone cannot fetch it. Re-anchoring
-  afterwards works but leaves `main` red until someone notices, and this
-  repository has paid that eleven times. Anchoring the record at an
-  older commit that survives the squash is not the way out: the bound
-  sources still resolve there, so the gate passes while the record
-  claims a run against a tree that produces different counts. Green and
-  false is worse than red and true.
+- **Use a merge commit when a branch changes a `config-digest` in the
+  evidence graph. Do not use a squash merge.** The test is mechanical:
+  `git diff` shows whether the branch moved one. A squash replaces the
+  commit that the record names, and the gate then refuses the record as
+  unreachable, correctly, because a fresh clone cannot fetch it.
+  `scripts/check-baseline-survives-merge.sh` reports which baselines a
+  squash would orphan, and CI runs it as an advisory step on every pull
+  request.
+- **Do not re-anchor the record at an older commit instead.** When the
+  branch changed a bound source, the gate refuses loudly, because the
+  older baseline never contained that source. When it changed only a
+  count, both gates pass while the record claims a run against a tree
+  that produces a different count. The first is noisy and the second is
+  silent, and neither is a way to keep the record true.
+- Re-anchoring after the merge does work, and this repository has done
+  it repeatedly. It leaves `main` red until the re-anchor lands.
 - Panels are authored against the frame range their descriptor declares
   and receive the chosen frame as a draw argument; unclipped ink past
   that frame's edge is counted and ratcheted per frame by the admission

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -137,6 +137,16 @@ the tag is what a human owes it.
   sources by content digest and its baseline by commit: editing a
   recorded source file requires re-recording that evidence, and history
   rewrites that orphan the baseline commit are forbidden.
+- **Merge a pull request that touches recorded evidence with a merge
+  commit, not a squash.** A squash replaces the commit the run was
+  produced against, and the gate then refuses the record as unreachable
+  — correctly, because a fresh clone cannot fetch it. Re-anchoring
+  afterwards works but leaves `main` red until someone notices, and this
+  repository has paid that eleven times. Anchoring the record at an
+  older commit that survives the squash is not the way out: the bound
+  sources still resolve there, so the gate passes while the record
+  claims a run against a tree that produces different counts. Green and
+  false is worse than red and true.
 - Panels are authored against the frame range their descriptor declares
   and receive the chosen frame as a draw argument; unclipped ink past
   that frame's edge is counted and ratcheted per frame by the admission

--- a/scripts/check-baseline-survives-merge.sh
+++ b/scripts/check-baseline-survives-merge.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+# Advisory: says whether this branch's recorded baselines would survive a
+# squash merge (#69).
+#
+# A recorded run names the commit it was produced against, and the gate
+# refuses a baseline it cannot reach from HEAD — a fresh clone cannot
+# fetch one. A squash merge replaces exactly that commit. So a branch
+# whose baseline is not already on the base branch must merge with a
+# merge commit, or main goes red the moment it lands.
+#
+# This cannot be a hard gate, and the reason is worth stating: on a pull
+# request build the checkout is the synthetic merge ref, where the lane
+# commit IS an ancestor, so the hard gate passes before the merge and
+# fails only after it. That asymmetry is why every episode of this was
+# found late. The point of an advisory step is to put the requirement on
+# the pull request page at the moment someone picks a merge button.
+set -euo pipefail
+
+root_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$root_dir"
+
+graph="${INDICATE_EVIDENCE_GRAPH:-docs/instruments/evidence-graph.evg}"
+base="${INDICATE_MERGE_BASE:-origin/main}"
+
+[ -f "$graph" ] || {
+    echo "check-baseline-survives-merge: no graph at $graph" >&2
+    exit 0
+}
+
+if ! git rev-parse --verify --quiet "$base" >/dev/null; then
+    echo "check-baseline-survives-merge: $base is not fetched; skipping"
+    exit 0
+fi
+
+branch_local=0
+for digest in $(sed -n 's/^attr config-digest \([0-9a-f]\{40\}\)$/\1/p' "$graph" | sort -u); do
+    if ! git cat-file -e "$digest^{commit}" 2>/dev/null; then
+        echo "UNKNOWN: baseline $digest is not an object in this clone" >&2
+        continue
+    fi
+    if git merge-base --is-ancestor "$digest" "$base" 2>/dev/null; then
+        echo "ok: baseline $digest is already on $base"
+    else
+        echo "BRANCH-LOCAL: baseline $digest exists only on this branch" >&2
+        branch_local=$((branch_local + 1))
+    fi
+done
+
+if [ "$branch_local" -ne 0 ]; then
+    echo "check-baseline-survives-merge: $branch_local baseline(s) would be orphaned by a squash." >&2
+    echo "Merge this pull request with a merge commit. See CONTRIBUTING.md." >&2
+    exit 0
+fi
+
+echo "check-baseline-survives-merge: every baseline is already on $base"

--- a/scripts/check-baseline-survives-merge.sh
+++ b/scripts/check-baseline-survives-merge.sh
@@ -1,19 +1,28 @@
 #!/usr/bin/env bash
 # Advisory: says whether this branch's recorded baselines would survive a
-# squash merge (#69).
+# merge that rewrites its commits.
 #
 # A recorded run names the commit it was produced against, and the gate
 # refuses a baseline it cannot reach from HEAD — a fresh clone cannot
-# fetch one. A squash merge replaces exactly that commit. So a branch
-# whose baseline is not already on the base branch must merge with a
-# merge commit, or main goes red the moment it lands.
+# fetch one. A squash merge replaces exactly that commit, and so does a
+# rebase merge. So a branch whose baseline is not already on the base
+# branch must merge with a merge commit, or main goes red the moment it
+# lands.
 #
 # This cannot be a hard gate, and the reason is worth stating: on a pull
 # request build the checkout is the synthetic merge ref, where the lane
-# commit IS an ancestor, so the hard gate passes before the merge and
+# commit IS an ancestor, so a hard gate passes before the merge and
 # fails only after it. That asymmetry is why every episode of this was
 # found late. The point of an advisory step is to put the requirement on
-# the pull request page at the moment someone picks a merge button.
+# the pull request page at the moment someone picks a merge button —
+# which requires this script to exit non-zero when it has something to
+# say. The workflow step carries `continue-on-error`, so a non-zero exit
+# marks the step without failing the build.
+#
+# Every path other than "checked, and every baseline is on the base"
+# exits non-zero. A check that cannot run and says nothing is
+# indistinguishable from a check that ran and found nothing, and the
+# second is the one a reviewer will assume.
 set -euo pipefail
 
 root_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
@@ -22,20 +31,32 @@ cd "$root_dir"
 graph="${INDICATE_EVIDENCE_GRAPH:-docs/instruments/evidence-graph.evg}"
 base="${INDICATE_MERGE_BASE:-origin/main}"
 
-[ -f "$graph" ] || {
-    echo "check-baseline-survives-merge: no graph at $graph" >&2
-    exit 0
-}
+if [ ! -r "$graph" ]; then
+    echo "UNCHECKED: no readable evidence graph at $graph" >&2
+    exit 1
+fi
 
 if ! git rev-parse --verify --quiet "$base" >/dev/null; then
-    echo "check-baseline-survives-merge: $base is not fetched; skipping"
-    exit 0
+    echo "UNCHECKED: $base is not fetched, so no baseline can be placed" >&2
+    exit 1
+fi
+
+digests="$(sed -n 's/^attr config-digest \([0-9a-f]\{40\}\)$/\1/p' "$graph" | sort -u)" || {
+    echo "UNCHECKED: could not read baselines from $graph" >&2
+    exit 1
+}
+
+if [ -z "$digests" ]; then
+    echo "UNCHECKED: $graph declares no baseline; a graph with none is not a clean graph" >&2
+    exit 1
 fi
 
 branch_local=0
-for digest in $(sed -n 's/^attr config-digest \([0-9a-f]\{40\}\)$/\1/p' "$graph" | sort -u); do
+unknown=0
+for digest in $digests; do
     if ! git cat-file -e "$digest^{commit}" 2>/dev/null; then
         echo "UNKNOWN: baseline $digest is not an object in this clone" >&2
+        unknown=$((unknown + 1))
         continue
     fi
     if git merge-base --is-ancestor "$digest" "$base" 2>/dev/null; then
@@ -46,10 +67,16 @@ for digest in $(sed -n 's/^attr config-digest \([0-9a-f]\{40\}\)$/\1/p' "$graph"
     fi
 done
 
+if [ "$unknown" -ne 0 ]; then
+    echo "check-baseline-survives-merge: $unknown baseline(s) could not be placed." >&2
+    exit 1
+fi
+
 if [ "$branch_local" -ne 0 ]; then
-    echo "check-baseline-survives-merge: $branch_local baseline(s) would be orphaned by a squash." >&2
-    echo "Merge this pull request with a merge commit. See CONTRIBUTING.md." >&2
-    exit 0
+    echo "check-baseline-survives-merge: $branch_local baseline(s) would be orphaned by a" >&2
+    echo "squash or rebase merge. Merge this pull request with a merge commit." >&2
+    echo "See CONTRIBUTING.md." >&2
+    exit 1
 fi
 
 echo "check-baseline-survives-merge: every baseline is already on $base"

--- a/scripts/check-baseline-survives-merge.sh
+++ b/scripts/check-baseline-survives-merge.sh
@@ -53,7 +53,9 @@ digests="$(sed -n 's/^attr config-digest *\([0-9a-fA-F]\{7,40\}\) *$/\1/p' "$gra
 # Distinct declared values, so this compares like with like: a gap
 # between the two counts means the graph declares a baseline in a form
 # this script did not parse, which is the shape that fails open.
-declared="$(sed -n 's/^attr config-digest *//p' "$graph" | sed 's/ *$//' | sort -u | grep -c .)"
+declared="$(sed -n 's/^attr config-digest *//p' "$graph" | sed 's/ *$//' | sort -u \
+    | grep -c . || true)"
+declared="${declared:-0}"
 if [ -z "$digests" ]; then
     echo "UNCHECKED: $graph declares no baseline this script can parse" >&2
     exit 1

--- a/scripts/check-baseline-survives-merge.sh
+++ b/scripts/check-baseline-survives-merge.sh
@@ -41,19 +41,29 @@ if ! git rev-parse --verify --quiet "$base" >/dev/null; then
     exit 1
 fi
 
-digests="$(sed -n 's/^attr config-digest \([0-9a-f]\{40\}\)$/\1/p' "$graph" | sort -u)" || {
+# Every form the gate accepts must be parsed here, or the guardrail is
+# narrower than the thing it guards and skips the difference in silence.
+# The gate hands the attribute to git after a trim, and git resolves
+# abbreviated and upper-case object ids, so this does too.
+digests="$(sed -n 's/^attr config-digest *\([0-9a-fA-F]\{7,40\}\) *$/\1/p' "$graph" | sort -u)" || {
     echo "UNCHECKED: could not read baselines from $graph" >&2
     exit 1
 }
 
+# Distinct declared values, so this compares like with like: a gap
+# between the two counts means the graph declares a baseline in a form
+# this script did not parse, which is the shape that fails open.
+declared="$(sed -n 's/^attr config-digest *//p' "$graph" | sed 's/ *$//' | sort -u | grep -c .)"
 if [ -z "$digests" ]; then
-    echo "UNCHECKED: $graph declares no baseline; a graph with none is not a clean graph" >&2
+    echo "UNCHECKED: $graph declares no baseline this script can parse" >&2
     exit 1
 fi
 
 branch_local=0
 unknown=0
+checked=0
 for digest in $digests; do
+    checked=$((checked + 1))
     if ! git cat-file -e "$digest^{commit}" 2>/dev/null; then
         echo "UNKNOWN: baseline $digest is not an object in this clone" >&2
         unknown=$((unknown + 1))
@@ -73,10 +83,29 @@ if [ "$unknown" -ne 0 ]; then
 fi
 
 if [ "$branch_local" -ne 0 ]; then
+    # A workflow annotation rather than only a log line: the stated
+    # purpose is to put the requirement on the pull request page at the
+    # moment someone picks a merge button, and a message inside a
+    # collapsed job log does not reach that page.
+    echo "::warning file=$graph::$branch_local baseline(s) would be orphaned by a squash or" \
+        "rebase merge; merge this pull request with a merge commit (see CONTRIBUTING.md)"
+    if [ -n "${GITHUB_STEP_SUMMARY:-}" ]; then
+        echo "**$branch_local baseline(s) would be orphaned by a squash or rebase merge.**" \
+            "Merge this pull request with a merge commit. See CONTRIBUTING.md." \
+            >> "$GITHUB_STEP_SUMMARY"
+    fi
     echo "check-baseline-survives-merge: $branch_local baseline(s) would be orphaned by a" >&2
     echo "squash or rebase merge. Merge this pull request with a merge commit." >&2
     echo "See CONTRIBUTING.md." >&2
     exit 1
 fi
 
-echo "check-baseline-survives-merge: every baseline is already on $base"
+# Says how many it placed, not that a clean result was reached: a count
+# a reader can compare against the graph is what distinguishes a check
+# that ran from a check that matched nothing.
+if [ "$checked" -ne "$declared" ]; then
+    echo "UNCHECKED: $graph declares $declared distinct baseline(s) but only $checked parsed" >&2
+    exit 1
+fi
+
+echo "check-baseline-survives-merge: all $checked declared baseline(s) are on $base"

--- a/scripts/test-baseline-survives-merge.sh
+++ b/scripts/test-baseline-survives-merge.sh
@@ -65,11 +65,52 @@ fi
 graph_with "$work/unknown.evg" "0123456789abcdef0123456789abcdef01234567"
 INDICATE_EVIDENCE_GRAPH="$work/unknown.evg" expect 1 "an unplaceable baseline is refused"
 
-# A graph that parses to no baseline at all: the digest is one character
-# short, so the pattern matches nothing and the loop never runs.
-graph_with "$work/short.evg" >/dev/null
-echo "attr config-digest 0123456789abcdef0123456789abcdef0123456" > "$work/short.evg"
-INDICATE_EVIDENCE_GRAPH="$work/short.evg" expect 1 "a graph with no parsable baseline is refused"
+# A graph that parses to no baseline at all. The value has to be
+# unparsable rather than merely short: the pattern takes 7 to 40
+# characters, so a 39-character digest is a form it accepts.
+echo "attr config-digest not-a-digest" > "$work/unparsable.evg"
+INDICATE_EVIDENCE_GRAPH="$work/unparsable.evg" expect 1 "a graph with no parsable baseline is refused"
+
+# A graph with no `config-digest` line at all is the case that counts
+# zero, and a counter that treats an empty count as an error kills the
+# script before its message runs.
+echo "node RESULT-PROBE verification-result" > "$work/no-attr.evg"
+INDICATE_EVIDENCE_GRAPH="$work/no-attr.evg" expect 1 "a graph declaring no baseline is refused"
+
+said="$(INDICATE_EVIDENCE_GRAPH="$work/no-attr.evg" "$check" 2>&1 || true)"
+if [ -n "$said" ]; then
+    echo "ok: a graph declaring no baseline says why before it exits"
+    passed=$((passed + 1))
+else
+    echo "REGRESSION: the no-baseline path exits silently" >&2
+    failed=$((failed + 1))
+fi
+
+# And it must say so rather than dying quietly: an exit status with no
+# message is indistinguishable from a crash, which is the shape the
+# script's own header argues against.
+# Captured rather than piped: this script runs under `pipefail`, so a
+# pipeline would carry the check's own non-zero status and say nothing
+# about whether it spoke.
+said="$(INDICATE_EVIDENCE_GRAPH="$work/unparsable.evg" "$check" 2>&1 || true)"
+if [ -n "$said" ]; then
+    echo "ok: an unparsable graph says why before it exits"
+    passed=$((passed + 1))
+else
+    echo "REGRESSION: the unparsable-graph path exits silently" >&2
+    failed=$((failed + 1))
+fi
+
+# One placeable baseline beside one the pattern cannot read. The loop
+# would place the first and report the all-clear, so the count of
+# distinct declarations against distinct parses is what refuses it.
+{
+    echo "node RESULT-PROBE verification-result"
+    echo "attr config-digest $on_base"
+    echo "attr config-digest not-a-digest"
+} > "$work/partly-parsable.evg"
+INDICATE_EVIDENCE_GRAPH="$work/partly-parsable.evg" \
+    expect 1 "a baseline the pattern cannot read refuses the whole run"
 
 # A graph that cannot be read at all.
 INDICATE_EVIDENCE_GRAPH="$work/absent.evg" expect 1 "an unreadable graph is refused"

--- a/scripts/test-baseline-survives-merge.sh
+++ b/scripts/test-baseline-survives-merge.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+# Selftest for check-baseline-survives-merge.sh.
+#
+# The check is advisory, which is exactly why it needs this: an advisory
+# step that exits 0 on every path looks identical to an advisory step
+# that found nothing, and nobody investigates a green step. Each case
+# below drives one path and asserts on the exit status, not on the text.
+set -euo pipefail
+
+root_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$root_dir"
+
+check="$root_dir/scripts/check-baseline-survives-merge.sh"
+passed=0
+failed=0
+work="$(mktemp -d)"
+trap 'rm -rf "$work"' EXIT
+
+# `expect <want> <label>` runs the check against the environment already
+# exported by the caller and compares its exit status to `want`, where 0
+# means "checked, and every baseline is on the base".
+expect() {
+    local want="$1" label="$2" got=0
+    "$check" >/dev/null 2>&1 || got=$?
+    if [ "$got" -eq "$want" ]; then
+        echo "ok: $label"
+        passed=$((passed + 1))
+    else
+        echo "REGRESSION: $label — wanted exit $want, got $got" >&2
+        failed=$((failed + 1))
+    fi
+}
+
+graph_with() {
+    local path="$1"
+    shift
+    {
+        echo "node RESULT-PROBE verification-result"
+        for digest in "$@"; do
+            echo "attr config-digest $digest"
+        done
+    } > "$path"
+}
+
+on_base="$(git rev-parse "${INDICATE_MERGE_BASE:-origin/main}")"
+head_commit="$(git rev-parse HEAD)"
+
+# A baseline already on the base branch survives any merge button.
+graph_with "$work/on-base.evg" "$on_base"
+INDICATE_EVIDENCE_GRAPH="$work/on-base.evg" expect 0 "a baseline on the base is accepted"
+
+# A commit that exists but is not on the base is the case the check is
+# for. It must be refused, or the advisory step is green on exactly the
+# branch it exists to warn about.
+if [ "$head_commit" != "$on_base" ] && ! git merge-base --is-ancestor "$head_commit" "$on_base"; then
+    graph_with "$work/branch-local.evg" "$head_commit"
+    INDICATE_EVIDENCE_GRAPH="$work/branch-local.evg" expect 1 "a branch-local baseline is refused"
+else
+    echo "ok: skipped the branch-local case — this checkout is on the base"
+    passed=$((passed + 1))
+fi
+
+# A well-formed digest naming no object in this clone cannot be placed.
+# Counting it and then printing the all-clear is the fail-open shape.
+graph_with "$work/unknown.evg" "0123456789abcdef0123456789abcdef01234567"
+INDICATE_EVIDENCE_GRAPH="$work/unknown.evg" expect 1 "an unplaceable baseline is refused"
+
+# A graph that parses to no baseline at all: the digest is one character
+# short, so the pattern matches nothing and the loop never runs.
+graph_with "$work/short.evg" >/dev/null
+echo "attr config-digest 0123456789abcdef0123456789abcdef0123456" > "$work/short.evg"
+INDICATE_EVIDENCE_GRAPH="$work/short.evg" expect 1 "a graph with no parsable baseline is refused"
+
+# A graph that cannot be read at all.
+INDICATE_EVIDENCE_GRAPH="$work/absent.evg" expect 1 "an unreadable graph is refused"
+
+# A base ref that is not fetched: nothing can be placed against it.
+INDICATE_EVIDENCE_GRAPH="$work/on-base.evg" INDICATE_MERGE_BASE="refs/heads/no-such-base" \
+    expect 1 "an unfetched base is refused"
+
+if [ "$failed" -ne 0 ]; then
+    echo "baseline-survives-merge-selftest: FAILED ($failed of $((passed + failed)) cases)" >&2
+    exit 1
+fi
+
+echo "baseline-survives-merge-selftest: OK ($passed cases)"

--- a/scripts/test-baseline-survives-merge.sh
+++ b/scripts/test-baseline-survives-merge.sh
@@ -74,6 +74,35 @@ INDICATE_EVIDENCE_GRAPH="$work/short.evg" expect 1 "a graph with no parsable bas
 # A graph that cannot be read at all.
 INDICATE_EVIDENCE_GRAPH="$work/absent.evg" expect 1 "an unreadable graph is refused"
 
+# Every form the gate accepts must be parsed here. The gate hands the
+# attribute to git after a trim, and git resolves abbreviated and
+# upper-case object ids, so a parser that took only 40 lowercase
+# characters would skip those in silence — and a graph mixing one form
+# it parses with one it does not would check the first and print the
+# all-clear.
+short_on_base="$(git rev-parse --short=12 "${INDICATE_MERGE_BASE:-origin/main}")"
+graph_with "$work/short-form.evg" "$short_on_base"
+INDICATE_EVIDENCE_GRAPH="$work/short-form.evg" expect 0 "an abbreviated baseline is placed, not skipped"
+
+upper_on_base="$(git rev-parse "${INDICATE_MERGE_BASE:-origin/main}" | tr 'a-f' 'A-F')"
+graph_with "$work/upper-form.evg" "$upper_on_base"
+INDICATE_EVIDENCE_GRAPH="$work/upper-form.evg" expect 0 "an upper-case baseline is placed, not skipped"
+
+# The mixed case is the one that fails open rather than closed: one form
+# parses and passes, so a narrower parser reports the all-clear while
+# never having looked at the other.
+{
+    echo "node RESULT-PROBE verification-result"
+    echo "attr config-digest $on_base"
+    echo "attr config-digest 0123456789ab"
+} > "$work/mixed.evg"
+INDICATE_EVIDENCE_GRAPH="$work/mixed.evg" expect 1 "a graph mixing a placeable and an unplaceable baseline is refused"
+
+# A trailing space is a form the gate accepts, because it trims.
+printf 'node RESULT-PROBE verification-result\nattr config-digest %s \n' "$on_base" \
+    > "$work/trailing.evg"
+INDICATE_EVIDENCE_GRAPH="$work/trailing.evg" expect 0 "a trailing space does not hide a baseline"
+
 # A base ref that is not fetched: nothing can be placed against it.
 INDICATE_EVIDENCE_GRAPH="$work/on-base.evg" INDICATE_MERGE_BASE="refs/heads/no-such-base" \
     expect 1 "an unfetched base is refused"


### PR DESCRIPTION
Closes the policy question raised by #67.

A recorded run names the commit it was produced against. The gate refuses a baseline it cannot reach from HEAD, correctly — a fresh clone cannot fetch one. A squash merge replaces exactly that commit, so every evidence-touching squash leaves `main` red until someone re-anchors it. Independent review of #67 counted **eleven** such re-anchor commits in this repository's history; I had estimated three.

The alternative I floated first is worse than unavailable. Anchoring the record at an older commit that survives the squash buys reachability by making the record untrue: the bound sources still resolve at that commit, so both the evidence gate and the new freshness check pass, while the record claims a run against a tree that produces a different count. #44's own lane demonstrates it — the panel suite moved 81 to 84 without touching any bound source. Green and false, with nothing able to see it.

Rebase-and-merge orphans identically. Relaxing reachability contradicts a deliberate design that CI asserts with a negative fixture. So the choice is exactly two: the merge style preserves the lane commit, or the baseline stops being a commit.

This takes the first. #65 was merged this way as the test: `main` stayed green, with no re-anchor needed.

No guardrail ships with this because none is available — GitHub's merge-method restriction is a repository setting, not a file in the tree. If the setting is tightened to match, this paragraph becomes the record of why.