### PR TITLE
Keep GroupSet capacity tied to defined groups (#77)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,31 @@ Entries are newest first, and the tag's message repeats the same five
 values so `git show <tag>` answers the question without a checkout.
 `CONTRIBUTING.md` has the release steps.
 
+## [0.6.1] — 2026-08-26
+
+`GroupSet` now assigns bit positions through `GroupId::index()`, not
+sparse wire tags. The representation therefore supports 32 defined
+group slots regardless of their tag values.
+
+The public `bits()` value now uses dense group positions. Consumers
+that read descriptor group masks through FFI must use the same mapping.
+A static assertion binds the word width to `GroupId::COUNT`. A test
+also round-trips the highest allocated group.
+
+No panel paint moved. The composition digest moved because it includes
+the required-group mask. The screen-composition digest moved because it
+includes the composition digest. Raster baselines remain unchanged.
+
+| Value | This release |
+|---|---|
+| State ABI | 8 |
+| Scene format | 1 |
+| Corpus | 6 |
+| Composition digest | `c8cbcd92c71bf55fe73788c1455f4ee5435082dd4afd7940e0480a96fb9611d1` |
+| Panel set | `pfd`, `hsi`, `autoflight`, `monitor` |
+
+Panel set changed since the previous release: no.
+
 ## [0.6.0] — 2026-08-21
 
 The state ABI moves to v8. The bump is the coordination point for the

--- a/crates/indicate-instrument-descriptor/src/group_set.rs
+++ b/crates/indicate-instrument-descriptor/src/group_set.rs
@@ -2,11 +2,17 @@
 
 use indicate_instrument_state::GroupId;
 
-/// A set of state groups, as a bitset keyed by [`GroupId`] wire tags.
+/// A set of state groups, as a bitset keyed by [`GroupId::index`].
 /// Const-constructible so descriptors can declare their needs in
-/// `static` data.
+/// `static` data. Dense indexing keeps capacity tied to the number of
+/// defined groups rather than to sparse wire-tag allocations.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub struct GroupSet(u32);
+
+const _: () = assert!(
+    GroupId::COUNT <= u32::BITS as usize,
+    "GroupSet is too narrow"
+);
 
 impl GroupSet {
     /// The empty set.
@@ -17,7 +23,7 @@ impl GroupSet {
         let mut bits = 0u32;
         let mut i = 0;
         while i < groups.len() {
-            bits |= 1 << groups[i] as u32;
+            bits |= 1 << groups[i].index();
             i += 1;
         }
         GroupSet(bits)
@@ -25,7 +31,7 @@ impl GroupSet {
 
     /// Whether `group` is in the set.
     pub const fn contains(&self, group: GroupId) -> bool {
-        self.0 & (1 << group as u32) != 0
+        self.0 & (1 << group.index()) != 0
     }
 
     /// Number of groups in the set.
@@ -38,7 +44,7 @@ impl GroupSet {
         self.0 == 0
     }
 
-    /// The raw bitset, bit position = [`GroupId`] wire tag. This is the
+    /// The raw bitset, bit position = [`GroupId::index`]. This is the
     /// wasm/FFI encoding of the set.
     pub const fn bits(&self) -> u32 {
         self.0

--- a/crates/indicate-instrument-descriptor/src/group_set/tests.rs
+++ b/crates/indicate-instrument-descriptor/src/group_set/tests.rs
@@ -17,9 +17,26 @@ fn membership_matches_construction() {
 }
 
 #[test]
-fn bits_use_wire_tags_as_positions() {
-    // The bitset is a wasm/FFI encoding: bit position must equal the
-    // group's wire tag, not an enum ordinal.
-    let set = GroupSet::of(&[GroupId::Attitude, GroupId::Trust]);
-    assert_eq!(set.bits(), (1 << 0x01) | (1 << 0x07));
+fn bits_use_dense_group_indexes_as_positions() {
+    let set = GroupSet::of(&[GroupId::Attitude, GroupId::Trust, GroupId::BearingPointers]);
+    assert_eq!(
+        set.bits(),
+        (1 << GroupId::Attitude.index())
+            | (1 << GroupId::Trust.index())
+            | (1 << GroupId::BearingPointers.index()),
+    );
+    assert_ne!(
+        GroupId::BearingPointers.index(),
+        GroupId::BearingPointers.to_u8() as usize
+    );
+}
+
+#[test]
+fn highest_allocated_group_round_trips_through_the_set() {
+    let highest = *GroupId::ALL
+        .last()
+        .expect("the group registry is not empty");
+    let set = GroupSet::of(&[highest]);
+    assert!(set.contains(highest));
+    assert_eq!(set.bits(), 1 << highest.index());
 }

--- a/release-manifest.json
+++ b/release-manifest.json
@@ -9,7 +9,7 @@
     "version": 6,
     "sha256": "9881c1d5fc4f3cdb869a2589b8f2c0fd5e50ea931b2eb128ea1f1f801d9c08cc"
   },
-  "compositionDigest": "8291c73e7c92e8b04963f743c9d68d9e1f590aa576f3776d0a0cfdc3183ae35b",
+  "compositionDigest": "c8cbcd92c71bf55fe73788c1455f4ee5435082dd4afd7940e0480a96fb9611d1",
   "screenComposition": {
     "fixture": "tools/instrument-bench",
     "screen": { "width": 960, "height": 720 },
@@ -18,7 +18,7 @@
       { "panel": "hsi", "x": 480, "y": 0, "width": 480, "height": 360 },
       { "panel": "monitor", "x": 0, "y": 360, "width": 480, "height": 360 }
     ],
-    "digest": "ea2522b6dcd1237b263ca0115110a171ef810687a8d65e7ba7ef96fa80b7e718"
+    "digest": "0f4f7c7fb27be2bb0df1fee4462d5aa0121001be1643299c705e117f379292dd"
   },
   "rasterBaselines": [
     { "panel": "pfd", "frame": { "width": 480, "height": 360 }, "sha256": "6e6bd9b8fb4599a549d5b9a31bf34fa97a03ad2cca3f0d92eb869983f2bb52bd" },

--- a/sets/indicate-instrument-panels/src/descriptors.rs
+++ b/sets/indicate-instrument-panels/src/descriptors.rs
@@ -346,7 +346,7 @@ pub const ALL_SETS: &[PanelSet] = &[BUILTIN_SET, CONFIG_SET];
 /// value moves once per deliberate contract change, re-pinned with a
 /// review note saying why.
 pub const BUILTIN_SCENE_DIGEST: &str =
-    "8291c73e7c92e8b04963f743c9d68d9e1f590aa576f3776d0a0cfdc3183ae35b";
+    "c8cbcd92c71bf55fe73788c1455f4ee5435082dd4afd7940e0480a96fb9611d1";
 
 pub use criticality_bands::BUILTIN_CRITICALITY_BANDS;
 pub use supplementary::{

--- a/tools/instrument-bench/src/screen.rs
+++ b/tools/instrument-bench/src/screen.rs
@@ -45,4 +45,4 @@ pub const BENCH_COMPOSITION: CompositionDescriptor = CompositionDescriptor {
 /// The pinned screen-composition digest over [`BENCH_COMPOSITION`]:
 /// every shell composing this screen from this registry reproduces it.
 pub const BENCH_COMPOSITION_DIGEST: &str =
-    "ea2522b6dcd1237b263ca0115110a171ef810687a8d65e7ba7ef96fa80b7e718";
+    "0f4f7c7fb27be2bb0df1fee4462d5aa0121001be1643299c705e117f379292dd";


### PR DESCRIPTION
Use dense GroupId indexes for GroupSet membership bits. Add compile-time capacity coverage and highest-group regression tests.\n\nBoth composition digests move because the required-group mask encoding changes. Panel paint does not change.\n\nCloses #77\n\n<!-- GitButler Footer Boundary Top -->\n---\nThis is **part 1 of 3 in a stack** made with GitButler:\n- <kbd>&nbsp;3&nbsp;</kbd> #87\n- <kbd>&nbsp;2&nbsp;</kbd> #86\n- <kbd>&nbsp;1&nbsp;</kbd> #85 👈 \n<!-- GitButler Footer Boundary Bottom -->