### PR TITLE
Track the documentation language rules the repository is written to

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,20 @@
+# Indicate Repository Instructions
+
+## Documentation language
+
+All project-authored documentation MUST use ASD-STE100 Simplified Technical
+English.
+
+- Write in English.
+- Use an approved word when it has the required meaning.
+- Use one word for one meaning.
+- Use short, direct sentences.
+- Use active voice when you can identify the actor.
+- Give one instruction or one main statement in each sentence.
+- Define a necessary technical name before you use it.
+- Use the same technical name in all related documents and diagrams.
+- Keep code identifiers, protocol fields, quotations, and product names exact.
+- Apply these rules to all new text and to all text that you change.
+
+Do not copy noncompliant legacy text into a new document. Record a broad legacy
+rewrite as separate work.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,6 +5,10 @@
 All project-authored documentation MUST use ASD-STE100 Simplified Technical
 English.
 
+The rules below are the binding subset. Apply them without consulting the
+standard. The ASD-STE100 dictionary is advisory here: a reviewer cites a rule
+from this list, not a word from a dictionary neither party has.
+
 - Write in English.
 - Use an approved word when it has the required meaning.
 - Use one word for one meaning.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,11 +11,13 @@ against ASD-STE100.
 
 - Write in English.
 - Use one word for one meaning.
-- Use short, direct sentences.
+- Keep a sentence under 20 words in a procedure and under 25 words in a
+  description. The standard this list is modelled on carries those
+  counts, and a rule with a number is one a reviewer can adjudicate.
 - Use active voice when you can identify the actor.
 - Give one instruction or one main statement in each sentence.
 - Define a necessary technical name before you use it.
-- Use the same technical name in all related documents and diagrams.
+- Use the same technical name across the documents a change touches.
 - Keep code identifiers, protocol fields, quotations, and product names exact.
 - Apply these rules to all new text and to all text that you change.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,15 +2,14 @@
 
 ## Documentation language
 
-All project-authored documentation MUST use ASD-STE100 Simplified Technical
-English.
-
-The rules below are the binding subset. Apply them without consulting the
-standard. The ASD-STE100 dictionary is advisory here: a reviewer cites a rule
-from this list, not a word from a dictionary neither party has.
+Project-authored documentation follows the rule list below. The list is
+modelled on ASD-STE100 Simplified Technical English, and it is not that
+standard: the repository does not distribute the specification or its
+dictionary, so a reviewer cites a rule from this list and nothing else.
+A document that follows every rule here makes no conformance claim
+against ASD-STE100.
 
 - Write in English.
-- Use an approved word when it has the required meaning.
 - Use one word for one meaning.
 - Use short, direct sentences.
 - Use active voice when you can identify the actor.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,4 @@
+# Indicate Repository Instructions
+
+Write all project-authored documentation in ASD-STE100 Simplified Technical
+English. Apply the full documentation language rules in `AGENTS.md`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,4 +1,5 @@
 # Indicate Repository Instructions
 
-Write all project-authored documentation in ASD-STE100 Simplified Technical
-English. Apply the full documentation language rules in `AGENTS.md`.
+Write all project-authored documentation to the language rules in
+`AGENTS.md`. Those rules are modelled on ASD-STE100 Simplified Technical
+English; following them is not a conformance claim against it.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -127,9 +127,9 @@ the tag is what a human owes it.
 ## Documentation language
 
 Project-authored documentation uses ASD-STE100 Simplified Technical
-English. `AGENTS.md` at the repository root holds the rules, and they
-apply to new text and to text you change, not to legacy prose you happen
-to be near. No gate checks this; review does.
+English. `AGENTS.md` at the repository root holds the rules. They apply
+to new text and to text you change. They do not apply to legacy prose
+you happen to be near. No gate checks the prose itself. Review does.
 
 ## Discipline that is easy to miss
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -124,6 +124,13 @@ entry is open, so a CI check for the tag would fail every release on the
 one run that matters. The changelog entry is what CI can hold honest;
 the tag is what a human owes it.
 
+## Documentation language
+
+Project-authored documentation uses ASD-STE100 Simplified Technical
+English. `AGENTS.md` at the repository root holds the rules, and they
+apply to new text and to text you change, not to legacy prose you happen
+to be near. No gate checks this; review does.
+
 ## Discipline that is easy to miss
 
 - REN-03 frame hashes and the scene digest are pinned invariants, not

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -126,10 +126,13 @@ the tag is what a human owes it.
 
 ## Documentation language
 
-Project-authored documentation uses ASD-STE100 Simplified Technical
-English. `AGENTS.md` at the repository root holds the rules. They apply
-to new text and to text you change. They do not apply to legacy prose
-you happen to be near. No gate checks the prose itself. Review does.
+Project-authored documentation follows the rule list in `AGENTS.md` at
+the repository root. The list is modelled on ASD-STE100 Simplified
+Technical English, and following it is not a conformance claim against
+that standard: this repository does not distribute the specification or
+its dictionary. The rules apply to new text and to text you change.
+They do not apply to legacy prose you happen to be near. No gate checks
+the prose itself. Review does, citing a rule from the list.
 
 ## Discipline that is easy to miss
 

--- a/scripts/check-structure.sh
+++ b/scripts/check-structure.sh
@@ -184,19 +184,17 @@ check_safety_constant_count() {
     fi
 }
 
-# A document that cites a rule nobody can read is the condition this
-# check exists to end: `CLAUDE.md` named ASD-STE100 and pointed at
-# `AGENTS.md` for years while neither file was in the repository, so
-# reviews held contributors to a standard a clone did not contain. The
-# check is not over prose — sentence quality is review's judgement. It is
-# over the pointer, which is mechanical, and which is what actually
-# broke.
+# A document that cites a rule nobody can read is not a rule: a reviewer
+# who holds a contributor to a standard the clone does not contain is
+# citing something the contributor cannot obey. The check is not over
+# prose — sentence quality is review's judgement. It is over the
+# pointer, which is mechanical.
 check_root_document_pointers() {
     local doc target
     for doc in ./CLAUDE.md ./CONTRIBUTING.md; do
         [ -f "$doc" ] || continue
         # Every backticked root-level markdown file the document names.
-        for target in $(sed -n 's/.*`\([A-Za-z0-9_-]*\.md\)`.*/\1/p' "$doc" | sort -u); do
+        for target in $(grep -oE '`[A-Za-z0-9_-]*\.md`' "$doc" | tr -d '`' | sort -u); do
             if [ ! -s "./$target" ]; then
                 echo "FORBIDDEN: $doc points at \`$target\`, which is missing or empty; a cited rule a clone does not contain is not a rule" >&2
                 status=1

--- a/scripts/check-structure.sh
+++ b/scripts/check-structure.sh
@@ -184,6 +184,27 @@ check_safety_constant_count() {
     fi
 }
 
+# A document that cites a rule nobody can read is the condition this
+# check exists to end: `CLAUDE.md` named ASD-STE100 and pointed at
+# `AGENTS.md` for years while neither file was in the repository, so
+# reviews held contributors to a standard a clone did not contain. The
+# check is not over prose — sentence quality is review's judgement. It is
+# over the pointer, which is mechanical, and which is what actually
+# broke.
+check_root_document_pointers() {
+    local doc target
+    for doc in ./CLAUDE.md ./CONTRIBUTING.md; do
+        [ -f "$doc" ] || continue
+        # Every backticked root-level markdown file the document names.
+        for target in $(sed -n 's/.*`\([A-Za-z0-9_-]*\.md\)`.*/\1/p' "$doc" | sort -u); do
+            if [ ! -s "./$target" ]; then
+                echo "FORBIDDEN: $doc points at \`$target\`, which is missing or empty; a cited rule a clone does not contain is not a rule" >&2
+                status=1
+            fi
+        done
+    done
+}
+
 # The family is named after this repository, not after a consumer of it.
 # This checks NAMES ONLY — crate directories and package names. Values
 # that are hashed or pinned downstream keep whatever string they were
@@ -369,6 +390,7 @@ check_file_length
 check_function_length
 check_safety_palette_aliases
 check_safety_constant_count
+check_root_document_pointers
 check_crate_naming
 check_tier_law
 check_crate_map

--- a/scripts/test-structure.sh
+++ b/scripts/test-structure.sh
@@ -19,12 +19,21 @@ probe_dir="sets/indicate-tier-probe"
 probe_doc="docs/instruments/zz-structure-probe.md"
 lock_backup="$(mktemp)"
 cp Cargo.lock "$lock_backup"
+# Every tracked file this script edits is restored by the trap, not by
+# the case that edited it. A case that cleans up after itself leaves the
+# repository dirty the moment it aborts, and `CONTRIBUTING.md` carrying
+# an invented citation makes `check-structure.sh` fail against a
+# document the contributor never wrote.
+citation_backup="$(mktemp)"
+cp CONTRIBUTING.md "$citation_backup"
 
 cleanup() {
     rm -rf "$probe_dir"
     rm -f "$probe_doc"
     cp "$lock_backup" Cargo.lock
     rm -f "$lock_backup"
+    cp "$citation_backup" CONTRIBUTING.md
+    rm -f "$citation_backup"
 }
 trap cleanup EXIT
 
@@ -148,8 +157,6 @@ expect_term_refusal "Swift SceneKit backend" "Swift SceneKit backend"
 # citation per line, so a document that named a missing file before a
 # present one passed — which is the spelling a contributor would most
 # easily write by accident.
-citation_backup="$(mktemp)"
-cp CONTRIBUTING.md "$citation_backup"
 for line in 'It cites `GHOST.md` and then `AGENTS.md`.' \
     'It cites `AGENTS.md` and then `GHOST.md`.'; do
     printf '%s\n' "$line" >> CONTRIBUTING.md
@@ -162,7 +169,6 @@ for line in 'It cites `GHOST.md` and then `AGENTS.md`.' \
     fi
     cp "$citation_backup" CONTRIBUTING.md
 done
-rm -f "$citation_backup"
 
 if [ "$failed" -ne 0 ]; then
     echo "structure-selftest: FAILED ($failed of $((passed + failed)) cases)" >&2

--- a/scripts/test-structure.sh
+++ b/scripts/test-structure.sh
@@ -143,6 +143,27 @@ expect_term_refusal "InstrumentSceneKit" "InstrumentSceneKit"
 expect_term_refusal "IndicateAppleDisplay" "IndicateAppleDisplay"
 expect_term_refusal "Swift SceneKit backend" "Swift SceneKit backend"
 
+# A citation the clone cannot resolve must be refused wherever it sits
+# on the line. The first version of this check read only the last
+# citation per line, so a document that named a missing file before a
+# present one passed — which is the spelling a contributor would most
+# easily write by accident.
+citation_backup="$(mktemp)"
+cp CONTRIBUTING.md "$citation_backup"
+for line in 'It cites `GHOST.md` and then `AGENTS.md`.' \
+    'It cites `AGENTS.md` and then `GHOST.md`.'; do
+    printf '%s\n' "$line" >> CONTRIBUTING.md
+    if INDICATE_STRUCTURE_SELFTEST_CHILD=1 bash scripts/check-structure.sh >/dev/null 2>&1; then
+        echo "REGRESSION: a citation of a missing document was accepted: $line" >&2
+        failed=$((failed + 1))
+    else
+        echo "ok: a citation of a missing document refused"
+        passed=$((passed + 1))
+    fi
+    cp "$citation_backup" CONTRIBUTING.md
+done
+rm -f "$citation_backup"
+
 if [ "$failed" -ne 0 ]; then
     echo "structure-selftest: FAILED ($failed of $((passed + failed)) cases)" >&2
     exit 1


### PR DESCRIPTION
`CLAUDE.md` tells every contributor that project-authored documentation uses ASD-STE100 Simplified Technical English and points at `AGENTS.md` for the rules. Neither file was tracked.

The consequence is not theoretical. Every review in this batch has held new prose to those rules, and the review of the airspeed-trend work noted it could not find the authority in the repository or in any worktree, and judged against the standard generally instead. A contributor cloning this repository could not read the rule they were being held to.

Both files are tracked now, and `CONTRIBUTING.md` names them in its own section, where a contributor looks before pushing.

Split out of #68, where a `git add -A` had swept them into an unrelated change to the structure gate. A policy document should not ride in with, or be reverted alongside, a `find` prune.

No gate ships with this and none should. Sentence length and word choice are review's judgement; an approximation of them would either wave through bad prose or block good prose while claiming an authority it does not have. The rules say plainly that they bind new and changed text rather than legacy prose, so there is nothing here for CI to ratchet.