### PR TITLE
Two entries under one version leave one of them unchecked

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,7 +59,9 @@ jobs:
         # merge commit, which does not exist while the pull request that
         # writes the entry is open, so the check would fail every release
         # on the run that matters. Tagging is a step in CONTRIBUTING.md.
-        run: bash scripts/check-release-markers.sh
+        run: |
+          bash scripts/test-release-markers.sh
+          bash scripts/check-release-markers.sh
 
       - name: release manifest drift guard
         # The changelog entry is prose a person reads; release-manifest.json

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -41,6 +41,8 @@ bash scripts/check-recorded-counts.sh --selftest
 bash scripts/check-recorded-counts.sh
 bash scripts/test-baseline-survives-merge.sh
 bash scripts/check-baseline-survives-merge.sh
+bash scripts/test-release-markers.sh
+bash scripts/check-release-markers.sh
 ```
 
 The evidence gate binds recorded test sources by content digest: editing

--- a/scripts/check-release-markers.sh
+++ b/scripts/check-release-markers.sh
@@ -57,6 +57,18 @@ entry="$(awk '
 
 version="$(printf '%s\n' "$entry" | awk 'NR == 1 { gsub(/^## \[|\].*$/, ""); print; exit }')"
 
+# Two entries under one version is the shape a merge produces when two
+# branches each add the next release. This check reads the newest entry
+# only, so the older twin's values are never compared against anything
+# and its claims go unchecked. Refuse the file rather than the entry:
+# which of the two is "the" release is not a question this check can
+# answer.
+duplicate="$(grep -oE '^## \[[0-9]+\.[0-9]+\.[0-9]+\]' "$changelog" \
+    | sort | uniq -d | head -1 || true)"
+if [ -n "$duplicate" ]; then
+    fail_closed "$changelog declares $duplicate more than once; two entries under one version leave the older one unchecked (fail-closed)"
+fi
+
 # The value cell of a `| <label> | <value> |` row in the entry's table.
 # Rows inside a fenced block or an HTML comment are illustration, not
 # claim, so a table that exists only as an example cannot stand in for

--- a/scripts/test-release-markers.sh
+++ b/scripts/test-release-markers.sh
@@ -93,6 +93,22 @@ DRIFT
 refuses "a value that disagrees with the tree" "DRIFT:"
 cp "$pristine" "$changelog"
 
+# An entry that exists but omits one of the five rows. This is the only
+# refusal path with no case of its own otherwise: the check would still
+# refuse a changelog missing every row, so a case that dropped them all
+# would pass on the no-versioned-entry guard instead.
+python3 - "$changelog" <<'DROP'
+import sys, pathlib, re
+p = pathlib.Path(sys.argv[1])
+s = p.read_text()
+# Inside the newest release entry, not the legend table above it.
+start = re.search(r"^## \[\d+\.\d+\.\d+\]", s, re.M).start()
+head, tail = s[:start], s[start:]
+p.write_text(head + re.sub(r"^\| Scene format \|[^\n]*\n", "", tail, count=1, flags=re.M))
+DROP
+refuses "an entry missing one of the five rows" "states no 'Scene format' row"
+cp "$pristine" "$changelog"
+
 # No versioned entry at all.
 python3 - "$changelog" <<'STRIP'
 import sys, pathlib, re

--- a/scripts/test-release-markers.sh
+++ b/scripts/test-release-markers.sh
@@ -11,33 +11,58 @@ root_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "$root_dir"
 
 check="$root_dir/scripts/check-release-markers.sh"
-changelog="CHANGELOG.md"
+work="$(mktemp -d)"
+changelog="$work/CHANGELOG.md"
+output_file="$work/output"
+export INDICATE_CHANGELOG="$changelog"
 passed=0
 failed=0
 
-backup="$(mktemp)"
-cp "$changelog" "$backup"
-cleanup() {
-    cp "$backup" "$changelog"
-    rm -f "$backup"
-}
-trap cleanup EXIT
+# Every case works on a copy. The committed CHANGELOG is never written,
+# so a case that aborts cannot leave the repository dirty and a missing
+# restore cannot hide behind the next case's own restore.
+pristine="$work/pristine"
+cp CHANGELOG.md "$pristine"
+cp "$pristine" "$changelog"
+trap 'rm -rf "$work"' EXIT
 
-# `expect <want> <label>` runs the check against the CHANGELOG as it
-# currently stands and compares its exit status to `want`.
-expect() {
-    local want="$1" label="$2" got=0
-    "$check" >/dev/null 2>&1 || got=$?
-    if [ "$got" -eq "$want" ]; then
-        echo "ok: $label"
+# `accepts <label>` expects a clean run. `refuses <label> <phrase>`
+# expects a refusal AND that the refusal names `phrase`: the check has
+# several ways to refuse, so a case that only counted the exit status
+# would pass on a refusal it did not ask for. That is the shape the
+# duplicate-version case was written in first, and it passed with the
+# guard it named deleted.
+run_check() {
+    "$check" >"$output_file" 2>&1
+}
+
+accepts() {
+    if run_check; then
+        echo "ok: $1"
         passed=$((passed + 1))
     else
-        echo "REGRESSION: $label — wanted exit $want, got $got" >&2
+        echo "REGRESSION: $1 — refused, saying: $(head -1 "$output_file")" >&2
         failed=$((failed + 1))
     fi
 }
 
-expect 0 "the committed CHANGELOG agrees with the tree"
+refuses() {
+    if run_check; then
+        echo "REGRESSION: $1 was accepted; the guard did not notice" >&2
+        failed=$((failed + 1))
+        return
+    fi
+    if ! grep -Fq "$2" "$output_file"; then
+        echo "REGRESSION: $1 was refused, but not for '$2'" >&2
+        echo "  it said: $(head -1 "$output_file")" >&2
+        failed=$((failed + 1))
+        return
+    fi
+    echo "ok: $1 refused"
+    passed=$((passed + 1))
+}
+
+accepts "the committed CHANGELOG agrees with the tree"
 
 # Two entries under one version: the check reads the newest only, so the
 # older twin's values are never compared against anything. This is the
@@ -55,8 +80,8 @@ start = headings[0]
 end = headings[1] if len(headings) > 1 else len(s)
 p.write_text(s[:start] + s[start:end] + s[start:])
 PLANT
-expect 1 "a version declared twice is refused"
-cp "$backup" "$changelog"
+refuses "a version declared twice" "more than once"
+cp "$pristine" "$changelog"
 
 # A value that disagrees with the tree.
 python3 - "$changelog" <<'DRIFT'
@@ -65,8 +90,8 @@ p = pathlib.Path(sys.argv[1])
 s = p.read_text()
 p.write_text(re.sub(r"\| State ABI \| \d+ \|", "| State ABI | 99 |", s, count=1))
 DRIFT
-expect 1 "a value that disagrees with the tree is refused"
-cp "$backup" "$changelog"
+refuses "a value that disagrees with the tree" "DRIFT:"
+cp "$pristine" "$changelog"
 
 # No versioned entry at all.
 python3 - "$changelog" <<'STRIP'
@@ -74,10 +99,10 @@ import sys, pathlib, re
 p = pathlib.Path(sys.argv[1])
 p.write_text(re.sub(r"^## \[\d+\.\d+\.\d+\]", "## [Unreleased]", p.read_text(), flags=re.M))
 STRIP
-expect 1 "a changelog with no versioned entry is refused"
-cp "$backup" "$changelog"
+refuses "a changelog with no versioned entry" "no versioned release entry found"
+cp "$pristine" "$changelog"
 
-expect 0 "the restored CHANGELOG agrees again"
+accepts "the restored CHANGELOG agrees again"
 
 if [ "$failed" -ne 0 ]; then
     echo "release-markers-selftest: FAILED ($failed of $((passed + failed)) cases)" >&2

--- a/scripts/test-release-markers.sh
+++ b/scripts/test-release-markers.sh
@@ -1,0 +1,87 @@
+#!/usr/bin/env bash
+# Selftest for check-release-markers.sh.
+#
+# The check reads the newest release entry and compares its five values
+# against the tree. Every case here drives one refusal and asserts on
+# the exit status, because a check that reports a clean tree when it
+# examined nothing is the failure worth catching.
+set -euo pipefail
+
+root_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$root_dir"
+
+check="$root_dir/scripts/check-release-markers.sh"
+changelog="CHANGELOG.md"
+passed=0
+failed=0
+
+backup="$(mktemp)"
+cp "$changelog" "$backup"
+cleanup() {
+    cp "$backup" "$changelog"
+    rm -f "$backup"
+}
+trap cleanup EXIT
+
+# `expect <want> <label>` runs the check against the CHANGELOG as it
+# currently stands and compares its exit status to `want`.
+expect() {
+    local want="$1" label="$2" got=0
+    "$check" >/dev/null 2>&1 || got=$?
+    if [ "$got" -eq "$want" ]; then
+        echo "ok: $label"
+        passed=$((passed + 1))
+    else
+        echo "REGRESSION: $label — wanted exit $want, got $got" >&2
+        failed=$((failed + 1))
+    fi
+}
+
+expect 0 "the committed CHANGELOG agrees with the tree"
+
+# Two entries under one version: the check reads the newest only, so the
+# older twin's values are never compared against anything. This is the
+# shape a merge produces when two branches each add the next release.
+# A complete duplicate of the newest entry, table and all, so the only
+# thing wrong with the file is that one version appears twice. A twin
+# with no table would be refused for a missing row instead, and the case
+# would pass with the duplicate check deleted.
+python3 - "$changelog" <<'PLANT'
+import sys, pathlib, re
+p = pathlib.Path(sys.argv[1])
+s = p.read_text()
+headings = [m.start() for m in re.finditer(r"^## \[\d+\.\d+\.\d+\]", s, re.M)]
+start = headings[0]
+end = headings[1] if len(headings) > 1 else len(s)
+p.write_text(s[:start] + s[start:end] + s[start:])
+PLANT
+expect 1 "a version declared twice is refused"
+cp "$backup" "$changelog"
+
+# A value that disagrees with the tree.
+python3 - "$changelog" <<'DRIFT'
+import sys, pathlib, re
+p = pathlib.Path(sys.argv[1])
+s = p.read_text()
+p.write_text(re.sub(r"\| State ABI \| \d+ \|", "| State ABI | 99 |", s, count=1))
+DRIFT
+expect 1 "a value that disagrees with the tree is refused"
+cp "$backup" "$changelog"
+
+# No versioned entry at all.
+python3 - "$changelog" <<'STRIP'
+import sys, pathlib, re
+p = pathlib.Path(sys.argv[1])
+p.write_text(re.sub(r"^## \[\d+\.\d+\.\d+\]", "## [Unreleased]", p.read_text(), flags=re.M))
+STRIP
+expect 1 "a changelog with no versioned entry is refused"
+cp "$backup" "$changelog"
+
+expect 0 "the restored CHANGELOG agrees again"
+
+if [ "$failed" -ne 0 ]; then
+    echo "release-markers-selftest: FAILED ($failed of $((passed + failed)) cases)" >&2
+    exit 1
+fi
+
+echo "release-markers-selftest: OK ($passed cases)"


### PR DESCRIPTION
`check-release-markers.sh` reads the newest release entry and compares its five values against the tree. When two branches each add the next release and both land, the file carries that version twice — and the older twin's values are never compared against anything. The check reports OK, because it found an entry it was happy with and stopped.

Three branches in flight right now (#59, #61, #63) each add a `## [0.5.1]`, which is what made this worth writing down rather than remembering to renumber by hand.

## The choice it makes

It refuses the file, not one of the entries. Which of two entries under one version is *the* release is not a question this check can answer, and picking one would be the fail-open answer — it would keep reporting OK on a changelog that says two different things about one version.

## The selftest

New `scripts/test-release-markers.sh`, five cases, wired as a hard CI step before the check itself.

The duplicate case plants a **complete** copy of the newest entry, table and all. A twin without a table is refused for a missing row instead, so a simpler case would pass with the duplicate check deleted — I wrote that version first and it did exactly that. Verified the case reddens when the guard is removed and only then.

The other four cover the paths that had no coverage at all: a value that disagrees with the tree, a changelog with no versioned entry, and the committed file before and after the mutations, so a case that left the file dirty would show up.

Local: `check-release-markers.sh` OK, `test-release-markers.sh` OK (5 cases), workspace suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)