### PR TITLE
An agent's worktree is a checkout too

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,8 +26,10 @@
 # path inside the work tree, so a worktree placed here needs this rule
 # where one placed outside the repository needs none. The `/target/`
 # rule above is anchored at the root and does not reach into them.
-# Agent tooling places worktrees under `.claude/` for the same reason a
-# contributor places them under `.worktrees/`, and they are checkouts
-# by the same argument.
+# Agent tooling places worktrees under `.claude/worktrees/` for the same
+# reason a contributor places them under `.worktrees/`, and they are
+# checkouts by the same argument. The rest of `.claude/` is content a
+# team commits — settings, agent definitions, commands — so the rule
+# names the subdirectory rather than the parent.
 .worktrees/
-.claude/
+.claude/worktrees/

--- a/.gitignore
+++ b/.gitignore
@@ -26,4 +26,8 @@
 # path inside the work tree, so a worktree placed here needs this rule
 # where one placed outside the repository needs none. The `/target/`
 # rule above is anchored at the root and does not reach into them.
+# Agent tooling places worktrees under `.claude/` for the same reason a
+# contributor places them under `.worktrees/`, and they are checkouts
+# by the same argument.
 .worktrees/
+.claude/

--- a/scripts/check-structure.sh
+++ b/scripts/check-structure.sh
@@ -34,8 +34,8 @@ is_excluded_path() {
 
 collect_rs_files() {
     find . \
-        -type d \( -name target -o -name generated -o -name .worktrees \
-        -o -name .claude \) -prune -o \
+        -type d \( -name target -o -name generated -o -name .worktrees \) -prune -o \
+        -type d -path './.claude/worktrees' -prune -o \
         -type f -name '*.rs' -print
 }
 
@@ -235,7 +235,7 @@ check_crate_naming() {
                 ;;
         esac
     done < <(find . -name Cargo.toml -not -path './target/*' -not -path './.git/*' \
-        -not -path './.worktrees/*' -not -path './.claude/*' -mindepth 2)
+        -not -path './.worktrees/*' -not -path './.claude/worktrees/*' -mindepth 2)
 }
 
 # The tier law from #13. The tiers are only real if the tree enforces
@@ -340,7 +340,7 @@ check_crate_map() {
             status=1
         fi
     done < <(find . -name Cargo.toml -not -path './target/*' -not -path './.git/*' \
-        -not -path './.worktrees/*' -not -path './.claude/*' -mindepth 2)
+        -not -path './.worktrees/*' -not -path './.claude/worktrees/*' -mindepth 2)
     while IFS= read -r name; do
         if [ ! -d "crates/$name" ] && [ ! -d "sets/$name" ]; then
             echo "FORBIDDEN: $map names $name, which is not a crate in this workspace" >&2

--- a/scripts/check-structure.sh
+++ b/scripts/check-structure.sh
@@ -34,7 +34,8 @@ is_excluded_path() {
 
 collect_rs_files() {
     find . \
-        -type d \( -name target -o -name generated -o -name .worktrees \) -prune -o \
+        -type d \( -name target -o -name generated -o -name .worktrees \
+        -o -name .claude \) -prune -o \
         -type f -name '*.rs' -print
 }
 
@@ -234,7 +235,7 @@ check_crate_naming() {
                 ;;
         esac
     done < <(find . -name Cargo.toml -not -path './target/*' -not -path './.git/*' \
-        -not -path './.worktrees/*' -mindepth 2)
+        -not -path './.worktrees/*' -not -path './.claude/*' -mindepth 2)
 }
 
 # The tier law from #13. The tiers are only real if the tree enforces
@@ -339,7 +340,7 @@ check_crate_map() {
             status=1
         fi
     done < <(find . -name Cargo.toml -not -path './target/*' -not -path './.git/*' \
-        -not -path './.worktrees/*' -mindepth 2)
+        -not -path './.worktrees/*' -not -path './.claude/*' -mindepth 2)
     while IFS= read -r name; do
         if [ ! -d "crates/$name" ] && [ ! -d "sets/$name" ]; then
             echo "FORBIDDEN: $map names $name, which is not a crate in this workspace" >&2

--- a/scripts/test-structure.sh
+++ b/scripts/test-structure.sh
@@ -18,12 +18,14 @@ cd "$root_dir"
 probe_dir="sets/indicate-tier-probe"
 probe_doc="docs/instruments/zz-structure-probe.md"
 worktree_probe_dir=".worktrees/zz-structure-probe"
+agent_probe_dir=".claude/worktrees/zz-structure-probe"
 lock_backup="$(mktemp)"
 cp Cargo.lock "$lock_backup"
 
 cleanup() {
     rm -rf "$probe_dir"
     rm -rf "$worktree_probe_dir"
+    rm -rf "$agent_probe_dir"
     rm -f "$probe_doc"
     cp "$lock_backup" Cargo.lock
     rm -f "$lock_backup"
@@ -166,6 +168,28 @@ else
     failed=$((failed + 1))
 fi
 rm -rf "$worktree_probe_dir"
+
+# Agent tooling places its worktrees under `.claude/`, which is the same
+# argument in a different directory: a checkout, walked by the same
+# `find`, reported against as though it were this repository's content.
+# A contributor running the local battery while an agent holds a
+# worktree sees findings from a tree they did not write.
+mkdir -p "$agent_probe_dir/probe/src"
+cat > "$agent_probe_dir/probe/Cargo.toml" <<'EOF'
+[workspace]
+members = []
+EOF
+printf '//! Structure probe inside an agent worktree.
+' \
+    > "$agent_probe_dir/probe/src/mod.rs"
+if INDICATE_STRUCTURE_SELFTEST_CHILD=1 bash scripts/check-structure.sh >/dev/null 2>&1; then
+    echo "ok: content under .claude is not walked"
+    passed=$((passed + 1))
+else
+    echo "REGRESSION: the gate walked into an agent worktree and reported on a checkout" >&2
+    failed=$((failed + 1))
+fi
+rm -rf "$agent_probe_dir"
 
 if [ "$failed" -ne 0 ]; then
     echo "structure-selftest: FAILED ($failed of $((passed + failed)) cases)" >&2

--- a/scripts/test-structure.sh
+++ b/scripts/test-structure.sh
@@ -183,7 +183,7 @@ printf '//! Structure probe inside an agent worktree.
 ' \
     > "$agent_probe_dir/probe/src/mod.rs"
 if INDICATE_STRUCTURE_SELFTEST_CHILD=1 bash scripts/check-structure.sh >/dev/null 2>&1; then
-    echo "ok: content under .claude is not walked"
+    echo "ok: content under .claude/worktrees is not walked"
     passed=$((passed + 1))
 else
     echo "REGRESSION: the gate walked into an agent worktree and reported on a checkout" >&2


### PR DESCRIPTION
The structure gate walks the tree with `find`, which reads no ignore file, and it pruned `.worktrees/` only. Agent tooling places its worktrees under `.claude/`, so a contributor running the local battery while an agent holds one sees findings against a tree they did not write.

Reproduced on a clean checkout: with two agent worktrees present, `check-structure.sh` reports a `mod.rs` that is not this repository's and a function over its limit in a crate at a commit nobody checked out.

The argument is the one already made for `.worktrees/` in #68: a linked worktree is a checkout, not content, and the walks that reach a worktree's own manifests and sources report this repository against a copy of itself. Both paths are pruned now, in the three walks that need it, and `.gitignore` covers the second for the same reason it covers the first.

The selftest plants a manifest **and** a source under each path, because the manifest walk and the source walk are pruned separately — a case that planted one would pass with the other open. Verified: removing the `.claude` prune reddens the new case.

Local: `check-structure.sh` OK, `test-structure.sh` OK, workspace suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)